### PR TITLE
fix autogen.py make for win10.

### DIFF
--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -82,7 +82,7 @@ class KerasIO:
                     name = fname[:-3]
                     example_path = name.split("/")[-1]
                     if example_path not in preexisting:
-                        f = open(path / fname)
+                        f = open(path / fname, encoding="utf-8")
                         f.readline()
                         title_line = f.readline()
                         f.close()
@@ -554,7 +554,7 @@ class KerasIO:
                         self.site_dir, "/"
                     )
 
-                md_file = open(src_dir / fname)
+                md_file = open(src_dir / fname, encoding="utf-8")
                 md_content = md_file.read()
                 md_file.close()
                 md_content = replace_links(md_content)


### PR DESCRIPTION
On Windows 10, new conda environment with python 3.7 `python autogen.py make` gave 2 errors similar to #100 
```

File "autogen.py", line 86, in make_examples_master
    f.readline()
UnicodeDecodeError: 'cp932' codec can't decode byte 0x91 in position 7775: illegal multibyte sequence


File "autogen.py", line 558, in render_md_sources_to_html
    md_content = md_file.read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0x93 in position 5643: illegal multibyte sequence
```

Fixed by adding `encoding="utf-8"` to the file open statements. Hopefully this is useful for other contributors too.

Signed-off-by: Robert Altena <Rob@Ra-ai.com>