### PR TITLE
Added transformer example

### DIFF
--- a/examples/nlp/ipynb/text_classification_with_transformer.ipynb
+++ b/examples/nlp/ipynb/text_classification_with_transformer.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Text classification with Transformer\n",
+    "\n",
+    "**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>\n",
+    "**Date created:** 2020/05/10<br>\n",
+    "**Last modified:** 2020/05/10<br>\n",
+    "**Description:** Implement transformer block as a Keras layer and use it for text classification."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Setup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Implement multi head self attention as a Keras layer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class MultiHeadSelfAttention(keras.layers.Layer):\n",
+    "    def __init__(self, embed_dim, num_heads=8):\n",
+    "        super(MultiHeadSelfAttention, self).__init__()\n",
+    "        self.embed_dim = embed_dim\n",
+    "        self.num_heads = num_heads\n",
+    "        assert (\n",
+    "            embed_dim % num_heads == 0\n",
+    "        ), \"embedding dimension not divisible by num heads\"\n",
+    "        self.projection_dim = embed_dim // num_heads\n",
+    "        self.wq = keras.layers.Dense(embed_dim)\n",
+    "        self.wk = keras.layers.Dense(embed_dim)\n",
+    "        self.wv = keras.layers.Dense(embed_dim)\n",
+    "        self.combine_heads = keras.layers.Dense(embed_dim)\n",
+    "\n",
+    "    def attention(self, q, k, v):\n",
+    "        score = tf.matmul(q, k, transpose_b=True)\n",
+    "        dk = tf.cast(tf.shape(k)[-1], tf.float32)\n",
+    "        scaled_score = score / tf.math.sqrt(dk)\n",
+    "        weights = tf.nn.softmax(scaled_score, axis=-1)\n",
+    "        output = tf.matmul(weights, v)\n",
+    "        return output, weights\n",
+    "\n",
+    "    def separate_heads(self, x, batch_size):\n",
+    "        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))\n",
+    "        return tf.transpose(x, perm=[0, 2, 1, 3])\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        # x.shape = [batch_size, seq_len, embedding_dim]\n",
+    "        batch_size = tf.shape(x)[0]\n",
+    "        q = self.wq(x)  # (batch_size, seq_len, embed_dim)\n",
+    "        k = self.wk(x)  # (batch_size, seq_len, embed_dim)\n",
+    "        v = self.wv(x)  # (batch_size, seq_len, embed_dim)\n",
+    "        q = self.separate_heads(\n",
+    "            q, batch_size\n",
+    "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
+    "        k = self.separate_heads(\n",
+    "            k, batch_size\n",
+    "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
+    "        v = self.separate_heads(\n",
+    "            v, batch_size\n",
+    "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
+    "        attention, weights = self.attention(q, k, v)\n",
+    "        attention = tf.transpose(\n",
+    "            attention, perm=[0, 2, 1, 3]\n",
+    "        )  # (batch_size, seq_len, num_heads, projection_dim)\n",
+    "        concat_attention = tf.reshape(\n",
+    "            attention, (batch_size, -1, self.embed_dim)\n",
+    "        )  # (batch_size, seq_len, embed_dim)\n",
+    "        output = self.combine_heads(\n",
+    "            concat_attention\n",
+    "        )  # (batch_size, seq_len, embed_dim)\n",
+    "        return output\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Implement transformer block as a layer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TransformerLayer(tf.keras.layers.Layer):\n",
+    "    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):\n",
+    "        super(TransformerLayer, self).__init__()\n",
+    "\n",
+    "        self.att = MultiHeadSelfAttention(embed_dim, num_heads)\n",
+    "        self.ffn = keras.Sequential(\n",
+    "            [\n",
+    "                keras.layers.Dense(ff_dim, activation=\"relu\"),\n",
+    "                keras.layers.Dense(embed_dim),\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)\n",
+    "\n",
+    "        self.dropout1 = tf.keras.layers.Dropout(rate)\n",
+    "        self.dropout2 = tf.keras.layers.Dropout(rate)\n",
+    "\n",
+    "    def call(self, x, training):\n",
+    "        attn_output = self.att(x)\n",
+    "        attn_output = self.dropout1(attn_output, training=training)\n",
+    "        out1 = self.layernorm1(x + attn_output)\n",
+    "\n",
+    "        ffn_output = self.ffn(out1)\n",
+    "        ffn_output = self.dropout2(ffn_output, training=training)\n",
+    "        out2 = self.layernorm2(out1 + ffn_output)\n",
+    "\n",
+    "        return out2\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Implement embedding layer\n",
+    "\n",
+    "Two seperate embedding layers, one for tokens, one for token index (positions).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class EmbeddingLayer(keras.layers.Layer):\n",
+    "    def __init__(self, maxlen, vocab_size, emded_dim):\n",
+    "        super(EmbeddingLayer, self).__init__()\n",
+    "        self.token_emb = keras.layers.Embedding(\n",
+    "            input_dim=vocab_size, output_dim=emded_dim\n",
+    "        )\n",
+    "        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        maxlen = tf.shape(x)[-1]\n",
+    "        positions = tf.range(start=0, limit=maxlen, delta=1)\n",
+    "        positions = self.pos_emb(positions)\n",
+    "        x = self.token_emb(x)\n",
+    "        return x + positions\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Create classifier model using transformer layer\n",
+    "\n",
+    "Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TransformerClassifier(tf.keras.Model):\n",
+    "    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):\n",
+    "        super(TransformerClassifier, self).__init__()\n",
+    "        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)\n",
+    "        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)\n",
+    "        self.prehead = keras.layers.Dense(20, activation=\"relu\")\n",
+    "        self.dropout1 = keras.layers.Dropout(0.05)\n",
+    "        self.dropout2 = keras.layers.Dropout(0.05)\n",
+    "        self.head = keras.layers.Dense(2, activation=\"softmax\")\n",
+    "\n",
+    "    def call(self, x, training):\n",
+    "        x = self.emb(x)\n",
+    "        x = self.transformer(x, training)\n",
+    "        x = tf.math.reduce_mean(x, axis=1)\n",
+    "        x = self.dropout1(x, training=training)\n",
+    "        x = self.prehead(x)\n",
+    "        x = self.dropout2(x, training=training)\n",
+    "        x = self.head(x)\n",
+    "        return x\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Download and prepare dataset\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "max_features = 6000  # Only consider the top 20k words\n",
+    "maxlen = 200  # Only consider the first 200 words of each movie review\n",
+    "(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(\n",
+    "    num_words=max_features\n",
+    ")\n",
+    "print(len(x_train), \"Training sequences\")\n",
+    "print(len(x_val), \"Validation sequences\")\n",
+    "x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)\n",
+    "x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Train and Evaluate\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "model = TransformerClassifier(\n",
+    "    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1\n",
+    ")\n",
+    "model.compile(\"adam\", \"sparse_categorical_crossentropy\", metrics=[\"accuracy\"])\n",
+    "history = model.fit(\n",
+    "    x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)\n",
+    ")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "text_classification_with_transformer",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/nlp/ipynb/text_classification_with_transformer.ipynb
+++ b/examples/nlp/ipynb/text_classification_with_transformer.ipynb
@@ -11,7 +11,7 @@
     "**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>\n",
     "**Date created:** 2020/05/10<br>\n",
     "**Last modified:** 2020/05/10<br>\n",
-    "**Description:** Implement transformer block as a Keras layer and use it for text classification."
+    "**Description:** Implement a Transformer block as a Keras layer and use it for text classification."
    ]
   },
   {
@@ -32,7 +32,8 @@
    "outputs": [],
    "source": [
     "import tensorflow as tf\n",
-    "from tensorflow import keras\n"
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n"
    ]
   },
   {
@@ -53,48 +54,49 @@
    "outputs": [],
    "source": [
     "\n",
-    "class MultiHeadSelfAttention(keras.layers.Layer):\n",
+    "class MultiHeadSelfAttention(layers.Layer):\n",
     "    def __init__(self, embed_dim, num_heads=8):\n",
     "        super(MultiHeadSelfAttention, self).__init__()\n",
     "        self.embed_dim = embed_dim\n",
     "        self.num_heads = num_heads\n",
-    "        assert (\n",
-    "            embed_dim % num_heads == 0\n",
-    "        ), \"embedding dimension not divisible by num heads\"\n",
+    "        if embed_dim % num_heads != 0:\n",
+    "            raise ValueError(\n",
+    "                f\"embedding dimension = {embed_dim} should be divisible by number of heads = {num_heads}\"\n",
+    "            )\n",
     "        self.projection_dim = embed_dim // num_heads\n",
-    "        self.wq = keras.layers.Dense(embed_dim)\n",
-    "        self.wk = keras.layers.Dense(embed_dim)\n",
-    "        self.wv = keras.layers.Dense(embed_dim)\n",
-    "        self.combine_heads = keras.layers.Dense(embed_dim)\n",
+    "        self.query_dense = layers.Dense(embed_dim)\n",
+    "        self.key_dense = layers.Dense(embed_dim)\n",
+    "        self.value_dense = layers.Dense(embed_dim)\n",
+    "        self.combine_heads = layers.Dense(embed_dim)\n",
     "\n",
-    "    def attention(self, q, k, v):\n",
-    "        score = tf.matmul(q, k, transpose_b=True)\n",
-    "        dk = tf.cast(tf.shape(k)[-1], tf.float32)\n",
-    "        scaled_score = score / tf.math.sqrt(dk)\n",
+    "    def attention(self, query, key, value):\n",
+    "        score = tf.matmul(query, key, transpose_b=True)\n",
+    "        dim_key = tf.cast(tf.shape(key)[-1], tf.float32)\n",
+    "        scaled_score = score / tf.math.sqrt(dim_key)\n",
     "        weights = tf.nn.softmax(scaled_score, axis=-1)\n",
-    "        output = tf.matmul(weights, v)\n",
+    "        output = tf.matmul(weights, value)\n",
     "        return output, weights\n",
     "\n",
     "    def separate_heads(self, x, batch_size):\n",
     "        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))\n",
     "        return tf.transpose(x, perm=[0, 2, 1, 3])\n",
     "\n",
-    "    def call(self, x):\n",
+    "    def call(self, inputs):\n",
     "        # x.shape = [batch_size, seq_len, embedding_dim]\n",
-    "        batch_size = tf.shape(x)[0]\n",
-    "        q = self.wq(x)  # (batch_size, seq_len, embed_dim)\n",
-    "        k = self.wk(x)  # (batch_size, seq_len, embed_dim)\n",
-    "        v = self.wv(x)  # (batch_size, seq_len, embed_dim)\n",
-    "        q = self.separate_heads(\n",
-    "            q, batch_size\n",
+    "        batch_size = tf.shape(inputs)[0]\n",
+    "        query = self.query_dense(inputs)  # (batch_size, seq_len, embed_dim)\n",
+    "        key = self.key_dense(inputs)  # (batch_size, seq_len, embed_dim)\n",
+    "        value = self.value_dense(inputs)  # (batch_size, seq_len, embed_dim)\n",
+    "        query = self.separate_heads(\n",
+    "            query, batch_size\n",
     "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
-    "        k = self.separate_heads(\n",
-    "            k, batch_size\n",
+    "        key = self.separate_heads(\n",
+    "            key, batch_size\n",
     "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
-    "        v = self.separate_heads(\n",
-    "            v, batch_size\n",
+    "        value = self.separate_heads(\n",
+    "            value, batch_size\n",
     "        )  # (batch_size, num_heads, seq_len, projection_dim)\n",
-    "        attention, weights = self.attention(q, k, v)\n",
+    "        attention, weights = self.attention(query, key, value)\n",
     "        attention = tf.transpose(\n",
     "            attention, perm=[0, 2, 1, 3]\n",
     "        )  # (batch_size, seq_len, num_heads, projection_dim)\n",
@@ -114,7 +116,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Implement transformer block as a layer\n"
+    "## Implement a Transformer block as a layer\n"
    ]
   },
   {
@@ -126,34 +128,25 @@
    "outputs": [],
    "source": [
     "\n",
-    "class TransformerLayer(tf.keras.layers.Layer):\n",
+    "class TransformerBlock(layers.Layer):\n",
     "    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):\n",
-    "        super(TransformerLayer, self).__init__()\n",
-    "\n",
+    "        super(TransformerBlock, self).__init__()\n",
     "        self.att = MultiHeadSelfAttention(embed_dim, num_heads)\n",
     "        self.ffn = keras.Sequential(\n",
-    "            [\n",
-    "                keras.layers.Dense(ff_dim, activation=\"relu\"),\n",
-    "                keras.layers.Dense(embed_dim),\n",
-    "            ]\n",
+    "            [layers.Dense(ff_dim, activation=\"relu\"), layers.Dense(embed_dim),]\n",
     "        )\n",
+    "        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.dropout1 = layers.Dropout(rate)\n",
+    "        self.dropout2 = layers.Dropout(rate)\n",
     "\n",
-    "        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)\n",
-    "        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)\n",
-    "\n",
-    "        self.dropout1 = tf.keras.layers.Dropout(rate)\n",
-    "        self.dropout2 = tf.keras.layers.Dropout(rate)\n",
-    "\n",
-    "    def call(self, x, training):\n",
-    "        attn_output = self.att(x)\n",
+    "    def call(self, inputs, training):\n",
+    "        attn_output = self.att(inputs)\n",
     "        attn_output = self.dropout1(attn_output, training=training)\n",
-    "        out1 = self.layernorm1(x + attn_output)\n",
-    "\n",
+    "        out1 = self.layernorm1(inputs + attn_output)\n",
     "        ffn_output = self.ffn(out1)\n",
     "        ffn_output = self.dropout2(ffn_output, training=training)\n",
-    "        out2 = self.layernorm2(out1 + ffn_output)\n",
-    "\n",
-    "        return out2\n",
+    "        return self.layernorm2(out1 + ffn_output)\n",
     "\n"
    ]
   },
