### PR TITLE
Fix the output of model_folder in keras: Serialisation and saving guide

### DIFF
--- a/examples/nlp/bidirectional_lstm_imdb.py
+++ b/examples/nlp/bidirectional_lstm_imdb.py
@@ -41,6 +41,8 @@ model.summary()
 )
 print(len(x_train), "Training sequences")
 print(len(x_val), "Validation sequences")
+# Use pad_sequence to standardize sequence length:
+# this will truncate sequences longer than 200 words and zero-pad sequences shorter than 200 words.
 x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
 x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 
@@ -48,5 +50,5 @@ x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 ## Train and evaluate the model
 """
 
-model.compile("adam", "binary_crossentropy", metrics=["accuracy"])
+model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
 model.fit(x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val))

--- a/guides/md/serialization_and_saving.md
+++ b/guides/md/serialization_and_saving.md
@@ -149,7 +149,7 @@ containing the following:
 
 <div class="k-default-codeblock">
 ```
-[34massets[m[m         saved_model.pb [34mvariables[m[m
+assets	saved_model.pb	variables
 
 ```
 </div>


### PR DESCRIPTION
In the section of What the SavedModel contains:

https://keras.io/guides/serialization_and_saving/#savedmodel-format
```
[34massets[m[m         saved_model.pb [34mvariables[m[m
```
output of saved model is display not properly. It's ideal to fix this issue manually with change in markdown as the PR. So for better readability of people reading guides.

What do you think @fchollet ?