### PR TITLE
Adding an example that shows MirroredStrategy

### DIFF
--- a/guides/distributed_training.py
+++ b/guides/distributed_training.py
@@ -456,5 +456,6 @@ results = model.evaluate(val_dataset)
     https://www.tensorflow.org/api_docs/python/tf/distribute/MirroredStrategy)
 4. [MultiWorkerMirroredStrategy docs](
     https://www.tensorflow.org/api_docs/python/tf/distribute/experimental/MultiWorkerMirroredStrategy)
-5. [Distributed training in `tf.keras`](https://towardsdatascience.com/distributed-training-in-tf-keras-with-w-b-ccf021f9322e)
+5. [Distributed training in tf.keras with Weights & Biases](
+    https://towardsdatascience.com/distributed-training-in-tf-keras-with-w-b-ccf021f9322e)
 """

--- a/guides/distributed_training.py
+++ b/guides/distributed_training.py
@@ -456,4 +456,5 @@ results = model.evaluate(val_dataset)
     https://www.tensorflow.org/api_docs/python/tf/distribute/MirroredStrategy)
 4. [MultiWorkerMirroredStrategy docs](
     https://www.tensorflow.org/api_docs/python/tf/distribute/experimental/MultiWorkerMirroredStrategy)
+5. [Distributed training in `tf.keras`](https://towardsdatascience.com/distributed-training-in-tf-keras-with-w-b-ccf021f9322e)
 """


### PR DESCRIPTION
The example already does a great job discussing different flavors of distributed training for Keras models. In the **Further reading** section, I just added a link to my article that shows the use of `MirroredStrategy` in a bit more detailed way. 