### PR TITLE
Fixed typo in introduction.

### DIFF
--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -18,7 +18,7 @@ contain, and how they're connected.
 - A set of losses and metrics (defined by compiling the model or calling
 `add_loss()` or `add_metric()`).
 
-The Keras API makes it possible to save of these pieces to disk at once,
+The Keras API makes it possible to save all of these pieces to disk at once,
 or to only selectively save some of them:
 
 - Saving everything into a single archive in the TensorFlow SavedModel format


### PR DESCRIPTION
From: 
"The Keras API makes it possible to save of these pieces to disk at once,
or to only selectively save some of them:"
To:
"The Keras API makes it possible to save all of these pieces to disk at once,
or to only selectively save some of them:"