@@ -177,13 +170,11 @@
    "outputs": [],
    "source": [
     "\n",
-    "class EmbeddingLayer(keras.layers.Layer):\n",
+    "class TokenAndPositionEmbedding(layers.Layer):\n",
     "    def __init__(self, maxlen, vocab_size, emded_dim):\n",
-    "        super(EmbeddingLayer, self).__init__()\n",
-    "        self.token_emb = keras.layers.Embedding(\n",
-    "            input_dim=vocab_size, output_dim=emded_dim\n",
-    "        )\n",
-    "        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)\n",
+    "        super(TokenAndPositionEmbedding, self).__init__()\n",
+    "        self.token_emb = layers.Embedding(input_dim=vocab_size, output_dim=emded_dim)\n",
+    "        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=emded_dim)\n",
     "\n",
     "    def call(self, x):\n",
     "        maxlen = tf.shape(x)[-1]\n",
@@ -191,48 +182,6 @@
     "        positions = self.pos_emb(positions)\n",
     "        x = self.token_emb(x)\n",
     "        return x + positions\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Create classifier model using transformer layer\n",
-    "\n",
-    "Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "\n",
-    "class TransformerClassifier(tf.keras.Model):\n",
-    "    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):\n",
-    "        super(TransformerClassifier, self).__init__()\n",
-    "        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)\n",
-    "        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)\n",
-    "        self.prehead = keras.layers.Dense(20, activation=\"relu\")\n",
-    "        self.dropout1 = keras.layers.Dropout(0.05)\n",
-    "        self.dropout2 = keras.layers.Dropout(0.05)\n",
-    "        self.head = keras.layers.Dense(2, activation=\"softmax\")\n",
-    "\n",
-    "    def call(self, x, training):\n",
-    "        x = self.emb(x)\n",
-    "        x = self.transformer(x, training)\n",
-    "        x = tf.math.reduce_mean(x, axis=1)\n",
-    "        x = self.dropout1(x, training=training)\n",
-    "        x = self.prehead(x)\n",
-    "        x = self.dropout2(x, training=training)\n",
-    "        x = self.head(x)\n",
-    "        return x\n",
     "\n"
    ]
   },
