### PR TITLE
Fix typos and reformat markdown for Cloud guide

### DIFF
--- a/guides/ipynb/training_keras_models_on_cloud.ipynb
+++ b/guides/ipynb/training_keras_models_on_cloud.ipynb
@@ -130,10 +130,12 @@
     "The API includes intelligent defaults for all the parameters -- everything is\n",
     "configurable, but many models can rely on these defaults.\n",
     "Upon calling `run()`, TensorFlow Cloud will:\n",
+    
     "- Make your Python script or notebook distribution-ready.\n",
     "- Convert it into a Docker image with required dependencies.\n",
     "- Run the training job on a GCP GPU-powered VM.\n",
     "- Stream relevant logs and job information.\n",
+    
     "The default VM configuration is 1 chief and 0 workers with 8 CPU cores and\n",
     "1 Tesla T4 GPU."
    ]
@@ -148,11 +150,13 @@
     "In order to facilitate the proper pathways for Cloud training, we will need to\n",
     "do some first-time setup. If you're a new Google Cloud user, there are a few\n",
     "preliminary steps you will need to take:\n",
+    
     "1. Create a GCP Project;\n",
     "2. Enable AI Platform Services;\n",
     "3. Create a Service Account;\n",
     "4. Download an authorization key;\n",
     "5. Create a Cloud Storage bucket.\n",
+    
     "Detailed first-time setup instructions can be found in the\n",
     "[TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),\n",
     "and an additional setup example is shown on the\n",
@@ -399,11 +403,13 @@
     "TensorFlow Cloud is also runnable from Python notebooks. Additionally, your specified\n",
     "`entry_point` can be a notebook if needed. There are two key differences to keep\n",
     "in mind between TensorFlow Cloud on notebooks compared to scripts:\n",
+    
     "- When calling `run()` from within a notebook, a Cloud Storage bucket must be specified\n",
     "for building and storing your Docker image.\n",
     "- GCloud authentication happens entirely through your authentication key, without\n",
     "project specification. An example workflow using TensorFlow Cloud from a notebook\n",
     "is provided in the \"Putting it all together\" section of this guide.\n",
+    
     "### Multi-file projects\n",
     "If your model depends on additional files, you only need to ensure that these files\n",
     "live in the same directory (or subdirectory) of the specified entry point. Every file\n",

--- a/guides/ipynb/training_keras_models_on_cloud.ipynb
+++ b/guides/ipynb/training_keras_models_on_cloud.ipynb
@@ -112,7 +112,7 @@
     "colab_type": "text"
    },
    "source": [
-    "To train this model on Gooogle Cloud we just need to add a call to `run()` at\n",
+    "To train this model on Google Cloud we just need to add a call to `run()` at\n",
     "the beginning of the script, before the imports:\n",
     "```python\n",
     "tfc.run()\n",
@@ -148,11 +148,11 @@
     "In order to facilitate the proper pathways for Cloud training, we will need to\n",
     "do some first-time setup. If you're a new Google Cloud user, there are a few\n",
     "preliminary steps you will need to take:\n",
-    "1. Create a GCP Project\n",
-    "2. Enable AI Platform Services\n",
-    "3. Create a Service Account\n",
-    "4. Download an authorization key\n",
-    "5. Create a Cloud Storage bucket\n",
+    "1. Create a GCP Project;\n",
+    "2. Enable AI Platform Services;\n",
+    "3. Create a Service Account;\n",
+    "4. Download an authorization key;\n",
+    "5. Create a Cloud Storage bucket.\n",
     "Detailed first-time setup instructions can be found in the\n",
     "[TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),\n",
     "and an additional setup example is shown on the\n",
@@ -449,7 +449,7 @@
     "By default, TensorFlow Cloud chooses the best distribution strategy for your machine\n",
     "configuration with a simple formula using the `chief_config`, `worker_config` and\n",
     "`worker_count` parameters provided.\n",
-    "- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.\n",
+    "- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy` will be chosen.\n",
     "- If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.\n",
     "- Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen."
    ]

--- a/guides/md/training_keras_models_on_cloud.md
+++ b/guides/md/training_keras_models_on_cloud.md
@@ -83,10 +83,12 @@ and distribution strategies when using TensorFlow Cloud.
 The API includes intelligent defaults for all the parameters -- everything is
 configurable, but many models can rely on these defaults.
 Upon calling `run()`, TensorFlow Cloud will:
+
 - Make your Python script or notebook distribution-ready.
 - Convert it into a Docker image with required dependencies.
 - Run the training job on a GCP GPU-powered VM.
 - Stream relevant logs and job information.
+
 The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
 1 Tesla T4 GPU.
 
@@ -95,11 +97,13 @@ The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
 In order to facilitate the proper pathways for Cloud training, we will need to
 do some first-time setup. If you're a new Google Cloud user, there are a few
 preliminary steps you will need to take:
