### PR TITLE
Fix allow_reuse_address usage

### DIFF
--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -641,11 +641,11 @@ class KerasIO:
 
     def serve(self):
         os.chdir(self.site_dir)
+        socketserver.ThreadingTCPServer.allow_reuse_address = True
         server = socketserver.ThreadingTCPServer(
             ("", 8000), http.server.SimpleHTTPRequestHandler
         )
         server.daemon_threads = True
-        server.allow_reuse_address = True
 
         def signal_handler(signal, frame):
             try:


### PR DESCRIPTION
allow_reuse_address should be set for the class because it's class variable.
Please check https://docs.python.org/3.7/library/socketserver.html#socketserver.BaseServer.allow_reuse_address 

Thanks