@@ -253,15 +202,54 @@
    },
    "outputs": [],
    "source": [
-    "max_features = 6000  # Only consider the top 20k words\n",
+    "vocab_size = 20000  # Only consider the top 20k words\n",
     "maxlen = 200  # Only consider the first 200 words of each movie review\n",
-    "(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(\n",
-    "    num_words=max_features\n",
-    ")\n",
+    "(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(num_words=vocab_size)\n",
     "print(len(x_train), \"Training sequences\")\n",
     "print(len(x_val), \"Validation sequences\")\n",
     "x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)\n",
     "x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Create classifier model using transformer layer\n",
+    "\n",
+    "Transformer layer outputs one vector for each time step of our input sequence.\n",
+    "Here, we take the mean across all time steps and\n",
+    "use a feed forward network on top of it to classify text.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "embed_dim = 32  # Embedding size for each token\n",
+    "num_heads = 2  # Number of attention heads\n",
+    "ff_dim = 32  # Hidden layer size in feed forward network inside transformer\n",
+    "\n",
+    "inputs = layers.Input(shape=(maxlen,))\n",
+    "embedding_layer = TokenAndPositionEmbedding(maxlen, vocab_size, embed_dim)\n",
+    "x = embedding_layer(inputs)\n",
+    "transformer_block = TransformerBlock(embed_dim, num_heads, ff_dim)\n",
+    "x = transformer_block(x)\n",
+    "x = layers.GlobalAveragePooling1D()(x)\n",
+    "x = layers.Dropout(0.1)(x)\n",
+    "x = layers.Dense(20, activation=\"relu\")(x)\n",
+    "x = layers.Dropout(0.1)(x)\n",
+    "outputs = layers.Dense(2, activation=\"softmax\")(x)\n",
+    "\n",
+    "model = keras.Model(inputs=inputs, outputs=outputs)\n",
+    "\n"
    ]
   },
   {
@@ -281,9 +269,6 @@
    },
    "outputs": [],
    "source": [
-    "model = TransformerClassifier(\n",
-    "    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1\n",
-    ")\n",
     "model.compile(\"adam\", \"sparse_categorical_crossentropy\", metrics=[\"accuracy\"])\n",
     "history = model.fit(\n",
     "    x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)\n",

--- a/examples/nlp/md/text_classification_with_transformer.md
+++ b/examples/nlp/md/text_classification_with_transformer.md
@@ -1,0 +1,236 @@
+# Text classification with Transformer
+
+**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>
+**Date created:** 2020/05/10<br>
+**Last modified:** 2020/05/10<br>
+**Description:** Implement transformer block as a Keras layer and use it for text classification.
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/nlp/ipynb/text_classification_with_transformer.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/nlp/text_classification_with_transformer.py)
+
+
+
+---
+## Setup
+
+
+
+```python
+import tensorflow as tf
+from tensorflow import keras
+
+```
+
+---
+## Implement multi head self attention as a Keras layer
+
+
+
+```python
+
+class MultiHeadSelfAttention(keras.layers.Layer):
+    def __init__(self, embed_dim, num_heads=8):
+        super(MultiHeadSelfAttention, self).__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        assert (
+            embed_dim % num_heads == 0
+        ), "embedding dimension not divisible by num heads"
+        self.projection_dim = embed_dim // num_heads
+        self.wq = keras.layers.Dense(embed_dim)
+        self.wk = keras.layers.Dense(embed_dim)
+        self.wv = keras.layers.Dense(embed_dim)
+        self.combine_heads = keras.layers.Dense(embed_dim)
+
+    def attention(self, q, k, v):
+        score = tf.matmul(q, k, transpose_b=True)
+        dk = tf.cast(tf.shape(k)[-1], tf.float32)
+        scaled_score = score / tf.math.sqrt(dk)
+        weights = tf.nn.softmax(scaled_score, axis=-1)
+        output = tf.matmul(weights, v)
+        return output, weights
+
+    def separate_heads(self, x, batch_size):
+        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))
+        return tf.transpose(x, perm=[0, 2, 1, 3])
+
+    def call(self, x):
+        # x.shape = [batch_size, seq_len, embedding_dim]
+        batch_size = tf.shape(x)[0]
+        q = self.wq(x)  # (batch_size, seq_len, embed_dim)
+        k = self.wk(x)  # (batch_size, seq_len, embed_dim)
+        v = self.wv(x)  # (batch_size, seq_len, embed_dim)
+        q = self.separate_heads(
+            q, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        k = self.separate_heads(
+            k, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        v = self.separate_heads(
+            v, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        attention, weights = self.attention(q, k, v)
+        attention = tf.transpose(
+            attention, perm=[0, 2, 1, 3]
+        )  # (batch_size, seq_len, num_heads, projection_dim)
+        concat_attention = tf.reshape(
+            attention, (batch_size, -1, self.embed_dim)
+        )  # (batch_size, seq_len, embed_dim)
+        output = self.combine_heads(
+            concat_attention
+        )  # (batch_size, seq_len, embed_dim)
+        return output
+
+
+```
+
+---
+## Implement transformer block as a layer
+
+
+
+```python
+
+class TransformerLayer(tf.keras.layers.Layer):
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super(TransformerLayer, self).__init__()
+
+        self.att = MultiHeadSelfAttention(embed_dim, num_heads)
+        self.ffn = keras.Sequential(
+            [
+                keras.layers.Dense(ff_dim, activation="relu"),
+                keras.layers.Dense(embed_dim),
+            ]
+        )
+
+        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)
+
+        self.dropout1 = tf.keras.layers.Dropout(rate)
+        self.dropout2 = tf.keras.layers.Dropout(rate)
+
+    def call(self, x, training):
+        attn_output = self.att(x)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(x + attn_output)
+
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        out2 = self.layernorm2(out1 + ffn_output)
+
+        return out2
+
+
+```
+
+---
+## Implement embedding layer
+
+Two seperate embedding layers, one for tokens, one for token index (positions).
+
+
+
+```python
+
+class EmbeddingLayer(keras.layers.Layer):
+    def __init__(self, maxlen, vocab_size, emded_dim):
+        super(EmbeddingLayer, self).__init__()
+        self.token_emb = keras.layers.Embedding(
+            input_dim=vocab_size, output_dim=emded_dim
+        )
+        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
+
+    def call(self, x):
+        maxlen = tf.shape(x)[-1]
+        positions = tf.range(start=0, limit=maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        x = self.token_emb(x)
+        return x + positions
+
+
+```
+
+---
+## Create classifier model using transformer layer
+
+Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.
+
+
+
+```python
+
+class TransformerClassifier(tf.keras.Model):
+    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):
+        super(TransformerClassifier, self).__init__()
+        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)
+        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)
+        self.prehead = keras.layers.Dense(20, activation="relu")
+        self.dropout1 = keras.layers.Dropout(0.05)
+        self.dropout2 = keras.layers.Dropout(0.05)
+        self.head = keras.layers.Dense(2, activation="softmax")
+
+    def call(self, x, training):
+        x = self.emb(x)
+        x = self.transformer(x, training)
+        x = tf.math.reduce_mean(x, axis=1)
+        x = self.dropout1(x, training=training)
+        x = self.prehead(x)
+        x = self.dropout2(x, training=training)
+        x = self.head(x)
+        return x
+
+
+```
+
+---
+## Download and prepare dataset
+
+
+
+```python
+max_features = 6000  # Only consider the top 20k words
+maxlen = 200  # Only consider the first 200 words of each movie review
+(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(
+    num_words=max_features
+)
+print(len(x_train), "Training sequences")
+print(len(x_val), "Validation sequences")
+x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
+x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
+
+```
+
+<div class="k-default-codeblock">
+```
+Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/imdb.npz
+17465344/17464789 [==============================] - 2s 0us/step
+25000 Training sequences
+25000 Validation sequences
+
+```
+</div>
+---
+## Train and Evaluate
+
+
+
+```python
+model = TransformerClassifier(
+    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1
+)
+model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
+history = model.fit(
+    x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)
+)
+
+```
+
+<div class="k-default-codeblock">
+```
+Epoch 1/2
+782/782 [==============================] - 29s 37ms/step - loss: 0.3767 - accuracy: 0.8248 - val_loss: 0.3363 - val_accuracy: 0.8561
+Epoch 2/2
+782/782 [==============================] - 30s 39ms/step - loss: 0.2497 - accuracy: 0.8992 - val_loss: 0.2959 - val_accuracy: 0.8716
+
+```
+</div>