+
 1. Create a GCP Project;
 2. Enable AI Platform Services;
 3. Create a Service Account;
 4. Download an authorization key;
 5. Create a Cloud Storage bucket.
+
 Detailed first-time setup instructions can be found in the
 [TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),
 and an additional setup example is shown on the
@@ -251,10 +255,13 @@ handle integrating these into your cloud build.
 TensorFlow Cloud is also runnable from Python notebooks. Additionally, your specified
 `entry_point` can be a notebook if needed. There are two key differences to keep
 in mind between TensorFlow Cloud on notebooks compared to scripts:
+
 - When calling `run()` from within a notebook, a Cloud Storage bucket must be specified
 for building and storing your Docker image.
 - GCloud authentication happens entirely through your authentication key, without
-project specification. An example workflow using TensorFlow Cloud from a notebook
+project specification. 
+
+An example workflow using TensorFlow Cloud from a notebook
 is provided in the "Putting it all together" section of this guide.
 ### Multi-file projects
 If your model depends on additional files, you only need to ensure that these files
@@ -295,6 +302,7 @@ tfc.run(
 By default, TensorFlow Cloud chooses the best distribution strategy for your machine
 configuration with a simple formula using the `chief_config`, `worker_config` and
 `worker_count` parameters provided.
+
 - If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy` will be chosen.
 - If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.
 - Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen.

--- a/guides/md/training_keras_models_on_cloud.md
+++ b/guides/md/training_keras_models_on_cloud.md
@@ -295,7 +295,7 @@ tfc.run(
 By default, TensorFlow Cloud chooses the best distribution strategy for your machine
 configuration with a simple formula using the `chief_config`, `worker_config` and
 `worker_count` parameters provided.
-- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.
+- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy` will be chosen.
 - If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.
 - Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen.
 

--- a/guides/md/training_keras_models_on_cloud.md
+++ b/guides/md/training_keras_models_on_cloud.md
@@ -72,7 +72,7 @@ model.compile(
 model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)
 ```
 
-To train this model on Gooogle Cloud we just need to add a call to `run()` at
+To train this model on Google Cloud we just need to add a call to `run()` at
 the beginning of the script, before the imports:
 ```python
 tfc.run()
@@ -95,11 +95,11 @@ The default VM configuration is 1 chief and 0 workers with 8 CPU cores and
 In order to facilitate the proper pathways for Cloud training, we will need to
 do some first-time setup. If you're a new Google Cloud user, there are a few
 preliminary steps you will need to take:
-1. Create a GCP Project
-2. Enable AI Platform Services
-3. Create a Service Account
-4. Download an authorization key
-5. Create a Cloud Storage bucket
+1. Create a GCP Project;
+2. Enable AI Platform Services;
+3. Create a Service Account;
+4. Download an authorization key;
+5. Create a Cloud Storage bucket.
 Detailed first-time setup instructions can be found in the
 [TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),
 and an additional setup example is shown on the

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -105,11 +105,11 @@ In order to facilitate the proper pathways for Cloud training, we will need to
 do some first-time setup. If you're a new Google Cloud user, there are a few
 preliminary steps you will need to take:
 
-1. Create a GCP Project
-2. Enable AI Platform Services
-3. Create a Service Account
-4. Download an authorization key
-5. Create a Cloud Storage bucket
+1. Create a GCP Project;
+2. Enable AI Platform Services;
+3. Create a Service Account;
+4. Download an authorization key;
+5. Create a Cloud Storage bucket.
 
 Detailed first-time setup instructions can be found in the
 [TensorFlow Cloud README](https://github.com/tensorflowcloud#setup-instructions),

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -317,7 +317,7 @@ By default, TensorFlow Cloud chooses the best distribution strategy for your mac
 configuration with a simple formula using the `chief_config`, `worker_config` and
 `worker_count` parameters provided.
 
-- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy`will be chosen.
+- If the number of GPUs specified is greater than zero, `tf.distribute.MirroredStrategy` will be chosen.
 - If the number of workers is greater than zero, `tf.distribute.experimental.MultiWorkerMirroredStrategy` or `tf.distribute.experimental.TPUStrategy` will be chosen based on the accelerator type.
 - Otherwise, `tf.distribute.OneDeviceStrategy` will be chosen.
 """

--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -74,7 +74,7 @@ model.fit(x_train, y_train, epochs=20, batch_size=128, validation_split=0.1)
 """
 
 """
-To train this model on Gooogle Cloud we just need to add a call to `run()` at
+To train this model on Google Cloud we just need to add a call to `run()` at
 the beginning of the script, before the imports:
 ```python
 tfc.run()


### PR DESCRIPTION
There might be some manual merging necessary due to your link update, but it should be straightforward. 