### PR TITLE
test: Add makefile to ensure testing using container can be performed even in local

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,8 +21,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: Ensure the docker image works and can start.
       run: |
-        docker build -t keras-io .
-        docker run --rm -d -p 8000:8000 --name keras-io-server keras-io
-        sleep 10
-        docker exec keras-io-server echo I am alive
-        docker kill keras-io-server
+        make container-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.7
 
+ARG TF_VERSION=2.2.0
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
+RUN pip install tensorflow==${TF_VERSION}
 
 COPY ./ ./
 WORKDIR scripts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+container-test:
+	docker build --build-arg TF_VERSION=2.3.0-rc0 -t keras-io .
+	docker run --rm -d -p 8000:8000 --name keras-io-server keras-io
+	sleep 10
+	docker exec keras-io-server echo I am alive
+	docker kill keras-io-server

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ docker build -t keras-io . && docker run --rm -p 8000:8000 keras-io
 It will take a while the first time because it's going to pull the
 image and the dependencies, but on the next times it'll be much faster.
 
+Another way of testing using docker is using `Makefile` with following command:
+
+```
+make container-test
+```
+
+The aforementioned command will build Dockerimage and then run it, thus it will make
+sure the documentation can be served.
 
 ## Call for examples
 


### PR DESCRIPTION
Previously in CI implementation we're using only docker build and docker run
to perform e2e test, yet we still need to make sure the test performed for this
is more elaborate by providing a command to do that.

Related to https://github.com/keras-team/keras-io/issues/14