### PR TITLE
Fixed a minor grammar mistake.

### DIFF
--- a/examples/nlp/text_classification_from_scratch.py
+++ b/examples/nlp/text_classification_from_scratch.py
@@ -58,7 +58,7 @@ cat aclImdb/train/pos/6248_7.txt
 """
 
 """
-We are only interest in the `pos` and `neg` subfolders, so let's delete the rest:
+We are only interested in the `pos` and `neg` subfolders, so let's delete the rest:
 """
 
 """shell


### PR DESCRIPTION
"We are only interest in the `pos` and `neg` subfolders, so let's delete the rest:" changed to "We are only interested in the `pos` and `neg` subfolders, so let's delete the rest:"