### PR TITLE
Fix a typo in intro_to_keras_for_researchers

### DIFF
--- a/guides/intro_to_keras_for_researchers.py
+++ b/guides/intro_to_keras_for_researchers.py
@@ -412,7 +412,7 @@ for epoch in range(2):
             print("Epoch:", epoch, "Step:", step)
             print("Total running accuracy so far: %.3f" % accuracy.result())
 
-    # Result the metric's state at the end of an epoch
+    # Reset the metric's state at the end of an epoch
     accuracy.reset_states()
 
 """


### PR DESCRIPTION
```
    # Result the metric's state at the end of an epoch
    accuracy.reset_states()
```
should be
```
    # Reset the metric's state at the end of an epoch
    accuracy.reset_states()
```

Thanks