--- a/examples/nlp/md/text_classification_with_transformer.md
+++ b/examples/nlp/md/text_classification_with_transformer.md
@@ -3,7 +3,7 @@
 **Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>
 **Date created:** 2020/05/10<br>
 **Last modified:** 2020/05/10<br>
-**Description:** Implement transformer block as a Keras layer and use it for text classification.
+**Description:** Implement a Transformer block as a Keras layer and use it for text classification.
 
 
 <img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/nlp/ipynb/text_classification_with_transformer.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/nlp/text_classification_with_transformer.py)
@@ -18,6 +18,7 @@
 ```python
 import tensorflow as tf
 from tensorflow import keras
+from tensorflow.keras import layers
 
 ```
 
@@ -28,48 +29,49 @@ from tensorflow import keras
 
 ```python
 
-class MultiHeadSelfAttention(keras.layers.Layer):
+class MultiHeadSelfAttention(layers.Layer):
     def __init__(self, embed_dim, num_heads=8):
         super(MultiHeadSelfAttention, self).__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
-        assert (
-            embed_dim % num_heads == 0
-        ), "embedding dimension not divisible by num heads"
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embedding dimension = {embed_dim} should be divisible by number of heads = {num_heads}"
+            )
         self.projection_dim = embed_dim // num_heads
-        self.wq = keras.layers.Dense(embed_dim)
-        self.wk = keras.layers.Dense(embed_dim)
-        self.wv = keras.layers.Dense(embed_dim)
-        self.combine_heads = keras.layers.Dense(embed_dim)
+        self.query_dense = layers.Dense(embed_dim)
+        self.key_dense = layers.Dense(embed_dim)
+        self.value_dense = layers.Dense(embed_dim)
+        self.combine_heads = layers.Dense(embed_dim)
 
-    def attention(self, q, k, v):
-        score = tf.matmul(q, k, transpose_b=True)
-        dk = tf.cast(tf.shape(k)[-1], tf.float32)
-        scaled_score = score / tf.math.sqrt(dk)
+    def attention(self, query, key, value):
+        score = tf.matmul(query, key, transpose_b=True)
+        dim_key = tf.cast(tf.shape(key)[-1], tf.float32)
+        scaled_score = score / tf.math.sqrt(dim_key)
         weights = tf.nn.softmax(scaled_score, axis=-1)
-        output = tf.matmul(weights, v)
+        output = tf.matmul(weights, value)
         return output, weights
 
     def separate_heads(self, x, batch_size):
         x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))
         return tf.transpose(x, perm=[0, 2, 1, 3])
 
-    def call(self, x):
+    def call(self, inputs):
         # x.shape = [batch_size, seq_len, embedding_dim]
-        batch_size = tf.shape(x)[0]
-        q = self.wq(x)  # (batch_size, seq_len, embed_dim)
-        k = self.wk(x)  # (batch_size, seq_len, embed_dim)
-        v = self.wv(x)  # (batch_size, seq_len, embed_dim)
-        q = self.separate_heads(
-            q, batch_size
+        batch_size = tf.shape(inputs)[0]
+        query = self.query_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        key = self.key_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        value = self.value_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        query = self.separate_heads(
+            query, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        k = self.separate_heads(
-            k, batch_size
+        key = self.separate_heads(
+            key, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        v = self.separate_heads(
-            v, batch_size
+        value = self.separate_heads(
+            value, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        attention, weights = self.attention(q, k, v)
+        attention, weights = self.attention(query, key, value)
         attention = tf.transpose(
             attention, perm=[0, 2, 1, 3]
         )  # (batch_size, seq_len, num_heads, projection_dim)
@@ -85,40 +87,31 @@ class MultiHeadSelfAttention(keras.layers.Layer):
 ```
 
 ---
