### PR TITLE
Added minimal CI with a black check

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,17 @@
+name: Continuous integration
+
+on: [push, pull_request]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Ensure files are formatted with black
+      run: |
+        pip install --upgrade pip
+        pip install black==19.10b0
+        black --check ./examples

--- a/examples/vision/image_classification_from_scratch.py
+++ b/examples/vision/image_classification_from_scratch.py
@@ -291,10 +291,7 @@ model.compile(
     metrics=["accuracy"],
 )
 model.fit(
-    train_ds,
-    epochs=epochs,
-    callbacks=callbacks,
-    validation_data=val_ds,
+    train_ds, epochs=epochs, callbacks=callbacks, validation_data=val_ds,
 )
 
 """


### PR DESCRIPTION
This is the start of our CI system. Let's start small.

The CI will start running automatically for the first time once this is merged in master. It's a security in github actions. Github actions isn't enabled unless the first workflow file is committed to the repo.

It's possible to see the result of the CI on my fork: https://github.com/gabrieldemarmiesse/keras-io/pull/2

