### PR TITLE
activation of num_classes > 1 should be softmax

### DIFF
--- a/examples/vision/oxford_pets_image_segmentation.py
+++ b/examples/vision/oxford_pets_image_segmentation.py
@@ -161,7 +161,8 @@ def get_model(img_size, num_classes):
         previous_block_activation = x  # Set aside next residual
 
     # Add a per-pixel classification layer
-    outputs = layers.Conv2D(num_classes, 3, activation="sigmoid", padding="same")(x)
+    _activation = "softmax" if num_classes > 1 else "sigmoid"
+    outputs = layers.Conv2D(num_classes, 3, activation=_activation, padding="same")(x)
 
     # Define the model
     model = keras.Model(inputs, outputs)

--- a/examples/vision/oxford_pets_image_segmentation.py
+++ b/examples/vision/oxford_pets_image_segmentation.py
@@ -161,8 +161,7 @@ def get_model(img_size, num_classes):
         previous_block_activation = x  # Set aside next residual
 
     # Add a per-pixel classification layer
-    _activation = "softmax" if num_classes > 1 else "sigmoid"
-    outputs = layers.Conv2D(num_classes, 3, activation=_activation, padding="same")(x)
+    outputs = layers.Conv2D(num_classes, 3, activation="softmax", padding="same")(x)
 
     # Define the model
     model = keras.Model(inputs, outputs)


### PR DESCRIPTION
When segmenting multi-class images, we expect a pixel to be assigned with one label from the num_classes. Therefore, the last activation must be "softmax", especially when compiling with "categorical_crossentropy" loss