### PR TITLE
Removes duplication of ExponentialDecay from list

### DIFF
--- a/scripts/master.py
+++ b/scripts/master.py
@@ -165,11 +165,6 @@ MASTER = {
                                     'title': 'InverseTimeDecay',
                                     'generate': ['tensorflow.keras.optimizers.schedules.InverseTimeDecay']
                                 },
-                                {
-                                    'path': 'exponential_decay',
-                                    'title': 'ExponentialDecay',
-                                    'generate': ['tensorflow.keras.optimizers.schedules.ExponentialDecay']
-                                },
                             ]
                         },
                     ]


### PR DESCRIPTION
This PR removes the duplication of the link to ExponentialDecay from [here](https://keras.io/api/optimizers/learning_rate_schedules/).

Duplication in code can be found on [line149](https://github.com/keras-team/keras-io/blob/master/scripts/master.py#L149) and [line169](https://github.com/keras-team/keras-io/blob/master/scripts/master.py#L169).