-## Implement transformer block as a layer
+## Implement a Transformer block as a layer
 
 
 
 ```python
 
-class TransformerLayer(tf.keras.layers.Layer):
+class TransformerBlock(layers.Layer):
     def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
-        super(TransformerLayer, self).__init__()
-
+        super(TransformerBlock, self).__init__()
         self.att = MultiHeadSelfAttention(embed_dim, num_heads)
         self.ffn = keras.Sequential(
-            [
-                keras.layers.Dense(ff_dim, activation="relu"),
-                keras.layers.Dense(embed_dim),
-            ]
+            [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim),]
         )
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
 
-        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)
-        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)
-
-        self.dropout1 = tf.keras.layers.Dropout(rate)
-        self.dropout2 = tf.keras.layers.Dropout(rate)
-
-    def call(self, x, training):
-        attn_output = self.att(x)
+    def call(self, inputs, training):
+        attn_output = self.att(inputs)
         attn_output = self.dropout1(attn_output, training=training)
-        out1 = self.layernorm1(x + attn_output)
-
+        out1 = self.layernorm1(inputs + attn_output)
         ffn_output = self.ffn(out1)
         ffn_output = self.dropout2(ffn_output, training=training)
-        out2 = self.layernorm2(out1 + ffn_output)
-
-        return out2
+        return self.layernorm2(out1 + ffn_output)
 
 
 ```
@@ -132,13 +125,11 @@ Two seperate embedding layers, one for tokens, one for token index (positions).
 
 ```python
 
-class EmbeddingLayer(keras.layers.Layer):
+class TokenAndPositionEmbedding(layers.Layer):
     def __init__(self, maxlen, vocab_size, emded_dim):
-        super(EmbeddingLayer, self).__init__()
-        self.token_emb = keras.layers.Embedding(
-            input_dim=vocab_size, output_dim=emded_dim
-        )
-        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
+        super(TokenAndPositionEmbedding, self).__init__()
+        self.token_emb = layers.Embedding(input_dim=vocab_size, output_dim=emded_dim)
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
 
     def call(self, x):
         maxlen = tf.shape(x)[-1]
@@ -151,48 +142,14 @@ class EmbeddingLayer(keras.layers.Layer):
 ```
 
 ---
