### PR TITLE
fixed display of ticks in `plot_latent`.

### DIFF
--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -138,7 +138,7 @@ def plot_latent(encoder, decoder):
 
     plt.figure(figsize=(figsize, figsize))
     start_range = digit_size // 2
-    end_range = n * digit_size + start_range + 1
+    end_range = n * digit_size + start_range
     pixel_range = np.arange(start_range, end_range, digit_size)
     sample_range_x = np.round(grid_x, 1)
     sample_range_y = np.round(grid_y, 1)


### PR DESCRIPTION
removed `+1` from end_range so pixel_range has the same shape as sample_range_x (array of 30 elements).