### PR TITLE
+ para on importance of `model.call()` definition

### DIFF
--- a/guides/making_new_layers_and_models_via_subclassing.py
+++ b/guides/making_new_layers_and_models_via_subclassing.py
@@ -550,6 +550,14 @@ Effectively, the `Layer` class corresponds to what we refer to in the
 literature as a "layer" (as in "convolution layer" or "recurrent layer") or as
 a "block" (as in "ResNet block" or "Inception block").
 
+Similarly to `Layer` class, when subclassing `Model`, it is recommended to redefine
+`model.call()` function which specifies interaction of the layers. One may notice
+that in some examples, including ones provided in 
+[Keras examples section](https://keras.io/examples/) `Model` is successfully subclassed 
+without update of `model.call()` definition. However, to ensure that the subclassed model
+is robust and works with wide range of data sources it is recommended to always 
+define `model.call()` in subclassed models.
+
 Meanwhile, the `Model` class corresponds to what is referred to in the
 literature as a "model" (as in "deep learning model") or as a "network" (as in
 "deep neural network").


### PR DESCRIPTION
I noticed that in some cases subclassed models work without `model.call()` definition, however they may fail if provided with data from other types of sources/loaders. So I decided to stress importance of its use in this guide. Perhaps exact phrasing should be different, but please consider addressing this issue somehow. 

What I find confusing:
1) some combinations of sublassed models and loaders work OK. Even without `call()` the subclassed `Model` worked fine with `tf.data.Dataset.from_tensor_slices`
2) yet same models failed to work with simple python generator and with subclassed `tf.keras.utils.Sequence()`
3) some examples at TF/Keras site do not use call() when subclassing models.
 Example: [VAE tutorial ](https://keras.io/examples/generative/vae/) by respectable @fchollet - he just feeds data directly to `Model.fit()` without loaders and everything works fine without `call()`. 
4) this guide always uses `call()` in subclassed models but does not stress its importance enough.

There are quite a few confused people out there trying to replicate Keras examples and struggling with this inconsistency (see [one](https://stackoverflow.com/questions/63832318/keras-using-a-generator-for-the-data-vae), [two](https://stackoverflow.com/questions/63822281/issue-with-modifying-a-keras-class-to-include-call-function)).
Perhaps some warnings should be made in the examples / documentations, promoting consistent use of `call()`, also see if any code changes are needed to ensure consistent enforcement of `call()` use. Potentially, changes may need to be done 'under the hood' to address such inconsistent behavior of subclassed models without `call()` redefined.
See [gist with issues demonstration](https://colab.research.google.com/gist/poedator/06e66814d0d914cfe65a70bd9595c98d/tf_loader_issues_without_call.ipynb)
See discussion [here at TF github](https://github.com/tensorflow/tensorflow/issues/43173#issuecomment-691652971)