-## Create classifier model using transformer layer
-
-Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.
-
-
-
-```python
-
-class TransformerClassifier(tf.keras.Model):
-    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):
-        super(TransformerClassifier, self).__init__()
-        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)
-        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)
-        self.prehead = keras.layers.Dense(20, activation="relu")
-        self.dropout1 = keras.layers.Dropout(0.05)
-        self.dropout2 = keras.layers.Dropout(0.05)
-        self.head = keras.layers.Dense(2, activation="softmax")
-
-    def call(self, x, training):
-        x = self.emb(x)
-        x = self.transformer(x, training)
-        x = tf.math.reduce_mean(x, axis=1)
-        x = self.dropout1(x, training=training)
-        x = self.prehead(x)
-        x = self.dropout2(x, training=training)
-        x = self.head(x)
-        return x
-
-
-```
-
----
 ## Download and prepare dataset
 
 
 
 ```python
-max_features = 6000  # Only consider the top 20k words
+vocab_size = 20000  # Only consider the top 20k words
 maxlen = 200  # Only consider the first 200 words of each movie review
-(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(
-    num_words=max_features
-)
+(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(num_words=vocab_size)
 print(len(x_train), "Training sequences")
 print(len(x_val), "Validation sequences")
 x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
@@ -202,22 +159,48 @@ x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 
 <div class="k-default-codeblock">
 ```
-Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/imdb.npz
-17465344/17464789 [==============================] - 2s 0us/step
 25000 Training sequences
 25000 Validation sequences
 
 ```
 </div>
 ---
+## Create classifier model using transformer layer
+
+Transformer layer outputs one vector for each time step of our input sequence.
+Here, we take the mean across all time steps and
+use a feed forward network on top of it to classify text.
+
+
+
+```python
+
+embed_dim = 32  # Embedding size for each token
+num_heads = 2  # Number of attention heads
+ff_dim = 32  # Hidden layer size in feed forward network inside transformer
+
+inputs = layers.Input(shape=(maxlen,))
+embedding_layer = TokenAndPositionEmbedding(maxlen, vocab_size, embed_dim)
+x = embedding_layer(inputs)
+transformer_block = TransformerBlock(embed_dim, num_heads, ff_dim)
+x = transformer_block(x)
+x = layers.GlobalAveragePooling1D()(x)
+x = layers.Dropout(0.1)(x)
+x = layers.Dense(20, activation="relu")(x)
+x = layers.Dropout(0.1)(x)
+outputs = layers.Dense(2, activation="softmax")(x)
+
+model = keras.Model(inputs=inputs, outputs=outputs)
+
+
+```
+
+---
 ## Train and Evaluate
 
 
 
 ```python
-model = TransformerClassifier(
-    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1
-)
 model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
 history = model.fit(
     x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)
@@ -228,9 +211,9 @@ history = model.fit(
 <div class="k-default-codeblock">
 ```
 Epoch 1/2
-782/782 [==============================] - 29s 37ms/step - loss: 0.3767 - accuracy: 0.8248 - val_loss: 0.3363 - val_accuracy: 0.8561
+782/782 [==============================] - 40s 51ms/step - loss: 0.3778 - accuracy: 0.8250 - val_loss: 0.4092 - val_accuracy: 0.8031
 Epoch 2/2
-782/782 [==============================] - 30s 39ms/step - loss: 0.2497 - accuracy: 0.8992 - val_loss: 0.2959 - val_accuracy: 0.8716
+782/782 [==============================] - 42s 54ms/step - loss: 0.2064 - accuracy: 0.9199 - val_loss: 0.3154 - val_accuracy: 0.8698
 
 ```
 </div>

--- a/examples/nlp/text_classification_with_transformer.py
+++ b/examples/nlp/text_classification_with_transformer.py
@@ -3,7 +3,7 @@ Title: Text classification with Transformer
 Author: [Apoorv Nandan](https://twitter.com/NandanApoorv)
 Date created: 2020/05/10
 Last modified: 2020/05/10
-Description: Implement transformer block as a Keras layer and use it for text classification.
+Description: Implement a Transformer block as a Keras layer and use it for text classification.
 """
 """
 ## Setup
@@ -11,54 +11,56 @@ Description: Implement transformer block as a Keras layer and use it for text cl
 
 import tensorflow as tf
 from tensorflow import keras
+from tensorflow.keras import layers
 
 """
 ## Implement multi head self attention as a Keras layer
 """
 
 
-class MultiHeadSelfAttention(keras.layers.Layer):
+class MultiHeadSelfAttention(layers.Layer):
     def __init__(self, embed_dim, num_heads=8):
         super(MultiHeadSelfAttention, self).__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
-        assert (
-            embed_dim % num_heads == 0
-        ), "embedding dimension not divisible by num heads"
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embedding dimension = {embed_dim} should be divisible by number of heads = {num_heads}"
+            )
         self.projection_dim = embed_dim // num_heads
-        self.wq = keras.layers.Dense(embed_dim)
-        self.wk = keras.layers.Dense(embed_dim)
-        self.wv = keras.layers.Dense(embed_dim)
-        self.combine_heads = keras.layers.Dense(embed_dim)
+        self.query_dense = layers.Dense(embed_dim)
+        self.key_dense = layers.Dense(embed_dim)
+        self.value_dense = layers.Dense(embed_dim)
+        self.combine_heads = layers.Dense(embed_dim)
 
-    def attention(self, q, k, v):
-        score = tf.matmul(q, k, transpose_b=True)
-        dk = tf.cast(tf.shape(k)[-1], tf.float32)
-        scaled_score = score / tf.math.sqrt(dk)
+    def attention(self, query, key, value):
+        score = tf.matmul(query, key, transpose_b=True)
+        dim_key = tf.cast(tf.shape(key)[-1], tf.float32)
+        scaled_score = score / tf.math.sqrt(dim_key)
         weights = tf.nn.softmax(scaled_score, axis=-1)
-        output = tf.matmul(weights, v)
+        output = tf.matmul(weights, value)
         return output, weights
 
     def separate_heads(self, x, batch_size):
         x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))
         return tf.transpose(x, perm=[0, 2, 1, 3])
 
-    def call(self, x):
+    def call(self, inputs):
         # x.shape = [batch_size, seq_len, embedding_dim]
