### PR TITLE
Bugfix: Q model and target model used the same weights

### DIFF
--- a/examples/rl/deep_q_network_breakout.py
+++ b/examples/rl/deep_q_network_breakout.py
@@ -1,8 +1,8 @@
 """
 Title: Deep Q-Learning for Atari Breakout
-Author: [Jacob Chapman](https://twitter.com/jacoblchapman)
+Author: [Jacob Chapman](https://twitter.com/jacoblchapman) and [Mathias Lechner](https://twitter.com/MLech20)
 Date created: 2020/05/23
-Last modified: 2020/05/23
+Last modified: 2020/06/17
 Description: Play Atari Breakout with a Deep Q-Network.
 """
 """
@@ -81,26 +81,31 @@ is chosen by selecting the larger of the four Q-values predicted in the output l
 
 num_actions = 4
 
-# Network defined by the Deepmind paper
-inputs = layers.Input(shape=(84, 84, 4,))
 
-# Convolutions on the frames on the screen
-layer1 = layers.Conv2D(32, 8, strides=4, activation="relu")(inputs)
-layer2 = layers.Conv2D(64, 4, strides=2, activation="relu")(layer1)
-layer3 = layers.Conv2D(64, 3, strides=1, activation="relu")(layer2)
+def create_q_model():
+    # Network defined by the Deepmind paper
+    inputs = layers.Input(shape=(84, 84, 4,))
 
-layer4 = layers.Flatten()(layer3)
+    # Convolutions on the frames on the screen
+    layer1 = layers.Conv2D(32, 8, strides=4, activation="relu")(inputs)
+    layer2 = layers.Conv2D(64, 4, strides=2, activation="relu")(layer1)
+    layer3 = layers.Conv2D(64, 3, strides=1, activation="relu")(layer2)
 
-layer5 = layers.Dense(512, activation="relu")(layer4)
-action = layers.Dense(num_actions, activation="linear")(layer5)
+    layer4 = layers.Flatten()(layer3)
+
+    layer5 = layers.Dense(512, activation="relu")(layer4)
+    action = layers.Dense(num_actions, activation="linear")(layer5)
+
+    return keras.Model(inputs=inputs, outputs=action)
+
 
 # The first model makes the predictions for Q-values which are used to
 # make a action.
-model = keras.Model(inputs=inputs, outputs=action)
+model = create_q_model()
 # Build a target model for the prediction of future rewards.
 # The weights of a target model get updated every 10000 steps thus when the
 # loss between the Q-values is calculated the target Q-value is stable.
-model_target = keras.Model(inputs=inputs, outputs=action)
+model_target = create_q_model()
 
 
 """
@@ -209,13 +214,13 @@ while True:  # Run until solved
                 q_action = tf.reduce_sum(tf.multiply(q_values, masks), axis=1)
                 # Calculate loss between new Q-value and old Q-value
                 # Clip the deltas using huber loss for stability
-                loss = tf.reduce_mean(keras.losses.huber(updated_q_values, q_action))
+                loss = tf.reduce_mean(keras.losses.Huber()(updated_q_values, q_action))
 
             # Backpropagation
             grads = tape.gradient(loss, model.trainable_variables)
             optimizer.apply_gradients(zip(grads, model.trainable_variables))
 
-        if frame_count % 10000 == 0:
+        if frame_count % update_target_network == 0:
             # update the the target network with new weights
             model_target.set_weights(model.get_weights())
             # Log details
