### PR TITLE
Add Keras compatibility for py38

### DIFF
--- a/templates/about.md
+++ b/templates/about.md
@@ -135,7 +135,7 @@ To start using Keras, simply [install TensorFlow 2.0](https://www.tensorflow.org
 
 Keras/TensorFlow are compatible with:
 
-- Python 3.5–3.7
+- Python 3.5–3.8
 - Ubuntu 16.04 or later
 - Windows 7 or later
 - macOS 10.12.6 (Sierra) or later.


### PR DESCRIPTION
Minor update to indicate support for python3.8 in TF2.2:
https://pypi.org/project/tensorflow/2.2.0/#files