-        batch_size = tf.shape(x)[0]
-        q = self.wq(x)  # (batch_size, seq_len, embed_dim)
-        k = self.wk(x)  # (batch_size, seq_len, embed_dim)
-        v = self.wv(x)  # (batch_size, seq_len, embed_dim)
-        q = self.separate_heads(
-            q, batch_size
+        batch_size = tf.shape(inputs)[0]
+        query = self.query_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        key = self.key_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        value = self.value_dense(inputs)  # (batch_size, seq_len, embed_dim)
+        query = self.separate_heads(
+            query, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        k = self.separate_heads(
-            k, batch_size
+        key = self.separate_heads(
+            key, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        v = self.separate_heads(
-            v, batch_size
+        value = self.separate_heads(
+            value, batch_size
         )  # (batch_size, num_heads, seq_len, projection_dim)
-        attention, weights = self.attention(q, k, v)
+        attention, weights = self.attention(query, key, value)
         attention = tf.transpose(
             attention, perm=[0, 2, 1, 3]
         )  # (batch_size, seq_len, num_heads, projection_dim)
@@ -72,38 +74,29 @@ class MultiHeadSelfAttention(keras.layers.Layer):
 
 
 """
-## Implement transformer block as a layer
+## Implement a Transformer block as a layer
 """
 
 
-class TransformerLayer(tf.keras.layers.Layer):
+class TransformerBlock(layers.Layer):
     def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
-        super(TransformerLayer, self).__init__()
-
+        super(TransformerBlock, self).__init__()
         self.att = MultiHeadSelfAttention(embed_dim, num_heads)
         self.ffn = keras.Sequential(
-            [
-                keras.layers.Dense(ff_dim, activation="relu"),
-                keras.layers.Dense(embed_dim),
-            ]
+            [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim),]
         )
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
 
-        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)
-        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)
-
-        self.dropout1 = tf.keras.layers.Dropout(rate)
-        self.dropout2 = tf.keras.layers.Dropout(rate)
-
-    def call(self, x, training):
-        attn_output = self.att(x)
+    def call(self, inputs, training):
+        attn_output = self.att(inputs)
         attn_output = self.dropout1(attn_output, training=training)
-        out1 = self.layernorm1(x + attn_output)
-
+        out1 = self.layernorm1(inputs + attn_output)
         ffn_output = self.ffn(out1)
         ffn_output = self.dropout2(ffn_output, training=training)
-        out2 = self.layernorm2(out1 + ffn_output)
-
-        return out2
+        return self.layernorm2(out1 + ffn_output)
 
 
 """
@@ -113,13 +106,11 @@ Two seperate embedding layers, one for tokens, one for token index (positions).
 """
 
 
-class EmbeddingLayer(keras.layers.Layer):
+class TokenAndPositionEmbedding(layers.Layer):
     def __init__(self, maxlen, vocab_size, emded_dim):
-        super(EmbeddingLayer, self).__init__()
-        self.token_emb = keras.layers.Embedding(
-            input_dim=vocab_size, output_dim=emded_dim
-        )
-        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
+        super(TokenAndPositionEmbedding, self).__init__()
+        self.token_emb = layers.Embedding(input_dim=vocab_size, output_dim=emded_dim)
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
 
     def call(self, x):
         maxlen = tf.shape(x)[-1]
@@ -130,54 +121,48 @@ class EmbeddingLayer(keras.layers.Layer):
 
 
 """
-## Create classifier model using transformer layer
-
-Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.
-"""
-
-
-class TransformerClassifier(tf.keras.Model):
-    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):
-        super(TransformerClassifier, self).__init__()
-        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)
-        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)
-        self.prehead = keras.layers.Dense(20, activation="relu")
-        self.dropout1 = keras.layers.Dropout(0.05)
-        self.dropout2 = keras.layers.Dropout(0.05)
-        self.head = keras.layers.Dense(2, activation="softmax")
-
-    def call(self, x, training):
-        x = self.emb(x)
-        x = self.transformer(x, training)
-        x = tf.math.reduce_mean(x, axis=1)
-        x = self.dropout1(x, training=training)
-        x = self.prehead(x)
-        x = self.dropout2(x, training=training)
-        x = self.head(x)
-        return x
-
-
-"""
 ## Download and prepare dataset
 """
 
-max_features = 6000  # Only consider the top 20k words
+vocab_size = 20000  # Only consider the top 20k words
 maxlen = 200  # Only consider the first 200 words of each movie review