@@ -247,6 +252,9 @@ while True:  # Run until solved
 
 """
 ## Visualizations
+Before any training:
+![Imgur](https://i.imgur.com/rRxXF4H.gif)
+
 In early stages of training:
 ![Imgur](https://i.imgur.com/X8ghdpL.gif)
 

--- a/examples/rl/deep_q_network_breakout.py
+++ b/examples/rl/deep_q_network_breakout.py
@@ -136,6 +136,8 @@ max_memory_length = 100000
 update_after_actions = 4
 # How often to update the target network
 update_target_network = 10000
+# Using huber loss for stability
+loss_function = keras.losses.Huber()
 
 while True:  # Run until solved
     state = np.array(env.reset())
@@ -213,8 +215,7 @@ while True:  # Run until solved
                 # Apply the masks to the Q-values to get the Q-value for action taken
                 q_action = tf.reduce_sum(tf.multiply(q_values, masks), axis=1)
                 # Calculate loss between new Q-value and old Q-value
-                # Clip the deltas using huber loss for stability
-                loss = tf.reduce_mean(keras.losses.Huber()(updated_q_values, q_action))
+                loss = loss_function(updated_q_values, q_action)
 
             # Backpropagation
             grads = tape.gradient(loss, model.trainable_variables)

--- a/examples/rl/ipynb/deep_q_network_breakout.ipynb
+++ b/examples/rl/ipynb/deep_q_network_breakout.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "# Deep Q-Learning for Atari Breakout\n",
     "\n",
-    "**Author:** [Jacob Chapman](https://twitter.com/jacoblchapman)<br>\n",
+    "**Author:** [Jacob Chapman](https://twitter.com/jacoblchapman) and [Mathias Lechner](https://twitter.com/MLech20)<br>\n",
     "**Date created:** 2020/05/23<br>\n",
-    "**Last modified:** 2020/05/23<br>\n",
+    "**Last modified:** 2020/06/17<br>\n",
     "**Description:** Play Atari Breakout with a Deep Q-Network."
    ]
   },
@@ -53,7 +53,7 @@
     "### References\n",
     "\n",
     "- [Q-Learning](https://link.springer.com/content/pdf/10.1007/BF00992698.pdf)\n",
-    "- [Deep Q-Learning](https://deepmind.com/research/publications/human-level-control-through-deep-reinforcement-learning)\n"
+    "- [Deep Q-Learning](https://deepmind.com/research/publications/human-level-control-through-deep-reinforcement-learning)"
    ]
   },
   {
@@ -62,7 +62,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Setup\n"
+    "## Setup"
    ]
   },
   {
@@ -95,7 +95,7 @@
     "env = make_atari(\"BreakoutNoFrameskip-v4\")\n",
     "# Warp the frames, grey scale, stake four frame and scale to smaller ratio\n",
     "env = wrap_deepmind(env, frame_stack=True, scale=True)\n",
-    "env.seed(seed)\n"
+    "env.seed(seed)"
    ]
   },
   {
@@ -109,7 +109,7 @@
     "This network learns an approximation of the Q-table, which is a mapping between\n",
     "the states and actions that an agent will take. For every state we'll have four\n",
     "actions, that can be taken. The environment provides the state, and the action\n",
-    "is chosen by selecting the larger of the four Q-values predicted in the output layer.\n"
+    "is chosen by selecting the larger of the four Q-values predicted in the output layer."
    ]
   },
   {
@@ -122,27 +122,32 @@
    "source": [
     "num_actions = 4\n",
     "\n",
-    "# Network defined by the Deepmind paper\n",
-    "inputs = layers.Input(shape=(84, 84, 4,))\n",
     "\n",
-    "# Convolutions on the frames on the screen\n",
-    "layer1 = layers.Conv2D(32, 8, strides=4, activation=\"relu\")(inputs)\n",
-    "layer2 = layers.Conv2D(64, 4, strides=2, activation=\"relu\")(layer1)\n",
-    "layer3 = layers.Conv2D(64, 3, strides=1, activation=\"relu\")(layer2)\n",
+    "def create_q_model():\n",
+    "    # Network defined by the Deepmind paper\n",
+    "    inputs = layers.Input(shape=(84, 84, 4,))\n",
     "\n",
-    "layer4 = layers.Flatten()(layer3)\n",
+    "    # Convolutions on the frames on the screen\n",
+    "    layer1 = layers.Conv2D(32, 8, strides=4, activation=\"relu\")(inputs)\n",
+    "    layer2 = layers.Conv2D(64, 4, strides=2, activation=\"relu\")(layer1)\n",
+    "    layer3 = layers.Conv2D(64, 3, strides=1, activation=\"relu\")(layer2)\n",
     "\n",
-    "layer5 = layers.Dense(512, activation=\"relu\")(layer4)\n",
-    "action = layers.Dense(num_actions, activation=\"linear\")(layer5)\n",
+    "    layer4 = layers.Flatten()(layer3)\n",
+    "\n",
+    "    layer5 = layers.Dense(512, activation=\"relu\")(layer4)\n",
+    "    action = layers.Dense(num_actions, activation=\"linear\")(layer5)\n",
+    "\n",
+    "    return keras.Model(inputs=inputs, outputs=action)\n",
+    "\n",
     "\n",
     "# The first model makes the predictions for Q-values which are used to\n",
     "# make a action.\n",
-    "model = keras.Model(inputs=inputs, outputs=action)\n",
+    "model = create_q_model()\n",
     "# Build a target model for the prediction of future rewards.\n",
     "# The weights of a target model get updated every 10000 steps thus when the\n",
     "# loss between the Q-values is calculated the target Q-value is stable.\n",
-    "model_target = keras.Model(inputs=inputs, outputs=action)\n",
-    "\n"
+    "model_target = create_q_model()\n",
+    ""
    ]
   },
   {
@@ -151,7 +156,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Train\n"
+    "## Train"
    ]
   },
   {
@@ -187,6 +192,8 @@
     "update_after_actions = 4\n",
     "# How often to update the target network\n",
     "update_target_network = 10000\n",
+    "# Using huber loss for stability\n",
+    "loss_function = keras.losses.Huber()\n",
     "\n",
     "while True:  # Run until solved\n",
     "    state = np.array(env.reset())\n",
@@ -264,14 +271,13 @@
     "                # Apply the masks to the Q-values to get the Q-value for action taken\n",
     "                q_action = tf.reduce_sum(tf.multiply(q_values, masks), axis=1)\n",
     "                # Calculate loss between new Q-value and old Q-value\n",
-    "                # Clip the deltas using huber loss for stability\n",
-    "                loss = tf.reduce_mean(keras.losses.huber(updated_q_values, q_action))\n",
+    "                loss = loss_function(updated_q_values, q_action)\n",
     "\n",
     "            # Backpropagation\n",
     "            grads = tape.gradient(loss, model.trainable_variables)\n",
     "            optimizer.apply_gradients(zip(grads, model.trainable_variables))\n",
     "\n",
-    "        if frame_count % 10000 == 0:\n",
+    "        if frame_count % update_target_network == 0:\n",
     "            # update the the target network with new weights\n",
     "            model_target.set_weights(model.get_weights())\n",
     "            # Log details\n",
@@ -299,7 +305,7 @@
     "\n",
     "    if running_reward > 40:  # Condition to consider the task solved\n",
     "        print(\"Solved at episode {}!\".format(episode_count))\n",
-    "        break\n"
+    "        break"
    ]
   },
   {
@@ -309,11 +315,14 @@
    },
    "source": [
     "## Visualizations\n",
+    "Before any training:\n",
+    "![Imgur](https://i.imgur.com/rRxXF4H.gif)\n",
+    "\n",
     "In early stages of training:\n",
     "![Imgur](https://i.imgur.com/X8ghdpL.gif)\n",
     "\n",
     "In later stages of training:\n",
-    "![Imgur](https://i.imgur.com/Z1K6qBQ.gif)\n"
+    "![Imgur](https://i.imgur.com/Z1K6qBQ.gif)"
    ]
   }
  ],


### PR DESCRIPTION
DQN keeps two copies of the weights (a normal Q model for exploration and a target model for computing the target Q values during training).
The code before this pull-request didn't create the two copies **properly**. Instead, the Q model and the target model always shared the same weights.

+ some minor fixes (instantiation of the Huber loss, variable *update_target_network* not used)
