### PR TITLE
Fix typo in "Save and serialize"

### DIFF
--- a/tf/functional.ipynb
+++ b/tf/functional.ipynb
@@ -432,7 +432,7 @@
     "## Save and serialize\n",
     "\n",
     "Saving the model and serialization work the same way for models built using\n",
-    "the functional API as they do for `Sequential` models. To standard way\n",
+    "the functional API as they do for `Sequential` models. The standard way\n",
     "to save a functional model is to call `model.save()`\n",
     "to save the entire model as a single file. You can later recreate the same model\n",
     "from this file, even if the code that built the model is no longer available.\n",


### PR DESCRIPTION
"To standard way to save a functional model is..." -> "The standard way to save a functional model is..."