-(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(
-    num_words=max_features
-)
+(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(num_words=vocab_size)
 print(len(x_train), "Training sequences")
 print(len(x_val), "Validation sequences")
 x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
 x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 
 """
+## Create classifier model using transformer layer
+
+Transformer layer outputs one vector for each time step of our input sequence.
+Here, we take the mean across all time steps and 
+use a feed forward network on top of it to classify text.
+"""
+
+
+embed_dim = 32  # Embedding size for each token
+num_heads = 2  # Number of attention heads
+ff_dim = 32  # Hidden layer size in feed forward network inside transformer
+
+inputs = layers.Input(shape=(maxlen,))
+embedding_layer = TokenAndPositionEmbedding(maxlen, vocab_size, embed_dim)
+x = embedding_layer(inputs)
+transformer_block = TransformerBlock(embed_dim, num_heads, ff_dim)
+x = transformer_block(x)
+x = layers.GlobalAveragePooling1D()(x)
+x = layers.Dropout(0.1)(x)
+x = layers.Dense(20, activation="relu")(x)
+x = layers.Dropout(0.1)(x)
+outputs = layers.Dense(2, activation="softmax")(x)
+
+model = keras.Model(inputs=inputs, outputs=outputs)
+
+
+"""
 ## Train and Evaluate
 """
 
-model = TransformerClassifier(
-    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1
-)
 model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
 history = model.fit(
     x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)

--- a/examples/nlp/text_classification_with_transformer.py
+++ b/examples/nlp/text_classification_with_transformer.py
@@ -1,0 +1,184 @@
+"""
+Title: Text classification with Transformer
+Author: [Apoorv Nandan](https://twitter.com/NandanApoorv)
+Date created: 2020/05/10
+Last modified: 2020/05/10
+Description: Implement transformer block as a Keras layer and use it for text classification.
+"""
+"""
+## Setup
+"""
+
+import tensorflow as tf
+from tensorflow import keras
+
+"""
+## Implement multi head self attention as a Keras layer
+"""
+
+
+class MultiHeadSelfAttention(keras.layers.Layer):
+    def __init__(self, embed_dim, num_heads=8):
+        super(MultiHeadSelfAttention, self).__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        assert (
+            embed_dim % num_heads == 0
+        ), "embedding dimension not divisible by num heads"
+        self.projection_dim = embed_dim // num_heads
+        self.wq = keras.layers.Dense(embed_dim)
+        self.wk = keras.layers.Dense(embed_dim)
+        self.wv = keras.layers.Dense(embed_dim)
+        self.combine_heads = keras.layers.Dense(embed_dim)
+
+    def attention(self, q, k, v):
+        score = tf.matmul(q, k, transpose_b=True)
+        dk = tf.cast(tf.shape(k)[-1], tf.float32)
+        scaled_score = score / tf.math.sqrt(dk)
+        weights = tf.nn.softmax(scaled_score, axis=-1)
+        output = tf.matmul(weights, v)
+        return output, weights
+
+    def separate_heads(self, x, batch_size):
+        x = tf.reshape(x, (batch_size, -1, self.num_heads, self.projection_dim))
+        return tf.transpose(x, perm=[0, 2, 1, 3])
+
+    def call(self, x):
+        # x.shape = [batch_size, seq_len, embedding_dim]
+        batch_size = tf.shape(x)[0]
+        q = self.wq(x)  # (batch_size, seq_len, embed_dim)
+        k = self.wk(x)  # (batch_size, seq_len, embed_dim)
+        v = self.wv(x)  # (batch_size, seq_len, embed_dim)
+        q = self.separate_heads(
+            q, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        k = self.separate_heads(
+            k, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        v = self.separate_heads(
+            v, batch_size
+        )  # (batch_size, num_heads, seq_len, projection_dim)
+        attention, weights = self.attention(q, k, v)
+        attention = tf.transpose(
+            attention, perm=[0, 2, 1, 3]
+        )  # (batch_size, seq_len, num_heads, projection_dim)
+        concat_attention = tf.reshape(
+            attention, (batch_size, -1, self.embed_dim)
+        )  # (batch_size, seq_len, embed_dim)
+        output = self.combine_heads(
+            concat_attention
+        )  # (batch_size, seq_len, embed_dim)
+        return output
+
+
+"""
+## Implement transformer block as a layer
+"""
+
+
+class TransformerLayer(tf.keras.layers.Layer):
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super(TransformerLayer, self).__init__()
+
+        self.att = MultiHeadSelfAttention(embed_dim, num_heads)
+        self.ffn = keras.Sequential(
+            [
+                keras.layers.Dense(ff_dim, activation="relu"),
+                keras.layers.Dense(embed_dim),
+            ]
+        )
+
+        self.layernorm1 = keras.layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = keras.layers.LayerNormalization(epsilon=1e-6)
+
+        self.dropout1 = tf.keras.layers.Dropout(rate)
+        self.dropout2 = tf.keras.layers.Dropout(rate)
+
+    def call(self, x, training):
+        attn_output = self.att(x)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(x + attn_output)
+
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        out2 = self.layernorm2(out1 + ffn_output)
+
+        return out2
+
+
+"""
+## Implement embedding layer
+
+Two seperate embedding layers, one for tokens, one for token index (positions).
+"""
+
+
+class EmbeddingLayer(keras.layers.Layer):
+    def __init__(self, maxlen, vocab_size, emded_dim):
+        super(EmbeddingLayer, self).__init__()
+        self.token_emb = keras.layers.Embedding(
+            input_dim=vocab_size, output_dim=emded_dim
+        )
+        self.pos_emb = keras.layers.Embedding(input_dim=maxlen, output_dim=emded_dim)
+
+    def call(self, x):
+        maxlen = tf.shape(x)[-1]
+        positions = tf.range(start=0, limit=maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        x = self.token_emb(x)
+        return x + positions
+
+
+"""
+## Create classifier model using transformer layer
+
+Transformer layer outputs one vector for each time step of your input sequence. Here, we take the mean across all time steps and build a two layered feed forward network on top of it.
+"""
+
+
+class TransformerClassifier(tf.keras.Model):
+    def __init__(self, maxlen, vocab_size, embed_dim, ff_dim, num_heads):
+        super(TransformerClassifier, self).__init__()
+        self.emb = EmbeddingLayer(maxlen, vocab_size, embed_dim)
+        self.transformer = TransformerLayer(embed_dim, num_heads, ff_dim)
+        self.prehead = keras.layers.Dense(20, activation="relu")
+        self.dropout1 = keras.layers.Dropout(0.05)
+        self.dropout2 = keras.layers.Dropout(0.05)
+        self.head = keras.layers.Dense(2, activation="softmax")
+
+    def call(self, x, training):
+        x = self.emb(x)
+        x = self.transformer(x, training)
+        x = tf.math.reduce_mean(x, axis=1)
+        x = self.dropout1(x, training=training)
+        x = self.prehead(x)
+        x = self.dropout2(x, training=training)
+        x = self.head(x)
+        return x
+
+
+"""
+## Download and prepare dataset
+"""
+
+max_features = 6000  # Only consider the top 20k words
+maxlen = 200  # Only consider the first 200 words of each movie review
+(x_train, y_train), (x_val, y_val) = keras.datasets.imdb.load_data(
+    num_words=max_features
+)
+print(len(x_train), "Training sequences")
+print(len(x_val), "Validation sequences")
+x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
+x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
+
+"""
+## Train and Evaluate
+"""
+
+model = TransformerClassifier(
+    maxlen=maxlen, vocab_size=max_features, embed_dim=32, ff_dim=32, num_heads=1
+)
+model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
+history = model.fit(
+    x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val)
+)


### PR DESCRIPTION
The example shows how to implement a transformer block as a Keras layer and use it for text classification on IMDB data. 

The model trains faster than an LSTM based classifier with a similar number of parameters and gives slightly better results.

- The transformer shown in the example is a small one; 2 attention heads, and small dimensions for projection heads and FFN. It achieves validation accuracy of 87% on IMDB in less than a minute on CPU.
- There is not a whole lot of description about the multi-head self-attention part, as I feel like that would make this into a detailed tutorial. Just implemented a simple version of the transformer block which can be used in place of an LSTM or GRU layer.  
(More description can be added if the maintainers feel like it is needed)
- Positional embedding are implemented using a standard `keras.layers.Embedding` layer, which according to the paper produced nearly identical results to the sinusoidal version. 
- For the classification head, I am taking the mean of transformer outputs across all timesteps. This has turned out to be a good practice even with larger transformer encoders like BERT.