### PR TITLE
Avoid downloading the full dataset

### DIFF
--- a/examples/vision/retinanet.py
+++ b/examples/vision/retinanet.py
@@ -867,7 +867,8 @@ callbacks_list = [
 #  set `data_dir=None` to load the complete dataset
 
 (train_dataset, val_dataset), dataset_info = tfds.load(
-    "coco/2017", split=["train", "validation"], with_info=True, data_dir="data"
+    "coco/2017", split=["train", "validation"], download=False, 
+    with_info=True, data_dir="data"
 )
 
 """


### PR DESCRIPTION
Without "download=False", it always downloads the full dataset, which will use up the disk space on Colab.