### PR TITLE
Updated OCR example status to WIP

### DIFF
--- a/call_for_contributions.md
+++ b/call_for_contributions.md
@@ -17,7 +17,9 @@ Recommendations:
 [Reference TF implementation](https://github.com/NVlabs/stylegan2)
 
 
-## End-to-end OCR
+## End-to-end OCR (currently WIP)
+
+This example is currently being worked on by @parthivc and @joshuacwnewton through the MLH Fellowship
 
 [Old Keras example](https://github.com/keras-team/keras/blob/master/examples/image_ocr.py)
 


### PR DESCRIPTION
Changed the status of the End-to-end OCR example in the [call_for_contributions.md file](https://github.com/keras-team/keras-io/blob/master/call_for_contributions.md) to a work in progress.

Also mentioned in issue #104.