### PR TITLE
Add TensorFlow Cloud guide to keras.io

### DIFF
--- a/guides/ipynb/training_keras_models_on_cloud.ipynb
+++ b/guides/ipynb/training_keras_models_on_cloud.ipynb
@@ -1,0 +1,599 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Training Keras models with TensorFlow Cloud\n",
+    "\n",
+    "**Author:** [Jonah Kohn](https://jonahkohn.com)<br>\n",
+    "**Date created:** 2020/08/11<br>\n",
+    "**Last modified:** 2020/08/11<br>\n",
+    "**Description:** In-depth usage guide for TensorFlow Cloud."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction\n",
+    "[TensorFlow Cloud](https://github.com/tensorflow/cloud) is a Python package that\n",
+    "provides APIs for a seamless transition from local debugging to distributed training\n",
+    "in Google Cloud. It simplifies the process of training TensorFlow models on the\n",
+    "cloud into a single, simple function call, requiring minimal setup and no changes\n",
+    "to your model. TensorFlow Cloud handles cloud-specific tasks such as creating VM\n",
+    "instances and distribution strategies for your models automatically. This guide\n",
+    "will demonstrate how to interface with Google Cloud through TensorFlow Cloud,\n",
+    "and the wide range of functionality provided within TensorFlow Cloud. We'll start\n",
+    "with the simplest use-case."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Setup\n",
+    "We'll get started by installing TensorFlow Cloud, and importing the packages we\n",
+    "will need in this guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q tensorflow_cloud"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import tensorflow_cloud as tfc\n",
+    "\n",
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## API overview: a first end-to-end example\n",
+    "Let's begin with a Keras model training script, such as the following CNN:\n",
+    "```python\n",
+    "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+    "model = keras.Sequential(\n",
+    "    [\n",
+    "        keras.Input(shape=(28, 28)),\n",
+    "        # Use a Rescaling layer to make sure input values are in the [0, 1] range.\n",
+    "        layers.experimental.preprocessing.Rescaling(1.0 / 255),\n",
+    "        # The original images have shape (28, 28), so we reshape them to (28, 28, 1)\n",
+    "        layers.Reshape(target_shape=(28, 28, 1)),\n",
+    "        # Follow-up with a classic small convnet\n",
+    "        layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "        layers.MaxPooling2D(2),\n",
+    "        layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "        layers.MaxPooling2D(2),\n",
+    "        layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "        layers.Flatten(),\n",
+    "        layers.Dense(128, activation=\"relu\"),\n",
+    "        layers.Dense(10),\n",
+    "    ]\n",
+    ")\n",
+    "model.compile(\n",
+    "    optimizer=keras.optimizers.Adam(),\n",
+    "    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "    metrics=keras.metrics.SparseCategoricalAccuracy(),\n",
+    ")\n",
+    "model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "To train this model on Gooogle Cloud we just need to add a call to `run()` at\n",
+    "the beginning of the script, before the imports:\n",
+    "```python\n",
+    "tfc.run()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We don’t need to worry about cloud-specific tasks such as creating VM instances\n",
+    "and distribution strategies when using TensorFlow Cloud.\n",
+    "The API includes intelligent defaults for all the parameters -- everything is\n",
+    "configurable, but many models can rely on these defaults.\n",
+    "Upon calling `run()`, TensorFlow Cloud will:\n",
+    "- Make your Python script or notebook distribution-ready.\n",
+    "- Convert it into a Docker image with required dependencies.\n",
+    "- Run the training job on a GCP GPU-powered VM.\n",
+    "- Stream relevant logs and job information.\n",
+    "The default VM configuration is 1 chief and 0 workers with 8 CPU cores and\n",
+    "1 Tesla T4 GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Google Cloud configuration\n",
+    "In order to facilitate the proper pathways for Cloud training, we will need to\n",
+    "do some first-time setup. If you're a new Google Cloud user, there are a few\n",
+    "preliminary steps you will need to take:\n",
+    "1. Create a GCP Project\n",
+    "2. Enable AI Platform Services\n",
+    "3. Create a Service Account\n",
+    "4. Download an authorization key\n",
+    "5. Create a Cloud Storage bucket\n",
+    "Detailed first-time setup instructions can be found in the\n",
+    "[TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),\n",
+    "and an additional setup example is shown on the\n",
+    "[TensorFlow Blog](https://blog.tensorflow.org/2020/08/train-your-tensorflow-model-on-google.html).\n",
+    "## Common workflows and Cloud storage\n",
+    "In most cases, you'll want to retrieve your model after training on Google Cloud.\n",
+    "For this, it's crucial to redirect saving and loading to Cloud Storage while\n",
+    "training remotely. We can direct TensorFlow Cloud to our Cloud Storage bucket for\n",
+    "a variety of tasks. The storage bucket can be used to save and load large training\n",
+    "datasets, store callback logs or model weights, and save trained model files.\n",
+    "To begin, let's configure `fit()` to save the model to a Cloud Storage, and set\n",
+    "up TensorBoard monitoring to track training progress."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def create_model():\n",
+    "    model = keras.Sequential(\n",
+    "        [\n",
+    "            keras.Input(shape=(28, 28)),\n",
+    "            layers.experimental.preprocessing.Rescaling(1.0 / 255),\n",
+    "            layers.Reshape(target_shape=(28, 28, 1)),\n",
+    "            layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "            layers.MaxPooling2D(2),\n",
+    "            layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "            layers.MaxPooling2D(2),\n",
+    "            layers.Conv2D(32, 3, activation=\"relu\"),\n",
+    "            layers.Flatten(),\n",
+    "            layers.Dense(128, activation=\"relu\"),\n",
+    "            layers.Dense(10),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    model.compile(\n",
+    "        optimizer=keras.optimizers.Adam(),\n",
+    "        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "        metrics=keras.metrics.SparseCategoricalAccuracy(),\n",
+    "    )\n",
+    "    return model\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Let's save the TensorBoard logs and model checkpoints generated during training\n",
+    "in our cloud storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import os\n",
+    "\n",
+    "gcp_bucket = \"keras-examples-jonah\"\n",
+    "\n",
+    "checkpoint_path = os.path.join(\"gs://\", gcp_bucket, \"mnist_example\", \"save_at_{epoch}\")\n",
+    "\n",
+    "tensorboard_path = os.path.join(  # Timestamp included to enable timeseries graphs\n",
+    "    \"gs://\", gcp_bucket, \"logs\", datetime.datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    ")\n",
+    "\n",
+    "callbacks = [\n",
+    "    # TensorBoard will store logs for each epoch and graph performance for us.\n",
+    "    keras.callbacks.TensorBoard(log_dir=tensorboard_path, histogram_freq=1),\n",
+    "    # ModelCheckpoint will save models after each epoch for retrieval later.\n",
+    "    keras.callbacks.ModelCheckpoint(checkpoint_path),\n",
+    "    # EarlyStopping will terminate training when val_loss ceases to improve.\n",
+    "    keras.callbacks.EarlyStopping(monitor=\"val_loss\", patience=3),\n",
+    "]\n",
+    "\n",
+    "model = create_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Here, we will load our data from Keras directly. In general, it's best practice\n",
+    "to store your dataset in your Cloud Storage bucket, however TensorFlow Cloud can\n",
+    "also accomodate datasets stored locally. That's covered in the Multi-file section\n",
+    "of this guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The [TensorFlow Cloud](https://github.com/tensorflow/cloud) API provides the\n",
+    "`remote()` function to determine whether code is being executed locally or on\n",
+    "the cloud. This allows for the separate designation of `fit()` parameters for\n",
+    "local and remote execution, and provides means for easy debugging without overloading\n",
+    "your local machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "if tfc.remote():\n",
+    "    epochs = 100\n",
+    "    callbacks = callbacks\n",
+    "    batch_size = 128\n",
+    "else:\n",
+    "    epochs = 1\n",
+    "    callbacks = None\n",
+    "    batch_size = None\n",
+    "\n",
+    "model.fit(x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Let's save the model in GCS after the training is complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "save_path = os.path.join(\"gs://\", gcp_bucket, \"mnist_example\")\n",
+    "\n",
+    "if tfc.remote():\n",
+    "    model.save(save_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We can also use this storage bucket for Docker image building, instead of your local\n",
+    "Docker instance. For this, just add your bucket to the `docker_image_bucket_name` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tfc.run(docker_image_bucket_name=gcp_bucket)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "After training the model, we can load the saved model and view our TensorBoard logs\n",
+    "to monitor performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "model = keras.models.load_model(save_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tensorboard dev upload --logdir \"gs://keras-examples-jonah/logs/fit\" --name \"Guide MNIST\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Large-scale projects\n",
+    "In many cases, your project containing a Keras model may encompass more than one\n",
+    "Python script, or may involve external data or specific dependencies. TensorFlow\n",
+    "Cloud is entirely flexible for large-scale deployment, and provides a number of\n",
+    "intelligent functionalities to aid your projects.\n",
+    "### Entry points: support for Python scripts and Jupyter notebooks\n",
+    "Your call to the `run()` API won't always be contained inside the same Python script\n",
+    "as your model training code. For this purpose, we provide an `entry_point` parameter.\n",
+    "The `entry_point` parameter can be used to specify the Python script or notebook in\n",
+    "which your model training code lives. When calling `run()` from the same script as\n",
+    "your model, use the `entry_point` default of `None`.\n",
+    "### `pip` dependencies\n",
+    "If your project calls on additional `pip` dependencies, it's possible to specify\n",
+    "the additional required libraries by including a `requirements.txt` file. In this\n",
+    "file, simply put a list of all the required dependencies and TensorFlow Cloud will\n",
+    "handle integrating these into your cloud build.\n",
+    "### Python notebooks\n",
+    "TensorFlow Cloud is also runnable from Python notebooks. Additionally, your specified\n",
+    "`entry_point` can be a notebook if needed. There are two key differences to keep\n",
+    "in mind between TensorFlow Cloud on notebooks compared to scripts:\n",
+    "- When calling `run()` from within a notebook, a Cloud Storage bucket must be specified\n",
+    "for building and storing your Docker image.\n",
+    "- GCloud authentication happens entirely through your authentication key, without\n",
+    "project specification. An example workflow using TensorFlow Cloud from a notebook\n",
+    "is provided in the \"Putting it all together\" section of this guide.\n",
+    "### Multi-file projects\n",
+    "If your model depends on additional files, you only need to ensure that these files\n",
+    "live in the same directory (or subdirectory) of the specified entry point. Every file\n",
+    "that is stored in the same directory as the specified `entry_point` will be included\n",
+    "in the Docker image, as well as any files stored in subdirectories adjacent to the\n",
+    "`entry_point`. This is also true for dependencies you may need which can't be acquired\n",
+    "through `pip`\n",
+    "For an example of a custom entry-point and multi-file project with additional pip\n",
+    "dependencies, take a look at this multi-file example on the\n",
+    "[TensorFlow Cloud Repository](https://github.com/tensorflow/cloud/tree/master/src/python/tensorflow_cloud/core/tests/examples/multi_file_example).\n",
+    "For brevity, we'll just include the example's `run()` call:\n",
+    "```python\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    entry_point=\"train_model.py\",\n",
+    "    requirements=\"requirements.txt\"\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Machine configuration and distributed training\n",
+    "Model training may require a wide range of different resources, depending on the\n",
+    "size of the model or the dataset. When accounting for configurations with multiple\n",
+    "GPUs, it becomes critical to choose a fitting\n",
+    "[distribution strategy](https://www.tensorflow.org/guide/distributed_training).\n",
+    "Here, we outline a few possible configurations:\n",
+    "### Multi-worker distribution\n",
+    "Here, we can use `COMMON_MACHINE_CONFIGS` to designate 1 chief CPU and 4 worker GPUs.\n",
+    "```python\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],\n",
+    "    worker_count=2,\n",
+    "    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X']\n",
+    ")\n",
+    "```\n",
+    "By default, TensorFlow Cloud chooses the best distribution strategy for your machine\n",
+    "configuration with a simple formula using the `chief_config`, `worker_config` and\n",
+    "`worker_count` parameters provided.\n",
+    "- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.\n",
+    "- If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.\n",
+    "- Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### TPU distribution\n",
+    "Let's train the same model on TPU, as shown:\n",
+    "```python\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    chief_config=tfc.COMMON_MACHINE_CONFIGS[\"CPU\"],\n",
+    "    worker_count=1,\n",
+    "    worker_config=tfc.COMMON_MACHINE_CONFIGS[\"TPU\"]\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Custom distribution strategy\n",
+    "To specify a custom distribution strategy, format your code normally as you would\n",
+    "according to the\n",
+    "[distributed training guide](https://www.tensorflow.org/guide/distributed_training)\n",
+    "and set `distribution_strategy` to `None`. Below, we'll specify our own distribution\n",
+    "strategy for the same MNIST model.\n",
+    "```python\n",
+    "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+    "mirrored_strategy = tf.distribute.MirroredStrategy()\n",
+    "with mirrored_strategy.scope():\n",
+    "  model = create_model()\n",
+    "if tfc.remote():\n",
+    "    epochs = 100\n",
+    "    batch_size = 128\n",
+    "else:\n",
+    "    epochs = 1\n",
+    "    callbacks = None\n",
+    "    batch_size = None\n",
+    "model.fit(\n",
+    "    x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size\n",
+    ")\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],\n",
+    "    worker_count=2,\n",
+    "    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X'],\n",
+    "    distribution_strategy=None\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Custom Docker images\n",
+    "By default, TensorFlow Cloud uses a\n",
+    "[Docker base image](https://hub.docker.com/r/tensorflow/tensorflow/)\n",
+    "supplied by Google and corresponding to your current TensorFlow version. However,\n",
+    "you can also specify a custom Docker image to fit your build requirements, if necessary.\n",
+    "For this example, we will specify the Docker image from an older version of TensorFlow:\n",
+    "```python\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    base_docker_image=\"tensorflow/tensorflow:2.1.0-gpu\"\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Additional metrics\n",
+    "You may find it useful to tag your Cloud jobs with specific labels, or to stream\n",
+    "your model's logs during Cloud training.\n",
+    "It's good practice to maintain proper labeling on all Cloud jobs, for record-keeping.\n",
+    "For this purpose, `run()` accepts a dictionary of labels up to 64 key-value pairs,\n",
+    "which are visible from the Cloud build logs. Logs such as epoch performance and model\n",
+    "saving internals can be accessed using the link provided by executing `tfc.run` or\n",
+    "printed to your local terminal using the `stream_logs` flag.\n",
+    "```python\n",
+    "job_labels = {\"job\": \"mnist-example\", \"team\": \"keras-io\", \"user\": \"jonah\"}\n",
+    "tfc.run(\n",
+    "    docker_image_bucket_name=gcp_bucket,\n",
+    "    job_labels=job_labels,\n",
+    "    stream_logs=True\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Putting it all together\n",
+    "For an in-depth Colab which uses many of the features described in this guide,\n",
+    "follow along\n",
+    "[this example](https://github.com/tensorflow/cloud/blob/master/src/python/tensorflow_cloud/core/tests/examples/dogs_classification.ipynb)\n",
+    "to train a state-of-the-art model to recognize dog breeds from photos using feature\n",
+    "extraction."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "training_keras_models_on_cloud",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/guides/md/training_keras_models_on_cloud.md
+++ b/guides/md/training_keras_models_on_cloud.md
@@ -1,0 +1,390 @@
+# Training Keras models with TensorFlow Cloud
+
+**Author:** [Jonah Kohn](https://jonahkohn.com)<br>
+**Date created:** 2020/08/11<br>
+**Last modified:** 2020/08/11<br>
+**Description:** In-depth usage guide for TensorFlow Cloud.
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/guidesipynb/training_keras_models_on_cloud.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/guidestraining_keras_models_on_cloud.py)
+
+
+
+---
+## Introduction
+[TensorFlow Cloud](https://github.com/tensorflow/cloud) is a Python package that
+provides APIs for a seamless transition from local debugging to distributed training
+in Google Cloud. It simplifies the process of training TensorFlow models on the
+cloud into a single, simple function call, requiring minimal setup and no changes
+to your model. TensorFlow Cloud handles cloud-specific tasks such as creating VM
+instances and distribution strategies for your models automatically. This guide
+will demonstrate how to interface with Google Cloud through TensorFlow Cloud,
+and the wide range of functionality provided within TensorFlow Cloud. We'll start
+with the simplest use-case.
+
+---
+## Setup
+We'll get started by installing TensorFlow Cloud, and importing the packages we
+will need in this guide.
+
+
+```python
+!pip install -q tensorflow_cloud
+```
+
+
+```python
+import tensorflow as tf
+import tensorflow_cloud as tfc
+
+from tensorflow import keras
+from tensorflow.keras import layers
+```
+
+---
+## API overview: a first end-to-end example
+Let's begin with a Keras model training script, such as the following CNN:
+```python
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+model = keras.Sequential(
+    [
+        keras.Input(shape=(28, 28)),
+        # Use a Rescaling layer to make sure input values are in the [0, 1] range.
+        layers.experimental.preprocessing.Rescaling(1.0 / 255),
+        # The original images have shape (28, 28), so we reshape them to (28, 28, 1)
+        layers.Reshape(target_shape=(28, 28, 1)),
+        # Follow-up with a classic small convnet
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.MaxPooling2D(2),
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.MaxPooling2D(2),
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.Flatten(),
+        layers.Dense(128, activation="relu"),
+        layers.Dense(10),
+    ]
+)
+model.compile(
+    optimizer=keras.optimizers.Adam(),
+    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    metrics=keras.metrics.SparseCategoricalAccuracy(),
+)
+model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)
+```
+
+To train this model on Gooogle Cloud we just need to add a call to `run()` at
+the beginning of the script, before the imports:
+```python
+tfc.run()
+```
+
+We don’t need to worry about cloud-specific tasks such as creating VM instances
+and distribution strategies when using TensorFlow Cloud.
+The API includes intelligent defaults for all the parameters -- everything is
+configurable, but many models can rely on these defaults.
+Upon calling `run()`, TensorFlow Cloud will:
+- Make your Python script or notebook distribution-ready.
+- Convert it into a Docker image with required dependencies.
+- Run the training job on a GCP GPU-powered VM.
+- Stream relevant logs and job information.
+The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
+1 Tesla T4 GPU.
+
+---
+## Google Cloud configuration
+In order to facilitate the proper pathways for Cloud training, we will need to
+do some first-time setup. If you're a new Google Cloud user, there are a few
+preliminary steps you will need to take:
+1. Create a GCP Project
+2. Enable AI Platform Services
+3. Create a Service Account
+4. Download an authorization key
+5. Create a Cloud Storage bucket
+Detailed first-time setup instructions can be found in the
+[TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),
+and an additional setup example is shown on the
+[TensorFlow Blog](https://blog.tensorflow.org/2020/08/train-your-tensorflow-model-on-google.html).
+---
+## Common workflows and Cloud storage
+In most cases, you'll want to retrieve your model after training on Google Cloud.
+For this, it's crucial to redirect saving and loading to Cloud Storage while
+training remotely. We can direct TensorFlow Cloud to our Cloud Storage bucket for
+a variety of tasks. The storage bucket can be used to save and load large training
+datasets, store callback logs or model weights, and save trained model files.
+To begin, let's configure `fit()` to save the model to a Cloud Storage, and set
+up TensorBoard monitoring to track training progress.
+
+
+```python
+
+def create_model():
+    model = keras.Sequential(
+        [
+            keras.Input(shape=(28, 28)),
+            layers.experimental.preprocessing.Rescaling(1.0 / 255),
+            layers.Reshape(target_shape=(28, 28, 1)),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.MaxPooling2D(2),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.MaxPooling2D(2),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.Flatten(),
+            layers.Dense(128, activation="relu"),
+            layers.Dense(10),
+        ]
+    )
+
+    model.compile(
+        optimizer=keras.optimizers.Adam(),
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=keras.metrics.SparseCategoricalAccuracy(),
+    )
+    return model
+
+```
+
+Let's save the TensorBoard logs and model checkpoints generated during training
+in our cloud storage bucket.
+
+
+```python
+import datetime
+import os
+
+gcp_bucket = "keras-examples-jonah"
+
+checkpoint_path = os.path.join("gs://", gcp_bucket, "mnist_example", "save_at_{epoch}")
+
+tensorboard_path = os.path.join(  # Timestamp included to enable timeseries graphs
+    "gs://", gcp_bucket, "logs", datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+)
+
+callbacks = [
+    # TensorBoard will store logs for each epoch and graph performance for us.
+    keras.callbacks.TensorBoard(log_dir=tensorboard_path, histogram_freq=1),
+    # ModelCheckpoint will save models after each epoch for retrieval later.
+    keras.callbacks.ModelCheckpoint(checkpoint_path),
+    # EarlyStopping will terminate training when val_loss ceases to improve.
+    keras.callbacks.EarlyStopping(monitor="val_loss", patience=3),
+]
+
+model = create_model()
+```
+
+Here, we will load our data from Keras directly. In general, it's best practice
+to store your dataset in your Cloud Storage bucket, however TensorFlow Cloud can
+also accomodate datasets stored locally. That's covered in the Multi-file section
+of this guide.
+
+
+```python
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+```
+
+The [TensorFlow Cloud](https://github.com/tensorflow/cloud) API provides the
+`remote()` function to determine whether code is being executed locally or on
+the cloud. This allows for the separate designation of `fit()` parameters for
+local and remote execution, and provides means for easy debugging without overloading
+your local machine.
+
+
+```python
+if tfc.remote():
+    epochs = 100
+    callbacks = callbacks
+    batch_size = 128
+else:
+    epochs = 1
+    callbacks = None
+    batch_size = None
+
+model.fit(x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size)
+```
+
+<div class="k-default-codeblock">
+```
+1875/1875 [==============================] - 34s 18ms/step - loss: 0.1530 - sparse_categorical_accuracy: 0.9528
+
+<tensorflow.python.keras.callbacks.History at 0x7ab534468748>
+
+```
+</div>
+Let's save the model in GCS after the training is complete.
+
+
+```python
+save_path = os.path.join("gs://", gcp_bucket, "mnist_example")
+
+if tfc.remote():
+    model.save(save_path)
+```
+
+We can also use this storage bucket for Docker image building, instead of your local
+Docker instance. For this, just add your bucket to the `docker_image_bucket_name` parameter.
+
+
+```python
+tfc.run(docker_image_bucket_name=gcp_bucket)
+```
+
+After training the model, we can load the saved model and view our TensorBoard logs
+to monitor performance.
+
+
+```python
+model = keras.models.load_model(save_path)
+
+"""shell
+tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
+"""
+```
+
+---
+## Large-scale projects
+In many cases, your project containing a Keras model may encompass more than one
+Python script, or may involve external data or specific dependencies. TensorFlow
+Cloud is entirely flexible for large-scale deployment, and provides a number of
+intelligent functionalities to aid your projects.
+### Entry points: support for Python scripts and Jupyter notebooks
+Your call to the `run()` API won't always be contained inside the same Python script
+as your model training code. For this purpose, we provide an `entry_point` parameter.
+The `entry_point` parameter can be used to specify the Python script or notebook in
+which your model training code lives. When calling `run()` from the same script as
+your model, use the `entry_point` default of `None`.
+### `pip` dependencies
+If your project calls on additional `pip` dependencies, it's possible to specify
+the additional required libraries by including a `requirements.txt` file. In this
+file, simply put a list of all the required dependencies and TensorFlow Cloud will
+handle integrating these into your cloud build.
+### Python notebooks
+TensorFlow Cloud is also runnable from Python notebooks. Additionally, your specified
+`entry_point` can be a notebook if needed. There are two key differences to keep
+in mind between TensorFlow Cloud on notebooks compared to scripts:
+- When calling `run()` from within a notebook, a Cloud Storage bucket must be specified
+for building and storing your Docker image.
+- GCloud authentication happens entirely through your authentication key, without
+project specification. An example workflow using TensorFlow Cloud from a notebook
+is provided in the "Putting it all together" section of this guide.
+### Multi-file projects
+If your model depends on additional files, you only need to ensure that these files
+live in the same directory (or subdirectory) of the specified entry point. Every file
+that is stored in the same directory as the specified `entry_point` will be included
+in the Docker image, as well as any files stored in subdirectories adjacent to the
+`entry_point`. This is also true for dependencies you may need which can't be acquired
+through `pip`
+For an example of a custom entry-point and multi-file project with additional pip
+dependencies, take a look at this multi-file example on the
+[TensorFlow Cloud Repository](https://github.com/tensorflow/cloud/tree/master/src/python/tensorflow_cloud/core/tests/examples/multi_file_example).
+For brevity, we'll just include the example's `run()` call:
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    entry_point="train_model.py",
+    requirements="requirements.txt"
+)
+```
+
+---
+## Machine configuration and distributed training
+Model training may require a wide range of different resources, depending on the
+size of the model or the dataset. When accounting for configurations with multiple
+GPUs, it becomes critical to choose a fitting
+[distribution strategy](https://www.tensorflow.org/guide/distributed_training).
+Here, we outline a few possible configurations:
+### Multi-worker distribution
+Here, we can use `COMMON_MACHINE_CONFIGS` to designate 1 chief CPU and 4 worker GPUs.
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],
+    worker_count=2,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X']
+)
+```
+By default, TensorFlow Cloud chooses the best distribution strategy for your machine
+configuration with a simple formula using the `chief_config`, `worker_config` and
+`worker_count` parameters provided.
+- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.
+- If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.
+- Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen.
+
+### TPU distribution
+Let's train the same model on TPU, as shown:
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS["CPU"],
+    worker_count=1,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS["TPU"]
+)
+```
+
+### Custom distribution strategy
+To specify a custom distribution strategy, format your code normally as you would
+according to the
+[distributed training guide](https://www.tensorflow.org/guide/distributed_training)
+and set `distribution_strategy` to `None`. Below, we'll specify our own distribution
+strategy for the same MNIST model.
+```python
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+mirrored_strategy = tf.distribute.MirroredStrategy()
+with mirrored_strategy.scope():
+  model = create_model()
+if tfc.remote():
+    epochs = 100
+    batch_size = 128
+else:
+    epochs = 1
+    callbacks = None
+    batch_size = None
+model.fit(
+    x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size
+)
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],
+    worker_count=2,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X'],
+    distribution_strategy=None
+)
+```
+
+---
+## Custom Docker images
+By default, TensorFlow Cloud uses a
+[Docker base image](https://hub.docker.com/r/tensorflow/tensorflow/)
+supplied by Google and corresponding to your current TensorFlow version. However,
+you can also specify a custom Docker image to fit your build requirements, if necessary.
+For this example, we will specify the Docker image from an older version of TensorFlow:
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    base_docker_image="tensorflow/tensorflow:2.1.0-gpu"
+)
+```
+
+---
+## Additional metrics
+You may find it useful to tag your Cloud jobs with specific labels, or to stream
+your model's logs during Cloud training.
+It's good practice to maintain proper labeling on all Cloud jobs, for record-keeping.
+For this purpose, `run()` accepts a dictionary of labels up to 64 key-value pairs,
+which are visible from the Cloud build logs. Logs such as epoch performance and model
+saving internals can be accessed using the link provided by executing `tfc.run` or
+printed to your local terminal using the `stream_logs` flag.
+```python
+job_labels = {"job": "mnist-example", "team": "keras-io", "user": "jonah"}
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    job_labels=job_labels,
+    stream_logs=True
+)
+```
+
+---
+## Putting it all together
+For an in-depth Colab which uses many of the features described in this guide,
+follow along
+[this example](https://github.com/tensorflow/cloud/blob/master/src/python/tensorflow_cloud/core/tests/examples/dogs_classification.ipynb)
+to train a state-of-the-art model to recognize dog breeds from photos using feature
+extraction.

--- a/guides/md/training_keras_models_on_cloud.md
+++ b/guides/md/training_keras_models_on_cloud.md
@@ -201,16 +201,7 @@ else:
 model.fit(x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size)
 ```
 
-<div class="k-default-codeblock">
-```
-1875/1875 [==============================] - 34s 18ms/step - loss: 0.1530 - sparse_categorical_accuracy: 0.9528
-
-<tensorflow.python.keras.callbacks.History at 0x7ab534468748>
-
-```
-</div>
 Let's save the model in GCS after the training is complete.
-
 
 ```python
 save_path = os.path.join("gs://", gcp_bucket, "mnist_example")
@@ -233,10 +224,10 @@ to monitor performance.
 
 ```python
 model = keras.models.load_model(save_path)
+```
 
-"""shell
-tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
-"""
+```python
+!tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
 ```
 
 ---

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -1,6 +1,6 @@
 """
 Title: Training Keras models with TensorFlow Cloud
-Authors: [Jonah Kohn](https://jonahkohn.com)
+Author: [Jonah Kohn](https://jonahkohn.com)
 Date created: 2020/08/11
 Last modified: 2020/08/11
 Description: In-depth usage guide for TensorFlow Cloud.

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -1,0 +1,415 @@
+"""
+Title: Training Keras models on Cloud
+Authors: [Jonah Kohn](https://jonahkohn.com)
+Date created: 2020/08/11
+Last modified: 2020/08/11
+Description: In-depth usage guide for TensorFlow Cloud.
+"""
+"""
+## Introduction
+
+[TensorFlow Cloud](https://github.com/tensorflow/cloud) is a Python package that
+provides APIs for a seamless transition from local debugging to distributed training
+in Google Cloud. It simplifies the process of training TensorFlow models on the
+cloud into a single, simple function call, requiring minimal setup and no changes
+to your model. TensorFlow Cloud handles cloud-specific tasks such as creating VM
+instances and distribution strategies for your models automatically. This guide
+will demonstrate how to interface with Google Cloud through TensorFlow Cloud,
+and the wide range of functionality provided within TensorFlow Cloud. We'll start
+with the simplest use-case.
+"""
+
+"""
+## Setup
+We'll get started by installing TensorFlow Cloud, and importing the packages we
+will need in this guide.
+"""
+
+"""shell
+pip install -q tensorflow_cloud
+"""
+
+import tensorflow as tf
+import tensorflow_cloud as tfc
+
+from tensorflow import keras
+from tensorflow.keras import layers
+
+"""
+##API overview: a first end-to-end example
+
+Let's begin with a Keras model training script, such as the following CNN:
+
+```python
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+model = keras.Sequential(
+    [
+        keras.Input(shape=(28, 28)),
+        # Use a Rescaling layer to make sure input values are in the [0, 1] range.
+        layers.experimental.preprocessing.Rescaling(1.0 / 255),
+        # The original images have shape (28, 28), so we reshape them to (28, 28, 1)
+        layers.Reshape(target_shape=(28, 28, 1)),
+        # Follow-up with a classic small convnet
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.MaxPooling2D(2),
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.MaxPooling2D(2),
+        layers.Conv2D(32, 3, activation="relu"),
+        layers.Flatten(),
+        layers.Dense(128, activation="relu"),
+        layers.Dense(10),
+    ]
+)
+
+model.compile(
+    optimizer=keras.optimizers.Adam(),
+    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    metrics=keras.metrics.SparseCategoricalAccuracy(),
+)
+
+model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)
+```
+"""
+
+"""
+To train this model on Gooogle Cloud we just need to add:
+```python
+tfc.run()
+```
+"""
+
+"""
+We don’t need to worry about cloud-specific tasks such as creating VM instances
+and distribution strategies when using TensorFlow Cloud.
+The API includes intelligent defaults for all the parameters -- everything is
+configurable, but many models can rely on these defaults.
+
+Upon calling `run()`, TensorFlow Cloud will:
+
+- Make your Python script or notebook distribution-ready.
+- Convert it into a Docker image with required dependencies.
+- Run the training job on a GCP GPU-powered VM.
+- Stream relevant logs and job information.
+
+The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
+1 Tesla T4 GPU.
+"""
+
+"""
+##Google Cloud configuration
+
+In order to facilitate the proper pathways for Cloud training, we will need to
+do some first-time setup. If you're a new Google Cloud user, there are a few
+preliminary steps you will need to take:
+
+1. Create a GCP Project
+2. Enable AI Platform Services
+3. Create a Service Account
+4. Download an authorization key
+5. Create a Cloud Storage bucket
+
+Detailed first-time setup instructions can be found in the
+[TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),
+and an additional setup example is shown on the
+[TensorFlow Blog](https://blog.tensorflow.org/2020/08/train-your-tensorflow-model-on-google.html).
+
+##Common workflows and Cloud storage
+
+In most cases, you'll want to retrieve your model after training on Google Cloud.
+For this, it's crucial to redirect saving and loading to Cloud Storage while
+training remotely. We can direct TensorFlow Cloud to our Cloud Storage bucket for
+a variety of tasks. The storage bucket can be used to save and load large training
+datasets, store callback logs or model weights, and save trained model files.
+To begin, let's configure `fit()` to save the model to a Cloud Storage, and set
+up TensorBoard monitoring to track training progress.
+"""
+
+
+def create_model():
+    model = keras.Sequential(
+        [
+            keras.Input(shape=(28, 28)),
+            layers.experimental.preprocessing.Rescaling(1.0 / 255),
+            layers.Reshape(target_shape=(28, 28, 1)),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.MaxPooling2D(2),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.MaxPooling2D(2),
+            layers.Conv2D(32, 3, activation="relu"),
+            layers.Flatten(),
+            layers.Dense(128, activation="relu"),
+            layers.Dense(10),
+        ]
+    )
+
+    model.compile(
+        optimizer=keras.optimizers.Adam(),
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=keras.metrics.SparseCategoricalAccuracy(),
+    )
+    return model
+
+
+"""
+Let's save the TensorBoard logs and model checkpoints generated during training
+in our cloud storage bucket.
+"""
+
+import datetime
+import os
+
+gcp_bucket = "keras-examples-jonah"
+
+checkpoint_path = os.path.join("gs://", gcp_bucket, "mnist_example", "save_at_{epoch}")
+
+tensorboard_path = os.path.join(  # Timestamp included to enable timeseries graphs
+    "gs://", gcp_bucket, "logs", datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+)
+
+callbacks = [
+    # TensorBoard will store logs for each epoch and graph performance for us.
+    keras.callbacks.TensorBoard(log_dir=tensorboard_path, histogram_freq=1),
+    # ModelCheckpoint will save models after each epoch for retrieval later.
+    keras.callbacks.ModelCheckpoint(checkpoint_path),
+    # EarlyStopping will terminate training when val_loss ceases to improve.
+    keras.callbacks.EarlyStopping(monitor="val_loss", patience=3),
+]
+
+model = create_model()
+
+"""
+Here, we will load our data from Keras directly. In general, it's best practice
+to store your dataset in your Cloud Storage bucket, however TensorFlow Cloud can
+also accomodate datasets stored locally. That's covered in the Multi-file section
+of this guide.
+"""
+
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+"""
+The [TensorFlow Cloud](https://github.com/tensorflow/cloud) API provides the
+`remote()` function to determine whether code is being executed locally or on
+the cloud. This allows for the separate designation of `fit()` parameters for
+local and remote execution, and provides means for easy debugging without overloading
+your local machine.
+"""
+
+if tfc.remote():
+    epochs = 100
+    callbacks = callbacks
+    batch_size = 128
+else:
+    epochs = 1
+    callbacks = None
+    batch_size = None
+
+model.fit(x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size)
+
+"""
+Let's save the model in GCS after the training is complete.
+"""
+
+save_path = os.path.join("gs://", gcp_bucket, "mnist_example")
+
+if tfc.remote():
+    model.save(save_path)
+
+"""
+We can also use this storage bucket for Docker image building, instead of your local
+Docker instance. For this, just add your bucket to the `docker_image_bucket_name` parameter.
+"""
+
+# tfc.run(docker_image_bucket_name=gcp_bucket)
+
+"""
+After training the model, we can load the saved model and view our TensorBoard logs
+to monitor performance.
+"""
+
+# model = keras.models.load_model(save_path)
+
+# """shell
+# tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
+# """   
+
+"""
+## Large-scale projects
+
+In many cases, your project containing a Keras model may encompass more than one
+Python script, or may involve external data or specific dependencies. TensorFlow
+Cloud is entirely flexible for large-scale deployment, and provides a number of
+intelligent functionalities to aid your projects.
+
+### Entry points: support for Python scripts and Jupyter notebooks
+
+Your call to the `run()` API won't always be contained inside the same Python script
+as your model training code. For this purpose, we provide an `entry_point` parameter.
+The `entry_point` parameter can be used to specify the Python script or notebook in
+which your model training code lives. When calling `run()` from the same script as
+your model, use the `entry_point` default of `None`.
+
+### `pip` dependencies
+
+If your project calls on additional `pip` dependencies, it's possible to specify
+the additional required libraries by including a `requirements.txt` file. In this
+file, simply put a list of all the required dependencies and TensorFlow Cloud will
+handle integrating these into your cloud build.
+
+### Python notebooks
+
+TensorFlow Cloud is also runnable from Python notebooks. Additionally, your specified
+`entry_point` can be a notebook if needed. There are two key differences to keep
+in mind between TensorFlow Cloud on notebooks compared to scripts:
+
+- When calling `run()` from within a notebook, a Cloud Storage bucket must be specified
+for building and storing your Docker image.
+- GCloud authentication happens entirely through your authentication key, without
+project specification. An example workflow using TensorFlow Cloud from a notebook
+is provided in the "Putting it all together" section of this guide.
+
+### Multi-file projects
+
+If your model depends on additional files, you only need to ensure that these files
+live in the same directory (or subdirectory) of the specified entry point. Every file
+that is stored in the same directory as the specified `entry_point` will be included
+in the Docker image, as well as any files stored in subdirectories adjacent to the
+`entry_point`. This is also true for dependencies you may need which can't be acquired
+through `pip`
+
+For an example of a custom entry-point and multi-file project with additional pip
+dependencies, take a look at this multi-file example on the
+[TensorFlow Cloud Repository](https://github.com/tensorflow/cloud/tree/master/src/python/tensorflow_cloud/core/tests/examples/multi_file_example).
+For brevity, we'll just include the example's `run()` call:
+
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    entry_point="train_model.py",
+    requirements="requirements.txt"
+)
+```
+"""
+
+"""
+## Machine configuration and distributed training
+
+Model training may require a wide range of different resources, depending on the
+size of the model or the dataset. When accounting for configurations with multiple
+GPUs, it becomes critical to choose a fitting
+[distribution strategy](https://www.tensorflow.org/guide/distributed_training).
+Here, we outline a few possible configurations:
+
+###Multi-worker distribution
+Here, we can use `COMMON_MACHINE_CONFIGS` to designate 1 chief CPU and 4 worker GPUs.
+
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],
+    worker_count=2,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X']
+)
+```
+By default, TensorFlow Cloud chooses the best distribution strategy for your machine
+configuration with a simple formula using the `chief_config`, `worker_config` and
+`worker_count` parameters provided.
+
+- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.
+- If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.
+- Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen.
+"""
+
+"""
+###TPU distribution
+Let's train the same model on TPU, as shown:
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS["CPU"],
+    worker_count=1,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS["TPU"]
+)
+```
+"""
+
+"""
+###Custom distribution strategy
+To specify a custom distribution strategy, format your code normally as you would
+according to the
+[distributed training guide](https://www.tensorflow.org/guide/distributed_training)
+and set `distribution_strategy` to `None`. Below, we'll specify our own distribution
+strategy for the same MNIST model.
+```python
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+mirrored_strategy = tf.distribute.MirroredStrategy()
+with mirrored_strategy.scope():
+  model = create_model()
+
+if tfc.remote():
+    epochs = 100
+    batch_size = 128
+else:
+    epochs = 1
+    callbacks = None
+    batch_size = None
+
+model.fit(
+    x_train, y_train, epochs=epochs, callbacks=callbacks, batch_size=batch_size
+)
+
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    chief_config=tfc.COMMON_MACHINE_CONFIGS['CPU'],
+    worker_count=2,
+    worker_config=tfc.COMMON_MACHINE_CONFIGS['T4_4X'],
+    distribution_strategy=None
+)
+```
+"""
+"""
+## Custom Docker images
+
+By default, TensorFlow Cloud uses a
+[Docker base image](https://hub.docker.com/r/tensorflow/tensorflow/)
+supplied by Google and corresponding to your current TensorFlow version. However,
+you can also specify a custom Docker image to fit your build requirements, if necessary.
+For this example, we will specify the Docker image from an older version of TensorFlow:
+```python
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    base_docker_image="tensorflow/tensorflow:2.1.0-gpu"
+)
+```
+"""
+
+"""
+##Additional metrics
+
+You may find it useful to tag your Cloud jobs with specific labels, or to stream
+your model's logs during Cloud training.
+It's good practice to maintain proper labeling on all Cloud jobs, for record-keeping.
+For this purpose, `run()` accepts a dictionary of labels up to 64 key-value pairs,
+which are visible from the Cloud build logs. Logs such as epoch performance and model
+saving internals can be accessed using the link provided by executing `tfc.run` or
+printed to your local terminal using the `stream_logs` flag.
+```python
+job_labels = {"job": "mnist-example", "team": "keras-io", "user": "jonah"}
+
+tfc.run(
+    docker_image_bucket_name=gcp_bucket,
+    job_labels=job_labels,
+    stream_logs=True
+)
+```
+"""
+"""
+##Putting it all together
+
+For an in-depth Colab which uses many of the features described in this guide,
+follow along
+[this example](https://github.com/tensorflow/cloud/blob/master/src/python/tensorflow_cloud/core/tests/examples/dogs_classification.ipynb)
+to train a state-of-the-art model to recognize dog breeds from photos using feature
+extraction.
+"""

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -1,5 +1,5 @@
 """
-Title: Training Keras models on Cloud
+Title: Training Keras models with TensorFlow Cloud
 Authors: [Jonah Kohn](https://jonahkohn.com)
 Date created: 2020/08/11
 Last modified: 2020/08/11
@@ -21,6 +21,7 @@ with the simplest use-case.
 
 """
 ## Setup
+
 We'll get started by installing TensorFlow Cloud, and importing the packages we
 will need in this guide.
 """
@@ -36,7 +37,7 @@ from tensorflow import keras
 from tensorflow.keras import layers
 
 """
-##API overview: a first end-to-end example
+## API overview: a first end-to-end example
 
 Let's begin with a Keras model training script, such as the following CNN:
 
@@ -73,7 +74,8 @@ model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)
 """
 
 """
-To train this model on Gooogle Cloud we just need to add:
+To train this model on Gooogle Cloud we just need to add a call to `run()` at
+the beginning of the script, before the imports:
 ```python
 tfc.run()
 ```
@@ -97,7 +99,7 @@ The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
 """
 
 """
-##Google Cloud configuration
+## Google Cloud configuration
 
 In order to facilitate the proper pathways for Cloud training, we will need to
 do some first-time setup. If you're a new Google Cloud user, there are a few
@@ -114,7 +116,7 @@ Detailed first-time setup instructions can be found in the
 and an additional setup example is shown on the
 [TensorFlow Blog](https://blog.tensorflow.org/2020/08/train-your-tensorflow-model-on-google.html).
 
-##Common workflows and Cloud storage
+## Common workflows and Cloud storage
 
 In most cases, you'll want to retrieve your model after training on Google Cloud.
 For this, it's crucial to redirect saving and loading to Cloud Storage while
@@ -300,7 +302,7 @@ GPUs, it becomes critical to choose a fitting
 [distribution strategy](https://www.tensorflow.org/guide/distributed_training).
 Here, we outline a few possible configurations:
 
-###Multi-worker distribution
+### Multi-worker distribution
 Here, we can use `COMMON_MACHINE_CONFIGS` to designate 1 chief CPU and 4 worker GPUs.
 
 ```python
@@ -321,7 +323,7 @@ configuration with a simple formula using the `chief_config`, `worker_config` an
 """
 
 """
-###TPU distribution
+### TPU distribution
 Let's train the same model on TPU, as shown:
 ```python
 tfc.run(
@@ -334,7 +336,7 @@ tfc.run(
 """
 
 """
-###Custom distribution strategy
+### Custom distribution strategy
 To specify a custom distribution strategy, format your code normally as you would
 according to the
 [distributed training guide](https://www.tensorflow.org/guide/distributed_training)
@@ -385,7 +387,7 @@ tfc.run(
 """
 
 """
-##Additional metrics
+## Additional metrics
 
 You may find it useful to tag your Cloud jobs with specific labels, or to stream
 your model's logs during Cloud training.
@@ -405,7 +407,7 @@ tfc.run(
 ```
 """
 """
-##Putting it all together
+## Putting it all together
 
 For an in-depth Colab which uses many of the features described in this guide,
 follow along

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -222,18 +222,18 @@ We can also use this storage bucket for Docker image building, instead of your l
 Docker instance. For this, just add your bucket to the `docker_image_bucket_name` parameter.
 """
 
-# tfc.run(docker_image_bucket_name=gcp_bucket)
+tfc.run(docker_image_bucket_name=gcp_bucket)
 
 """
 After training the model, we can load the saved model and view our TensorBoard logs
 to monitor performance.
 """
 
-# model = keras.models.load_model(save_path)
+model = keras.models.load_model(save_path)
 
-# """shell
-# tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
-# """   
+"""shell
+tensorboard dev upload --logdir "gs://keras-examples-jonah/logs/fit" --name "Guide MNIST"
+"""   
 
 """
 ## Large-scale projects


### PR DESCRIPTION
The run() call, model.load(), and tensorboard log generation have all been temporarily commented out to allow the successful creation of a notebook. I'll manually add these in after generation. 