### PR TITLE
Change EfficientNetB0 to EfficientNetB1 in the final line

### DIFF
--- a/examples/vision/image_classification_efficientnet_fine_tuning.py
+++ b/examples/vision/image_classification_efficientnet_fine_tuning.py
@@ -491,7 +491,7 @@ download the checkpoint. As example, here we download noisy-student version of B
 !tar -xf noisy_student_efficientnet-b1.tar.gz
 ```
 
-Then use the script efficientnet_weight_update_util.py to convert ckpt file to h5 file.
+Then use the script [efficientnet_weight_update_util.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/efficientnet_weight_update_util.py) to convert ckpt file to h5 file.
 
 ```
 !python efficientnet_weight_update_util.py --model b1 --notop --ckpt \
@@ -501,6 +501,6 @@ Then use the script efficientnet_weight_update_util.py to convert ckpt file to h
 When creating model, use the following to load new weight:
 
 ```python
-model = EfficientNetB0(weights="efficientnetb1_notop.h5", include_top=False)
+model = EfficientNetB1(weights="efficientnetb1_notop.h5", include_top=False)
 ```
 """

--- a/examples/vision/ipynb/image_classification_efficientnet_fine_tuning.ipynb
+++ b/examples/vision/ipynb/image_classification_efficientnet_fine_tuning.ipynb
@@ -1,766 +1,733 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "image_classification_efficientnet_fine_tuning",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Image classification via fine-tuning with EfficientNet\n",
+    "\n",
+    "**Author:** [Yixing Fu](https://github.com/yixingfu)<br>\n",
+    "**Date created:** 2020/06/30<br>\n",
+    "**Last modified:** 2020/07/16<br>\n",
+    "**Description:** Use EfficientNet with weights pre-trained on imagenet for Stanford Dogs classification."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "uhDSOiAz6XNK"
-      },
-      "source": [
-        "# Image classification via fine-tuning with EfficientNet\n",
-        "\n",
-        "**Author:** [Yixing Fu](https://github.com/yixingfu)<br>\n",
-        "**Date created:** 2020/06/30<br>\n",
-        "**Last modified:** 2020/07/16<br>\n",
-        "**Description:** Use EfficientNet with weights pre-trained on imagenet for Stanford Dogs classification."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "gdhiJ7Cz6XNL"
-      },
-      "source": [
-        "## Introduction: what is EfficientNet\n",
-        "\n",
-        "EfficientNet, first introduced in [Tan and Le, 2019](https://arxiv.org/abs/1905.11946)\n",
-        "is among the most efficient models (i.e. requiring least FLOPS for inference)\n",
-        "that reaches State-of-the-Art accuracy on both\n",
-        "imagenet and common image classification transfer learning tasks.\n",
-        "\n",
-        "The smallest base model is similar to [MnasNet](https://arxiv.org/abs/1807.11626), which\n",
-        "reached near-SOTA with a significantly smaller model. By introducing a heuristic way to\n",
-        "scale the model, EfficientNet provides a family of models (B0 to B7) that represents a\n",
-        "good combination of efficiency and accuracy on a variety of scales. Such a scaling\n",
-        "heuristics (compound-scaling, details see\n",
-        "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946)) allows the\n",
-        "efficiency-oriented base model (B0) to surpass models at every scale, while avoiding\n",
-        "extensive grid-search of hyperparameters.\n",
-        "\n",
-        "A summary of the latest updates on the model is available at\n",
-        "[here](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), where various\n",
-        "augmentation schemes and semi-supervised learning approaches are applied to further\n",
-        "improve the imagenet performance of the models. These extensions of the model can be used\n",
-        "by updating weights without changing model architecture.\n",
-        "\n",
-        "## B0 to B7 variants of EfficientNet\n",
-        "\n",
-        "*(This section provides some details on \"compound scaling\", and can be skipped\n",
-        "if you're only interested in using the models)*\n",
-        "\n",
-        "Based on the [original paper](https://arxiv.org/abs/1905.11946) people may have the\n",
-        "impression that EfficientNet is a continuous family of models created by arbitrarily\n",
-        "choosing scaling factor in as Eq.(3) of the paper.  However, choice of resolution,\n",
-        "depth and width are also restricted by many factors:\n",
-        "\n",
-        "- Resolution: Resolutions not divisible by 8, 16, etc. cause zero-padding near boundaries\n",
-        "of some layers which wastes computational resources. This especially applies to smaller\n",
-        "variants of the model, hence the input resolution for B0 and B1 are chosen as 224 and\n",
-        "240.\n",
-        "\n",
-        "- Depth and width: The building blocks of EfficientNet demands channel size to be\n",
-        "multiples of 8.\n",
-        "\n",
-        "- Resource limit: Memory limitation may bottleneck resolution when depth\n",
-        "and width can still increase. In such a situation, increasing depth and/or\n",
-        "width but keep resolution can still improve performance.\n",
-        "\n",
-        "As a result, the depth, width and resolution of each variant of the EfficientNet models\n",
-        "are hand-picked and proven to produce good results, though they may be significantly\n",
-        "off from the compound scaling formula.\n",
-        "Therefore, the keras implementation (detailed below) only provide these 8 models, B0 to B7,\n",
-        "instead of allowing arbitray choice of width / depth / resolution parameters.\n",
-        "\n",
-        "## Keras implementation of EfficientNet\n",
-        "\n",
-        "An implementation of EfficientNet B0 to B7 has been shipped with tf.keras since TF2.3. To\n",
-        "use EfficientNetB0 for classifying 1000 classes of images from imagenet, run:\n",
-        "\n",
-        "```python\n",
-        "from tensorflow.keras.applications import EfficientNetB0\n",
-        "model = EfficientNetB0(weights='imagenet')\n",
-        "```\n",
-        "\n",
-        "This model takes input images of shape (224, 224, 3), and the input data should range\n",
-        "[0, 255]. Normalization is included as part of the model.\n",
-        "\n",
-        "Because training EfficientNet on ImageNet takes a tremendous amount of resources and\n",
-        "several techniques that are not a part of the model architecture itself. Hence the Keras\n",
-        "implementation by default loads pre-trained weights obtained via training with\n",
-        "[AutoAugment](https://arxiv.org/abs/1805.09501).\n",
-        "\n",
-        "For B0 to B7 base models, the input shapes are different. Here is a list of input shape\n",
-        "expected for each model:\n",
-        "\n",
-        "| Base model | resolution|\n",
-        "|----------------|-----|\n",
-        "| EfficientNetB0 | 224 |\n",
-        "| EfficientNetB1 | 240 |\n",
-        "| EfficientNetB2 | 260 |\n",
-        "| EfficientNetB3 | 300 |\n",
-        "| EfficientNetB4 | 380 |\n",
-        "| EfficientNetB5 | 456 |\n",
-        "| EfficientNetB6 | 528 |\n",
-        "| EfficientNetB7 | 600 |\n",
-        "\n",
-        "When the model is intended for transfer learning, the Keras implementation\n",
-        "provides a option to remove the top layers:\n",
-        "```\n",
-        "model = EfficientNetB0(include_top=False, weights='imagenet')\n",
-        "```\n",
-        "This option excludes the final `Dense` layer that turns 1280 features on the penultimate\n",
-        "layer into prediction of the 1000 ImageNet classes. Replacing the top layer with custom\n",
-        "layers allows using EfficientNet as a feature extractor in a transfer learning workflow.\n",
-        "\n",
-        "Another argument in the model constructor worth noticing is `drop_connect_rate` which controls\n",
-        "the dropout rate responsible for [stochastic depth](https://arxiv.org/abs/1603.09382).\n",
-        "This parameter serves as a toggle for extra regularization in finetuning, but does not\n",
-        "affect loaded weights. For example, when stronger regularization is desired, try:\n",
-        "\n",
-        "```python\n",
-        "model = EfficientNetB0(weights='imagenet', drop_connect_rate=0.4)\n",
-        "```\n",
-        "The default value is 0.2.\n",
-        "\n",
-        "## Example: EfficientNetB0 for Stanford Dogs.\n",
-        "\n",
-        "EfficientNet is capable of a wide range of image classification tasks.\n",
-        "This makes it a good model for transfer learning.\n",
-        "As an end-to-end example, we will show using pre-trained EfficientNetB0 on\n",
-        "[Stanford Dogs](http://vision.stanford.edu/aditya86/ImageNetDogs/main.html) dataset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "xDaDenvn6XNM",
-        "colab": {}
-      },
-      "source": [
-        "# IMG_SIZE is determined by EfficientNet model choice\n",
-        "IMG_SIZE = 224"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ayahLyrr6XNR"
-      },
-      "source": [
-        "## Setup and data loading\n",
-        "\n",
-        "This example requires TensorFlow 2.3 or above.\n",
-        "\n",
-        "To use TPU, the TPU runtime must match current running TensorFlow\n",
-        "version. If there is a mismatch, try:\n",
-        "\n",
-        "```python\n",
-        "from cloud_tpu_client import Client\n",
-        "c = Client()\n",
-        "c.configure_tpu_version(tf.__version__, restart_type=\"always\")\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "Wp5hiU2d6XNR",
-        "colab": {}
-      },
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "try:\n",
-        "    tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection\n",
-        "    print(\"Running on TPU \", tpu.cluster_spec().as_dict()[\"worker\"])\n",
-        "    tf.config.experimental_connect_to_cluster(tpu)\n",
-        "    tf.tpu.experimental.initialize_tpu_system(tpu)\n",
-        "    strategy = tf.distribute.experimental.TPUStrategy(tpu)\n",
-        "except ValueError:\n",
-        "    print(\"Not connected to a TPU runtime. Using CPU/GPU strategy\")\n",
-        "    strategy = tf.distribute.MirroredStrategy()\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "oYVEoTQw6XNU"
-      },
-      "source": [
-        "### Loading data\n",
-        "\n",
-        "Here we load data from [tensorflow_datasets](https://www.tensorflow.org/datasets)\n",
-        "(hereafter TFDS).\n",
-        "Stanford Dogs dataset is provided in\n",
-        "TFDS as [stanford_dogs](https://www.tensorflow.org/datasets/catalog/stanford_dogs).\n",
-        "It features 20,580 images that belong to 120 classes of dog breeds\n",
-        "(12,000 for training and 8,580 for testing).\n",
-        "\n",
-        "By simply changing `dataset_name` below, you may also try this notebook for\n",
-        "other datasets in TFDS such as\n",
-        "[cifar10](https://www.tensorflow.org/datasets/catalog/cifar10),\n",
-        "[cifar100](https://www.tensorflow.org/datasets/catalog/cifar100),\n",
-        "[food101](https://www.tensorflow.org/datasets/catalog/food101),\n",
-        "etc. When the images are much smaller than the size of EfficientNet input,\n",
-        "we can simply upsample the input images. It has been shown in\n",
-        "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946) that transfer learning\n",
-        "result is better for increased resolution even if input images remain small.\n",
-        "\n",
-        "For TPU: if using TFDS datasets,\n",
-        "a [GCS bucket](https://cloud.google.com/storage/docs/key-terms#buckets)\n",
-        "location is required to save the datasets. For example:\n",
-        "\n",
-        "```python\n",
-        "tfds.load(dataset_name, data_dir=\"gs://example-bucket/datapath\")\n",
-        "```\n",
-        "\n",
-        "Also, both the current environment and the TPU service account have\n",
-        "proper [access](https://cloud.google.com/tpu/docs/storage-buckets#authorize_the_service_account)\n",
-        "to the bucket. Alternatively, for small datasets you may try loading data\n",
-        "into the memory and use `tf.data.Dataset.from_tensor_slices()`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "tHwO62kr6XNV",
-        "colab": {}
-      },
-      "source": [
-        "import tensorflow_datasets as tfds\n",
-        "\n",
-        "batch_size = 64\n",
-        "\n",
-        "dataset_name = \"stanford_dogs\"\n",
-        "(ds_train, ds_test), ds_info = tfds.load(\n",
-        "    dataset_name, split=[\"train\", \"test\"], with_info=True, as_supervised=True\n",
-        ")\n",
-        "NUM_CLASSES = ds_info.features[\"label\"].num_classes\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "8EZo6pZv6XNY"
-      },
-      "source": [
-        "When the dataset include images with various size, we need to resize them into a\n",
-        "shared size. The Stanford Dogs dataset includes only images at least 200x200\n",
-        "pixels in size. Here we resize the images to the input size needed for EfficientNet."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "-IGjHUEU6XNZ",
-        "colab": {}
-      },
-      "source": [
-        "size = (IMG_SIZE, IMG_SIZE)\n",
-        "ds_train = ds_train.map(lambda image, label: (tf.image.resize(image, size), label))\n",
-        "ds_test = ds_test.map(lambda image, label: (tf.image.resize(image, size), label))"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "APtEC9ch6XNb"
-      },
-      "source": [
-        "### Visualizing the data\n",
-        "\n",
-        "The following code shows the first 9 images with their labels."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "TKUH-Uvx6XNc",
-        "colab": {}
-      },
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "\n",
-        "def format_label(label):\n",
-        "    string_label = label_info.int2str(label)\n",
-        "    return string_label.split(\"-\")[1]\n",
-        "\n",
-        "\n",
-        "label_info = ds_info.features[\"label\"]\n",
-        "for i, (image, label) in enumerate(ds_train.take(9)):\n",
-        "    ax = plt.subplot(3, 3, i + 1)\n",
-        "    plt.imshow(image.numpy().astype(\"uint8\"))\n",
-        "    plt.title(\"{}\".format(format_label(label)))\n",
-        "    plt.axis(\"off\")\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "miHK6as56XNf"
-      },
-      "source": [
-        "### Data augmentation\n",
-        "\n",
-        "We can use preprocessing layers APIs for image augmentation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "H-_3Jwc86XNf",
-        "colab": {}
-      },
-      "source": [
-        "from tensorflow.keras.layers.experimental import preprocessing\n",
-        "from tensorflow.keras.models import Sequential\n",
-        "from tensorflow.keras import layers\n",
-        "\n",
-        "img_augmentation = Sequential(\n",
-        "    [\n",
-        "        preprocessing.RandomRotation(factor=0.15),\n",
-        "        preprocessing.RandomTranslation(height_factor=0.1, width_factor=0.1),\n",
-        "        preprocessing.RandomFlip(),\n",
-        "        preprocessing.RandomContrast(factor=0.1),\n",
-        "    ],\n",
-        "    name=\"img_augmentation\",\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "HKDK6ZDQ6XNk"
-      },
-      "source": [
-        "This `Sequential` model object can be used both as a part of\n",
-        "the model we later build, and as a function to preprocess\n",
-        "data before feeding into the model. Using them as function makes\n",
-        "it easy to visualize the augmented images. Here we plot 9 examples\n",
-        "of augmentation result of a given figure."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "XKv5HnFH6XNk",
-        "colab": {}
-      },
-      "source": [
-        "for image, label in ds_train.take(1):\n",
-        "    for i in range(9):\n",
-        "        ax = plt.subplot(3, 3, i + 1)\n",
-        "        aug_img = img_augmentation(tf.expand_dims(image, axis=0))\n",
-        "        plt.imshow(aug_img[0].numpy().astype(\"uint8\"))\n",
-        "        plt.title(\"{}\".format(format_label(label)))\n",
-        "        plt.axis(\"off\")\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "HAlPMmv26XNo"
-      },
-      "source": [
-        "### Prepare inputs\n",
-        "\n",
-        "Once we verify the input data and augmentation are working correctly,\n",
-        "we prepare dataset for training. The input data are resized to uniform\n",
-        "`IMG_SIZE`. The labels are put into one-hot\n",
-        "(a.k.a. categorical) encoding. The dataset is batched.\n",
-        "\n",
-        "Note: `prefetch` and `AUTOTUNE` may in some situation improve\n",
-        "performance, but depends on environment and the specific dataset used.\n",
-        "See this [guide](https://www.tensorflow.org/guide/data_performance)\n",
-        "for more information on data pipeline performance."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "en03mckm6XNo",
-        "colab": {}
-      },
-      "source": [
-        "# One-hot / categorical encoding\n",
-        "def input_preprocess(image, label):\n",
-        "    label = tf.one_hot(label, NUM_CLASSES)\n",
-        "    return image, label\n",
-        "\n",
-        "\n",
-        "ds_train = ds_train.map(\n",
-        "    input_preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE\n",
-        ")\n",
-        "ds_train = ds_train.batch(batch_size=batch_size, drop_remainder=True)\n",
-        "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)\n",
-        "\n",
-        "ds_test = ds_test.map(input_preprocess)\n",
-        "ds_test = ds_test.batch(batch_size=batch_size, drop_remainder=True)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "DLBMqMFf6XNr"
-      },
-      "source": [
-        "## Training a model from scratch\n",
-        "\n",
-        "We build an EfficientNetB0 with 120 output classes, that is initialized from scratch:\n",
-        "\n",
-        "Note: the accuracy will increase very slowly and may overfit."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "XrmmaUL36XNs",
-        "colab": {}
-      },
-      "source": [
-        "from tensorflow.keras.applications import EfficientNetB0\n",
-        "\n",
-        "with strategy.scope():\n",
-        "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
-        "    x = img_augmentation(inputs)\n",
-        "    outputs = EfficientNetB0(include_top=True, weights=None, classes=NUM_CLASSES)(x)\n",
-        "\n",
-        "    model = tf.keras.Model(inputs, outputs)\n",
-        "    model.compile(\n",
-        "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-        "    )\n",
-        "\n",
-        "model.summary()\n",
-        "\n",
-        "epochs = 40  # @param {type: \"slider\", min:10, max:100}\n",
-        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "77GHLr_n6XNv"
-      },
-      "source": [
-        "Training the model is relatively fast (takes only 20 seconds per epoch on TPUv2 that is\n",
-        "available on Colab). This might make it sounds easy to simply train EfficientNet on any\n",
-        "dataset wanted from scratch. However, training EfficientNet on smaller datasets,\n",
-        "especially those with lower resolution like CIFAR-100, faces the significant challenge of\n",
-        "overfitting.\n",
-        "\n",
-        "Hence training from scratch requires very careful choice of hyperparameters and is\n",
-        "difficult to find suitable regularization. It would also be much more demanding in resources.\n",
-        "Plotting the training and validation accuracy\n",
-        "makes it clear that validation accuracy stagnates at a low value."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "dgnJVHA06XNv",
-        "colab": {}
-      },
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "\n",
-        "def plot_hist(hist):\n",
-        "    plt.plot(hist.history[\"accuracy\"])\n",
-        "    plt.plot(hist.history[\"val_accuracy\"])\n",
-        "    plt.title(\"model accuracy\")\n",
-        "    plt.ylabel(\"accuracy\")\n",
-        "    plt.xlabel(\"epoch\")\n",
-        "    plt.legend([\"train\", \"validation\"], loc=\"upper left\")\n",
-        "    plt.show()\n",
-        "\n",
-        "\n",
-        "plot_hist(hist)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "u0jKQzbc6XNy"
-      },
-      "source": [
-        "## Transfer learning from pre-trained weights\n",
-        "\n",
-        "Here we initialize the model with pre-trained ImageNet weights,\n",
-        "and we fine-tune it on our own dataset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "5mXgnyOb6XNz",
-        "colab": {}
-      },
-      "source": [
-        "from tensorflow.keras.layers.experimental import preprocessing\n",
-        "\n",
-        "\n",
-        "def build_model(num_classes):\n",
-        "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
-        "    x = img_augmentation(inputs)\n",
-        "    model = EfficientNetB0(include_top=False, input_tensor=x, weights=\"imagenet\")\n",
-        "\n",
-        "    # Freeze the pretrained weights\n",
-        "    model.trainable = False\n",
-        "\n",
-        "    # Rebuild top\n",
-        "    x = layers.GlobalAveragePooling2D(name=\"avg_pool\")(model.output)\n",
-        "    x = layers.BatchNormalization()(x)\n",
-        "\n",
-        "    top_dropout_rate = 0.2\n",
-        "    x = layers.Dropout(top_dropout_rate, name=\"top_dropout\")(x)\n",
-        "    outputs = layers.Dense(NUM_CLASSES, activation=\"softmax\", name=\"pred\")(x)\n",
-        "\n",
-        "    # Compile\n",
-        "    model = tf.keras.Model(inputs, outputs, name=\"EfficientNet\")\n",
-        "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-2)\n",
-        "    model.compile(\n",
-        "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-        "    )\n",
-        "    return model\n"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "aFdcpU826XN2"
-      },
-      "source": [
-        "The first step to transfer learning is to freeze all layers and train only the top\n",
-        "layers. For this step, a relatively large learning rate (1e-2) can be used.\n",
-        "Note that validation accuracy and loss will usually be better than training\n",
-        "accuracy and loss. This is because the regularization is strong, which only\n",
-        "suppresses training-time metrics.\n",
-        "\n",
-        "Note that the convergence may take up to 50 epochs depending on choice of learning rate.\n",
-        "If image augmentation layers were not\n",
-        "applied, the validation accuracy may only reach ~60%."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "MjiTeKht6XN2",
-        "colab": {}
-      },
-      "source": [
-        "with strategy.scope():\n",
-        "    model = build_model(num_classes=NUM_CLASSES)\n",
-        "\n",
-        "epochs = 25  # @param {type: \"slider\", min:8, max:80}\n",
-        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
-        "plot_hist(hist)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "e_521nOR6XN7"
-      },
-      "source": [
-        "The second step is to unfreeze a number of layers and fit the model using smaller\n",
-        "learning rate. In this example we show unfreezing all layers, but depending on\n",
-        "specific dataset it may be desireble to only unfreeze a fraction of all layers.\n",
-        "\n",
-        "When the feature extraction with\n",
-        "pretrained model works good enough, this step would give a very limited gain on\n",
-        "validation accuracy. In our case we only see a small improvement,\n",
-        "as ImageNet pretraining already exposed the model to a good amount of dogs.\n",
-        "\n",
-        "On the other hand, when we use pretrained weights on a dataset that is more different\n",
-        "from ImageNet, this fine-tuning step can be crucial as the feature extractor also\n",
-        "needs to be adjusted by a considerable amount. Such a situation can be demonstrated\n",
-        "if choosing CIFAR-100 dataset instead, where fine-tuning boosts validation accuracy\n",
-        "by about 10% to pass 80% on `EfficientNetB0`.\n",
-        "In such a case the convergence may take more than 50 epochs.\n",
-        "\n",
-        "A side note on freezing/unfreezing models: setting `trainable` of a `Model` will\n",
-        "simultaneously set all layers belonging to the `Model` to the same `trainable`\n",
-        "attribute. Each layer is trainable only if both the layer itself and the model\n",
-        "containing it are trainable. Hence when we need to partially freeze/unfreeze\n",
-        "a model, we need to make sure the `trainable` attribute of the model is set\n",
-        "to `True`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "EIkSxkXP6XN8",
-        "colab": {}
-      },
-      "source": [
-        "\n",
-        "def unfreeze_model(model):\n",
-        "    # We unfreeze the top 20 layers while leaving BatchNorm layers frozen\n",
-        "    for layer in model.layers[-20:]:\n",
-        "        if not isinstance(layer, layers.BatchNormalization):\n",
-        "            layer.trainable = True\n",
-        "\n",
-        "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-4)\n",
-        "    model.compile(\n",
-        "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "unfreeze_model(model)\n",
-        "\n",
-        "epochs = 10  # @param {type: \"slider\", min:8, max:50}\n",
-        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
-        "plot_hist(hist)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "wt4CoBb86XN_"
-      },
-      "source": [
-        "### Tips for fine tuning EfficientNet\n",
-        "\n",
-        "On unfreezing layers:\n",
-        "\n",
-        "- The `BathcNormalization` layers need to be kept frozen\n",
-        "([more details](https://keras.io/guides/transfer_learning/)).\n",
-        "If they are also turned to trainable, the\n",
-        "first epoch after unfreezing will significantly reduce accuracy.\n",
-        "- In some cases it may be beneficial to open up only a portion of layers instead of\n",
-        "unfreezing all. This will make fine tuning much faster when going to larger models like\n",
-        "B7.\n",
-        "- Each block needs to be all turned on or off. This is because the architecture includes\n",
-        "a shortcut from the first layer to the last layer for each block. Not respecting blocks\n",
-        "also significantly harms the final performance.\n",
-        "\n",
-        "Some other tips for utilizing EfficientNet:\n",
-        "\n",
-        "- Larger variants of EfficientNet do not guarantee improved performance, especially for\n",
-        "tasks with less data or fewer classes. In such a case, the larger variant of EfficientNet\n",
-        "chosen, the harder it is to tune hyperparameters.\n",
-        "- EMA (Exponential Moving Average) is very helpful in training EfficientNet from scratch,\n",
-        "but not so much for transfer learning.\n",
-        "- Do not use the RMSprop setup as in the original paper for transfer learning. The\n",
-        "momentum and learning rate are too high for transfer learning. It will easily corrupt the\n",
-        "pretrained weight and blow up the loss. A quick check is to see if loss (as categorical\n",
-        "cross entropy) is getting significantly larger than log(NUM_CLASSES) after the same\n",
-        "epoch. If so, the initial learning rate/momentum is too high.\n",
-        "- Smaller batch size benefit validation accuracy, possibly due to effectively providing\n",
-        "regularization.\n",
-        "\n",
-        "## Using the latest EfficientNet weights\n",
-        "\n",
-        "Since the initial paper, the EfficientNet has been improved by various methods for data\n",
-        "preprocessing and for using unlabelled data to enhance learning results. These\n",
-        "improvements are relatively hard and computationally costly to reproduce, and require\n",
-        "extra code; but the weights are readily available in the form of TF checkpoint files. The\n",
-        "model architecture has not changed, so loading the improved checkpoints is possible.\n",
-        "\n",
-        "To use a checkpoint provided at\n",
-        "[the official model repository](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), first\n",
-        "download the checkpoint. As example, here we download noisy-student version of B1:\n",
-        "\n",
-        "```\n",
-        "!wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet\\\n",
-        "       /noisystudent/noisy_student_efficientnet-b1.tar.gz\n",
-        "!tar -xf noisy_student_efficientnet-b1.tar.gz\n",
-        "```\n",
-        "\n",
-        "Then use the script [efficientnet_weight_update_util.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/efficientnet_weight_update_util.py) to convert ckpt file to h5 file.\n",
-        "\n",
-        "```\n",
-        "!python efficientnet_weight_update_util.py --model b1 --notop --ckpt \\\n",
-        "        efficientnet-b1/model.ckpt --o efficientnetb1_notop.h5\n",
-        "```\n",
-        "\n",
-        "When creating model, use the following to load new weight:\n",
-        "\n",
-        "```python\n",
-        "model = EfficientNetB1(weights=\"efficientnetb1_notop.h5\", include_top=False)\n",
-        "```"
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction: what is EfficientNet\n",
+    "\n",
+    "EfficientNet, first introduced in [Tan and Le, 2019](https://arxiv.org/abs/1905.11946)\n",
+    "is among the most efficient models (i.e. requiring least FLOPS for inference)\n",
+    "that reaches State-of-the-Art accuracy on both\n",
+    "imagenet and common image classification transfer learning tasks.\n",
+    "\n",
+    "The smallest base model is similar to [MnasNet](https://arxiv.org/abs/1807.11626), which\n",
+    "reached near-SOTA with a significantly smaller model. By introducing a heuristic way to\n",
+    "scale the model, EfficientNet provides a family of models (B0 to B7) that represents a\n",
+    "good combination of efficiency and accuracy on a variety of scales. Such a scaling\n",
+    "heuristics (compound-scaling, details see\n",
+    "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946)) allows the\n",
+    "efficiency-oriented base model (B0) to surpass models at every scale, while avoiding\n",
+    "extensive grid-search of hyperparameters.\n",
+    "\n",
+    "A summary of the latest updates on the model is available at\n",
+    "[here](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), where various\n",
+    "augmentation schemes and semi-supervised learning approaches are applied to further\n",
+    "improve the imagenet performance of the models. These extensions of the model can be used\n",
+    "by updating weights without changing model architecture.\n",
+    "\n",
+    "## B0 to B7 variants of EfficientNet\n",
+    "\n",
+    "*(This section provides some details on \"compound scaling\", and can be skipped\n",
+    "if you're only interested in using the models)*\n",
+    "\n",
+    "Based on the [original paper](https://arxiv.org/abs/1905.11946) people may have the\n",
+    "impression that EfficientNet is a continuous family of models created by arbitrarily\n",
+    "choosing scaling factor in as Eq.(3) of the paper.  However, choice of resolution,\n",
+    "depth and width are also restricted by many factors:\n",
+    "\n",
+    "- Resolution: Resolutions not divisible by 8, 16, etc. cause zero-padding near boundaries\n",
+    "of some layers which wastes computational resources. This especially applies to smaller\n",
+    "variants of the model, hence the input resolution for B0 and B1 are chosen as 224 and\n",
+    "240.\n",
+    "\n",
+    "- Depth and width: The building blocks of EfficientNet demands channel size to be\n",
+    "multiples of 8.\n",
+    "\n",
+    "- Resource limit: Memory limitation may bottleneck resolution when depth\n",
+    "and width can still increase. In such a situation, increasing depth and/or\n",
+    "width but keep resolution can still improve performance.\n",
+    "\n",
+    "As a result, the depth, width and resolution of each variant of the EfficientNet models\n",
+    "are hand-picked and proven to produce good results, though they may be significantly\n",
+    "off from the compound scaling formula.\n",
+    "Therefore, the keras implementation (detailed below) only provide these 8 models, B0 to B7,\n",
+    "instead of allowing arbitray choice of width / depth / resolution parameters.\n",
+    "\n",
+    "## Keras implementation of EfficientNet\n",
+    "\n",
+    "An implementation of EfficientNet B0 to B7 has been shipped with tf.keras since TF2.3. To\n",
+    "use EfficientNetB0 for classifying 1000 classes of images from imagenet, run:\n",
+    "\n",
+    "```python\n",
+    "from tensorflow.keras.applications import EfficientNetB0\n",
+    "model = EfficientNetB0(weights='imagenet')\n",
+    "```\n",
+    "\n",
+    "This model takes input images of shape (224, 224, 3), and the input data should range\n",
+    "[0, 255]. Normalization is included as part of the model.\n",
+    "\n",
+    "Because training EfficientNet on ImageNet takes a tremendous amount of resources and\n",
+    "several techniques that are not a part of the model architecture itself. Hence the Keras\n",
+    "implementation by default loads pre-trained weights obtained via training with\n",
+    "[AutoAugment](https://arxiv.org/abs/1805.09501).\n",
+    "\n",
+    "For B0 to B7 base models, the input shapes are different. Here is a list of input shape\n",
+    "expected for each model:\n",
+    "\n",
+    "| Base model | resolution|\n",
+    "|----------------|-----|\n",
+    "| EfficientNetB0 | 224 |\n",
+    "| EfficientNetB1 | 240 |\n",
+    "| EfficientNetB2 | 260 |\n",
+    "| EfficientNetB3 | 300 |\n",
+    "| EfficientNetB4 | 380 |\n",
+    "| EfficientNetB5 | 456 |\n",
+    "| EfficientNetB6 | 528 |\n",
+    "| EfficientNetB7 | 600 |\n",
+    "\n",
+    "When the model is intended for transfer learning, the Keras implementation\n",
+    "provides a option to remove the top layers:\n",
+    "```\n",
+    "model = EfficientNetB0(include_top=False, weights='imagenet')\n",
+    "```\n",
+    "This option excludes the final `Dense` layer that turns 1280 features on the penultimate\n",
+    "layer into prediction of the 1000 ImageNet classes. Replacing the top layer with custom\n",
+    "layers allows using EfficientNet as a feature extractor in a transfer learning workflow.\n",
+    "\n",
+    "Another argument in the model constructor worth noticing is `drop_connect_rate` which controls\n",
+    "the dropout rate responsible for [stochastic depth](https://arxiv.org/abs/1603.09382).\n",
+    "This parameter serves as a toggle for extra regularization in finetuning, but does not\n",
+    "affect loaded weights. For example, when stronger regularization is desired, try:\n",
+    "\n",
+    "```python\n",
+    "model = EfficientNetB0(weights='imagenet', drop_connect_rate=0.4)\n",
+    "```\n",
+    "The default value is 0.2.\n",
+    "\n",
+    "## Example: EfficientNetB0 for Stanford Dogs.\n",
+    "\n",
+    "EfficientNet is capable of a wide range of image classification tasks.\n",
+    "This makes it a good model for transfer learning.\n",
+    "As an end-to-end example, we will show using pre-trained EfficientNetB0 on\n",
+    "[Stanford Dogs](http://vision.stanford.edu/aditya86/ImageNetDogs/main.html) dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# IMG_SIZE is determined by EfficientNet model choice\n",
+    "IMG_SIZE = 224"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Setup and data loading\n",
+    "\n",
+    "This example requires TensorFlow 2.3 or above.\n",
+    "\n",
+    "To use TPU, the TPU runtime must match current running TensorFlow\n",
+    "version. If there is a mismatch, try:\n",
+    "\n",
+    "```python\n",
+    "from cloud_tpu_client import Client\n",
+    "c = Client()\n",
+    "c.configure_tpu_version(tf.__version__, restart_type=\"always\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "try:\n",
+    "    tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection\n",
+    "    print(\"Running on TPU \", tpu.cluster_spec().as_dict()[\"worker\"])\n",
+    "    tf.config.experimental_connect_to_cluster(tpu)\n",
+    "    tf.tpu.experimental.initialize_tpu_system(tpu)\n",
+    "    strategy = tf.distribute.experimental.TPUStrategy(tpu)\n",
+    "except ValueError:\n",
+    "    print(\"Not connected to a TPU runtime. Using CPU/GPU strategy\")\n",
+    "    strategy = tf.distribute.MirroredStrategy()\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Loading data\n",
+    "\n",
+    "Here we load data from [tensorflow_datasets](https://www.tensorflow.org/datasets)\n",
+    "(hereafter TFDS).\n",
+    "Stanford Dogs dataset is provided in\n",
+    "TFDS as [stanford_dogs](https://www.tensorflow.org/datasets/catalog/stanford_dogs).\n",
+    "It features 20,580 images that belong to 120 classes of dog breeds\n",
+    "(12,000 for training and 8,580 for testing).\n",
+    "\n",
+    "By simply changing `dataset_name` below, you may also try this notebook for\n",
+    "other datasets in TFDS such as\n",
+    "[cifar10](https://www.tensorflow.org/datasets/catalog/cifar10),\n",
+    "[cifar100](https://www.tensorflow.org/datasets/catalog/cifar100),\n",
+    "[food101](https://www.tensorflow.org/datasets/catalog/food101),\n",
+    "etc. When the images are much smaller than the size of EfficientNet input,\n",
+    "we can simply upsample the input images. It has been shown in\n",
+    "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946) that transfer learning\n",
+    "result is better for increased resolution even if input images remain small.\n",
+    "\n",
+    "For TPU: if using TFDS datasets,\n",
+    "a [GCS bucket](https://cloud.google.com/storage/docs/key-terms#buckets)\n",
+    "location is required to save the datasets. For example:\n",
+    "\n",
+    "```python\n",
+    "tfds.load(dataset_name, data_dir=\"gs://example-bucket/datapath\")\n",
+    "```\n",
+    "\n",
+    "Also, both the current environment and the TPU service account have\n",
+    "proper [access](https://cloud.google.com/tpu/docs/storage-buckets#authorize_the_service_account)\n",
+    "to the bucket. Alternatively, for small datasets you may try loading data\n",
+    "into the memory and use `tf.data.Dataset.from_tensor_slices()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow_datasets as tfds\n",
+    "\n",
+    "batch_size = 64\n",
+    "\n",
+    "dataset_name = \"stanford_dogs\"\n",
+    "(ds_train, ds_test), ds_info = tfds.load(\n",
+    "    dataset_name, split=[\"train\", \"test\"], with_info=True, as_supervised=True\n",
+    ")\n",
+    "NUM_CLASSES = ds_info.features[\"label\"].num_classes\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "When the dataset include images with various size, we need to resize them into a\n",
+    "shared size. The Stanford Dogs dataset includes only images at least 200x200\n",
+    "pixels in size. Here we resize the images to the input size needed for EfficientNet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "size = (IMG_SIZE, IMG_SIZE)\n",
+    "ds_train = ds_train.map(lambda image, label: (tf.image.resize(image, size), label))\n",
+    "ds_test = ds_test.map(lambda image, label: (tf.image.resize(image, size), label))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Visualizing the data\n",
+    "\n",
+    "The following code shows the first 9 images with their labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "def format_label(label):\n",
+    "    string_label = label_info.int2str(label)\n",
+    "    return string_label.split(\"-\")[1]\n",
+    "\n",
+    "\n",
+    "label_info = ds_info.features[\"label\"]\n",
+    "for i, (image, label) in enumerate(ds_train.take(9)):\n",
+    "    ax = plt.subplot(3, 3, i + 1)\n",
+    "    plt.imshow(image.numpy().astype(\"uint8\"))\n",
+    "    plt.title(\"{}\".format(format_label(label)))\n",
+    "    plt.axis(\"off\")\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Data augmentation\n",
+    "\n",
+    "We can use preprocessing layers APIs for image augmentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow.keras.layers.experimental import preprocessing\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras import layers\n",
+    "\n",
+    "img_augmentation = Sequential(\n",
+    "    [\n",
+    "        preprocessing.RandomRotation(factor=0.15),\n",
+    "        preprocessing.RandomTranslation(height_factor=0.1, width_factor=0.1),\n",
+    "        preprocessing.RandomFlip(),\n",
+    "        preprocessing.RandomContrast(factor=0.1),\n",
+    "    ],\n",
+    "    name=\"img_augmentation\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "This `Sequential` model object can be used both as a part of\n",
+    "the model we later build, and as a function to preprocess\n",
+    "data before feeding into the model. Using them as function makes\n",
+    "it easy to visualize the augmented images. Here we plot 9 examples\n",
+    "of augmentation result of a given figure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "for image, label in ds_train.take(1):\n",
+    "    for i in range(9):\n",
+    "        ax = plt.subplot(3, 3, i + 1)\n",
+    "        aug_img = img_augmentation(tf.expand_dims(image, axis=0))\n",
+    "        plt.imshow(aug_img[0].numpy().astype(\"uint8\"))\n",
+    "        plt.title(\"{}\".format(format_label(label)))\n",
+    "        plt.axis(\"off\")\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Prepare inputs\n",
+    "\n",
+    "Once we verify the input data and augmentation are working correctly,\n",
+    "we prepare dataset for training. The input data are resized to uniform\n",
+    "`IMG_SIZE`. The labels are put into one-hot\n",
+    "(a.k.a. categorical) encoding. The dataset is batched.\n",
+    "\n",
+    "Note: `prefetch` and `AUTOTUNE` may in some situation improve\n",
+    "performance, but depends on environment and the specific dataset used.\n",
+    "See this [guide](https://www.tensorflow.org/guide/data_performance)\n",
+    "for more information on data pipeline performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# One-hot / categorical encoding\n",
+    "def input_preprocess(image, label):\n",
+    "    label = tf.one_hot(label, NUM_CLASSES)\n",
+    "    return image, label\n",
+    "\n",
+    "\n",
+    "ds_train = ds_train.map(\n",
+    "    input_preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE\n",
+    ")\n",
+    "ds_train = ds_train.batch(batch_size=batch_size, drop_remainder=True)\n",
+    "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)\n",
+    "\n",
+    "ds_test = ds_test.map(input_preprocess)\n",
+    "ds_test = ds_test.batch(batch_size=batch_size, drop_remainder=True)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Training a model from scratch\n",
+    "\n",
+    "We build an EfficientNetB0 with 120 output classes, that is initialized from scratch:\n",
+    "\n",
+    "Note: the accuracy will increase very slowly and may overfit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow.keras.applications import EfficientNetB0\n",
+    "\n",
+    "with strategy.scope():\n",
+    "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
+    "    x = img_augmentation(inputs)\n",
+    "    outputs = EfficientNetB0(include_top=True, weights=None, classes=NUM_CLASSES)(x)\n",
+    "\n",
+    "    model = tf.keras.Model(inputs, outputs)\n",
+    "    model.compile(\n",
+    "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+    "    )\n",
+    "\n",
+    "model.summary()\n",
+    "\n",
+    "epochs = 40  # @param {type: \"slider\", min:10, max:100}\n",
+    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Training the model is relatively fast (takes only 20 seconds per epoch on TPUv2 that is\n",
+    "available on Colab). This might make it sounds easy to simply train EfficientNet on any\n",
+    "dataset wanted from scratch. However, training EfficientNet on smaller datasets,\n",
+    "especially those with lower resolution like CIFAR-100, faces the significant challenge of\n",
+    "overfitting.\n",
+    "\n",
+    "Hence training from scratch requires very careful choice of hyperparameters and is\n",
+    "difficult to find suitable regularization. It would also be much more demanding in resources.\n",
+    "Plotting the training and validation accuracy\n",
+    "makes it clear that validation accuracy stagnates at a low value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "def plot_hist(hist):\n",
+    "    plt.plot(hist.history[\"accuracy\"])\n",
+    "    plt.plot(hist.history[\"val_accuracy\"])\n",
+    "    plt.title(\"model accuracy\")\n",
+    "    plt.ylabel(\"accuracy\")\n",
+    "    plt.xlabel(\"epoch\")\n",
+    "    plt.legend([\"train\", \"validation\"], loc=\"upper left\")\n",
+    "    plt.show()\n",
+    "\n",
+    "\n",
+    "plot_hist(hist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Transfer learning from pre-trained weights\n",
+    "\n",
+    "Here we initialize the model with pre-trained ImageNet weights,\n",
+    "and we fine-tune it on our own dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow.keras.layers.experimental import preprocessing\n",
+    "\n",
+    "\n",
+    "def build_model(num_classes):\n",
+    "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
+    "    x = img_augmentation(inputs)\n",
+    "    model = EfficientNetB0(include_top=False, input_tensor=x, weights=\"imagenet\")\n",
+    "\n",
+    "    # Freeze the pretrained weights\n",
+    "    model.trainable = False\n",
+    "\n",
+    "    # Rebuild top\n",
+    "    x = layers.GlobalAveragePooling2D(name=\"avg_pool\")(model.output)\n",
+    "    x = layers.BatchNormalization()(x)\n",
+    "\n",
+    "    top_dropout_rate = 0.2\n",
+    "    x = layers.Dropout(top_dropout_rate, name=\"top_dropout\")(x)\n",
+    "    outputs = layers.Dense(NUM_CLASSES, activation=\"softmax\", name=\"pred\")(x)\n",
+    "\n",
+    "    # Compile\n",
+    "    model = tf.keras.Model(inputs, outputs, name=\"EfficientNet\")\n",
+    "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-2)\n",
+    "    model.compile(\n",
+    "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+    "    )\n",
+    "    return model\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The first step to transfer learning is to freeze all layers and train only the top\n",
+    "layers. For this step, a relatively large learning rate (1e-2) can be used.\n",
+    "Note that validation accuracy and loss will usually be better than training\n",
+    "accuracy and loss. This is because the regularization is strong, which only\n",
+    "suppresses training-time metrics.\n",
+    "\n",
+    "Note that the convergence may take up to 50 epochs depending on choice of learning rate.\n",
+    "If image augmentation layers were not\n",
+    "applied, the validation accuracy may only reach ~60%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "with strategy.scope():\n",
+    "    model = build_model(num_classes=NUM_CLASSES)\n",
+    "\n",
+    "epochs = 25  # @param {type: \"slider\", min:8, max:80}\n",
+    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
+    "plot_hist(hist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The second step is to unfreeze a number of layers and fit the model using smaller\n",
+    "learning rate. In this example we show unfreezing all layers, but depending on\n",
+    "specific dataset it may be desireble to only unfreeze a fraction of all layers.\n",
+    "\n",
+    "When the feature extraction with\n",
+    "pretrained model works good enough, this step would give a very limited gain on\n",
+    "validation accuracy. In our case we only see a small improvement,\n",
+    "as ImageNet pretraining already exposed the model to a good amount of dogs.\n",
+    "\n",
+    "On the other hand, when we use pretrained weights on a dataset that is more different\n",
+    "from ImageNet, this fine-tuning step can be crucial as the feature extractor also\n",
+    "needs to be adjusted by a considerable amount. Such a situation can be demonstrated\n",
+    "if choosing CIFAR-100 dataset instead, where fine-tuning boosts validation accuracy\n",
+    "by about 10% to pass 80% on `EfficientNetB0`.\n",
+    "In such a case the convergence may take more than 50 epochs.\n",
+    "\n",
+    "A side note on freezing/unfreezing models: setting `trainable` of a `Model` will\n",
+    "simultaneously set all layers belonging to the `Model` to the same `trainable`\n",
+    "attribute. Each layer is trainable only if both the layer itself and the model\n",
+    "containing it are trainable. Hence when we need to partially freeze/unfreeze\n",
+    "a model, we need to make sure the `trainable` attribute of the model is set\n",
+    "to `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def unfreeze_model(model):\n",
+    "    # We unfreeze the top 20 layers while leaving BatchNorm layers frozen\n",
+    "    for layer in model.layers[-20:]:\n",
+    "        if not isinstance(layer, layers.BatchNormalization):\n",
+    "            layer.trainable = True\n",
+    "\n",
+    "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-4)\n",
+    "    model.compile(\n",
+    "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "unfreeze_model(model)\n",
+    "\n",
+    "epochs = 10  # @param {type: \"slider\", min:8, max:50}\n",
+    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
+    "plot_hist(hist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Tips for fine tuning EfficientNet\n",
+    "\n",
+    "On unfreezing layers:\n",
+    "\n",
+    "- The `BathcNormalization` layers need to be kept frozen\n",
+    "([more details](https://keras.io/guides/transfer_learning/)).\n",
+    "If they are also turned to trainable, the\n",
+    "first epoch after unfreezing will significantly reduce accuracy.\n",
+    "- In some cases it may be beneficial to open up only a portion of layers instead of\n",
+    "unfreezing all. This will make fine tuning much faster when going to larger models like\n",
+    "B7.\n",
+    "- Each block needs to be all turned on or off. This is because the architecture includes\n",
+    "a shortcut from the first layer to the last layer for each block. Not respecting blocks\n",
+    "also significantly harms the final performance.\n",
+    "\n",
+    "Some other tips for utilizing EfficientNet:\n",
+    "\n",
+    "- Larger variants of EfficientNet do not guarantee improved performance, especially for\n",
+    "tasks with less data or fewer classes. In such a case, the larger variant of EfficientNet\n",
+    "chosen, the harder it is to tune hyperparameters.\n",
+    "- EMA (Exponential Moving Average) is very helpful in training EfficientNet from scratch,\n",
+    "but not so much for transfer learning.\n",
+    "- Do not use the RMSprop setup as in the original paper for transfer learning. The\n",
+    "momentum and learning rate are too high for transfer learning. It will easily corrupt the\n",
+    "pretrained weight and blow up the loss. A quick check is to see if loss (as categorical\n",
+    "cross entropy) is getting significantly larger than log(NUM_CLASSES) after the same\n",
+    "epoch. If so, the initial learning rate/momentum is too high.\n",
+    "- Smaller batch size benefit validation accuracy, possibly due to effectively providing\n",
+    "regularization.\n",
+    "\n",
+    "## Using the latest EfficientNet weights\n",
+    "\n",
+    "Since the initial paper, the EfficientNet has been improved by various methods for data\n",
+    "preprocessing and for using unlabelled data to enhance learning results. These\n",
+    "improvements are relatively hard and computationally costly to reproduce, and require\n",
+    "extra code; but the weights are readily available in the form of TF checkpoint files. The\n",
+    "model architecture has not changed, so loading the improved checkpoints is possible.\n",
+    "\n",
+    "To use a checkpoint provided at\n",
+    "[the official model repository](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), first\n",
+    "download the checkpoint. As example, here we download noisy-student version of B1:\n",
+    "\n",
+    "```\n",
+    "!wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet\\\n",
+    "       /noisystudent/noisy_student_efficientnet-b1.tar.gz\n",
+    "!tar -xf noisy_student_efficientnet-b1.tar.gz\n",
+    "```\n",
+    "\n",
+    "Then use the script [efficientnet_weight_update_util.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/efficientnet_weight_update_util.py) to convert ckpt file to h5 file.\n",
+    "\n",
+    "```\n",
+    "!python efficientnet_weight_update_util.py --model b1 --notop --ckpt \\\n",
+    "        efficientnet-b1/model.ckpt --o efficientnetb1_notop.h5\n",
+    "```\n",
+    "\n",
+    "When creating model, use the following to load new weight:\n",
+    "\n",
+    "```python\n",
+    "model = EfficientNetB1(weights=\"efficientnetb1_notop.h5\", include_top=False)\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "image_classification_efficientnet_fine_tuning",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/examples/vision/ipynb/image_classification_efficientnet_fine_tuning.ipynb
+++ b/examples/vision/ipynb/image_classification_efficientnet_fine_tuning.ipynb
@@ -1,733 +1,766 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "# Image classification via fine-tuning with EfficientNet\n",
-    "\n",
-    "**Author:** [Yixing Fu](https://github.com/yixingfu)<br>\n",
-    "**Date created:** 2020/06/30<br>\n",
-    "**Last modified:** 2020/07/16<br>\n",
-    "**Description:** Use EfficientNet with weights pre-trained on imagenet for Stanford Dogs classification."
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "image_classification_efficientnet_fine_tuning",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.0"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Introduction: what is EfficientNet\n",
-    "\n",
-    "EfficientNet, first introduced in [Tan and Le, 2019](https://arxiv.org/abs/1905.11946)\n",
-    "is among the most efficient models (i.e. requiring least FLOPS for inference)\n",
-    "that reaches State-of-the-Art accuracy on both\n",
-    "imagenet and common image classification transfer learning tasks.\n",
-    "\n",
-    "The smallest base model is similar to [MnasNet](https://arxiv.org/abs/1807.11626), which\n",
-    "reached near-SOTA with a significantly smaller model. By introducing a heuristic way to\n",
-    "scale the model, EfficientNet provides a family of models (B0 to B7) that represents a\n",
-    "good combination of efficiency and accuracy on a variety of scales. Such a scaling\n",
-    "heuristics (compound-scaling, details see\n",
-    "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946)) allows the\n",
-    "efficiency-oriented base model (B0) to surpass models at every scale, while avoiding\n",
-    "extensive grid-search of hyperparameters.\n",
-    "\n",
-    "A summary of the latest updates on the model is available at\n",
-    "[here](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), where various\n",
-    "augmentation schemes and semi-supervised learning approaches are applied to further\n",
-    "improve the imagenet performance of the models. These extensions of the model can be used\n",
-    "by updating weights without changing model architecture.\n",
-    "\n",
-    "## B0 to B7 variants of EfficientNet\n",
-    "\n",
-    "*(This section provides some details on \"compound scaling\", and can be skipped\n",
-    "if you're only interested in using the models)*\n",
-    "\n",
-    "Based on the [original paper](https://arxiv.org/abs/1905.11946) people may have the\n",
-    "impression that EfficientNet is a continuous family of models created by arbitrarily\n",
-    "choosing scaling factor in as Eq.(3) of the paper.  However, choice of resolution,\n",
-    "depth and width are also restricted by many factors:\n",
-    "\n",
-    "- Resolution: Resolutions not divisible by 8, 16, etc. cause zero-padding near boundaries\n",
-    "of some layers which wastes computational resources. This especially applies to smaller\n",
-    "variants of the model, hence the input resolution for B0 and B1 are chosen as 224 and\n",
-    "240.\n",
-    "\n",
-    "- Depth and width: The building blocks of EfficientNet demands channel size to be\n",
-    "multiples of 8.\n",
-    "\n",
-    "- Resource limit: Memory limitation may bottleneck resolution when depth\n",
-    "and width can still increase. In such a situation, increasing depth and/or\n",
-    "width but keep resolution can still improve performance.\n",
-    "\n",
-    "As a result, the depth, width and resolution of each variant of the EfficientNet models\n",
-    "are hand-picked and proven to produce good results, though they may be significantly\n",
-    "off from the compound scaling formula.\n",
-    "Therefore, the keras implementation (detailed below) only provide these 8 models, B0 to B7,\n",
-    "instead of allowing arbitray choice of width / depth / resolution parameters.\n",
-    "\n",
-    "## Keras implementation of EfficientNet\n",
-    "\n",
-    "An implementation of EfficientNet B0 to B7 has been shipped with tf.keras since TF2.3. To\n",
-    "use EfficientNetB0 for classifying 1000 classes of images from imagenet, run:\n",
-    "\n",
-    "```python\n",
-    "from tensorflow.keras.applications import EfficientNetB0\n",
-    "model = EfficientNetB0(weights='imagenet')\n",
-    "```\n",
-    "\n",
-    "This model takes input images of shape (224, 224, 3), and the input data should range\n",
-    "[0, 255]. Normalization is included as part of the model.\n",
-    "\n",
-    "Because training EfficientNet on ImageNet takes a tremendous amount of resources and\n",
-    "several techniques that are not a part of the model architecture itself. Hence the Keras\n",
-    "implementation by default loads pre-trained weights obtained via training with\n",
-    "[AutoAugment](https://arxiv.org/abs/1805.09501).\n",
-    "\n",
-    "For B0 to B7 base models, the input shapes are different. Here is a list of input shape\n",
-    "expected for each model:\n",
-    "\n",
-    "| Base model | resolution|\n",
-    "|----------------|-----|\n",
-    "| EfficientNetB0 | 224 |\n",
-    "| EfficientNetB1 | 240 |\n",
-    "| EfficientNetB2 | 260 |\n",
-    "| EfficientNetB3 | 300 |\n",
-    "| EfficientNetB4 | 380 |\n",
-    "| EfficientNetB5 | 456 |\n",
-    "| EfficientNetB6 | 528 |\n",
-    "| EfficientNetB7 | 600 |\n",
-    "\n",
-    "When the model is intended for transfer learning, the Keras implementation\n",
-    "provides a option to remove the top layers:\n",
-    "```\n",
-    "model = EfficientNetB0(include_top=False, weights='imagenet')\n",
-    "```\n",
-    "This option excludes the final `Dense` layer that turns 1280 features on the penultimate\n",
-    "layer into prediction of the 1000 ImageNet classes. Replacing the top layer with custom\n",
-    "layers allows using EfficientNet as a feature extractor in a transfer learning workflow.\n",
-    "\n",
-    "Another argument in the model constructor worth noticing is `drop_connect_rate` which controls\n",
-    "the dropout rate responsible for [stochastic depth](https://arxiv.org/abs/1603.09382).\n",
-    "This parameter serves as a toggle for extra regularization in finetuning, but does not\n",
-    "affect loaded weights. For example, when stronger regularization is desired, try:\n",
-    "\n",
-    "```python\n",
-    "model = EfficientNetB0(weights='imagenet', drop_connect_rate=0.4)\n",
-    "```\n",
-    "The default value is 0.2.\n",
-    "\n",
-    "## Example: EfficientNetB0 for Stanford Dogs.\n",
-    "\n",
-    "EfficientNet is capable of a wide range of image classification tasks.\n",
-    "This makes it a good model for transfer learning.\n",
-    "As an end-to-end example, we will show using pre-trained EfficientNetB0 on\n",
-    "[Stanford Dogs](http://vision.stanford.edu/aditya86/ImageNetDogs/main.html) dataset."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "# IMG_SIZE is determined by EfficientNet model choice\n",
-    "IMG_SIZE = 224"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Setup and data loading\n",
-    "\n",
-    "This example requires TensorFlow 2.3 or above.\n",
-    "\n",
-    "To use TPU, the TPU runtime must match current running TensorFlow\n",
-    "version. If there is a mismatch, try:\n",
-    "\n",
-    "```python\n",
-    "from cloud_tpu_client import Client\n",
-    "c = Client()\n",
-    "c.configure_tpu_version(tf.__version__, restart_type=\"always\")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "try:\n",
-    "    tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection\n",
-    "    print(\"Running on TPU \", tpu.cluster_spec().as_dict()[\"worker\"])\n",
-    "    tf.config.experimental_connect_to_cluster(tpu)\n",
-    "    tf.tpu.experimental.initialize_tpu_system(tpu)\n",
-    "    strategy = tf.distribute.experimental.TPUStrategy(tpu)\n",
-    "except ValueError:\n",
-    "    print(\"Not connected to a TPU runtime. Using CPU/GPU strategy\")\n",
-    "    strategy = tf.distribute.MirroredStrategy()\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "### Loading data\n",
-    "\n",
-    "Here we load data from [tensorflow_datasets](https://www.tensorflow.org/datasets)\n",
-    "(hereafter TFDS).\n",
-    "Stanford Dogs dataset is provided in\n",
-    "TFDS as [stanford_dogs](https://www.tensorflow.org/datasets/catalog/stanford_dogs).\n",
-    "It features 20,580 images that belong to 120 classes of dog breeds\n",
-    "(12,000 for training and 8,580 for testing).\n",
-    "\n",
-    "By simply changing `dataset_name` below, you may also try this notebook for\n",
-    "other datasets in TFDS such as\n",
-    "[cifar10](https://www.tensorflow.org/datasets/catalog/cifar10),\n",
-    "[cifar100](https://www.tensorflow.org/datasets/catalog/cifar100),\n",
-    "[food101](https://www.tensorflow.org/datasets/catalog/food101),\n",
-    "etc. When the images are much smaller than the size of EfficientNet input,\n",
-    "we can simply upsample the input images. It has been shown in\n",
-    "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946) that transfer learning\n",
-    "result is better for increased resolution even if input images remain small.\n",
-    "\n",
-    "For TPU: if using TFDS datasets,\n",
-    "a [GCS bucket](https://cloud.google.com/storage/docs/key-terms#buckets)\n",
-    "location is required to save the datasets. For example:\n",
-    "\n",
-    "```python\n",
-    "tfds.load(dataset_name, data_dir=\"gs://example-bucket/datapath\")\n",
-    "```\n",
-    "\n",
-    "Also, both the current environment and the TPU service account have\n",
-    "proper [access](https://cloud.google.com/tpu/docs/storage-buckets#authorize_the_service_account)\n",
-    "to the bucket. Alternatively, for small datasets you may try loading data\n",
-    "into the memory and use `tf.data.Dataset.from_tensor_slices()`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow_datasets as tfds\n",
-    "\n",
-    "batch_size = 64\n",
-    "\n",
-    "dataset_name = \"stanford_dogs\"\n",
-    "(ds_train, ds_test), ds_info = tfds.load(\n",
-    "    dataset_name, split=[\"train\", \"test\"], with_info=True, as_supervised=True\n",
-    ")\n",
-    "NUM_CLASSES = ds_info.features[\"label\"].num_classes\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "When the dataset include images with various size, we need to resize them into a\n",
-    "shared size. The Stanford Dogs dataset includes only images at least 200x200\n",
-    "pixels in size. Here we resize the images to the input size needed for EfficientNet."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "size = (IMG_SIZE, IMG_SIZE)\n",
-    "ds_train = ds_train.map(lambda image, label: (tf.image.resize(image, size), label))\n",
-    "ds_test = ds_test.map(lambda image, label: (tf.image.resize(image, size), label))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "### Visualizing the data\n",
-    "\n",
-    "The following code shows the first 9 images with their labels."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "\n",
-    "def format_label(label):\n",
-    "    string_label = label_info.int2str(label)\n",
-    "    return string_label.split(\"-\")[1]\n",
-    "\n",
-    "\n",
-    "label_info = ds_info.features[\"label\"]\n",
-    "for i, (image, label) in enumerate(ds_train.take(9)):\n",
-    "    ax = plt.subplot(3, 3, i + 1)\n",
-    "    plt.imshow(image.numpy().astype(\"uint8\"))\n",
-    "    plt.title(\"{}\".format(format_label(label)))\n",
-    "    plt.axis(\"off\")\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "### Data augmentation\n",
-    "\n",
-    "We can use preprocessing layers APIs for image augmentation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from tensorflow.keras.layers.experimental import preprocessing\n",
-    "from tensorflow.keras.models import Sequential\n",
-    "from tensorflow.keras import layers\n",
-    "\n",
-    "img_augmentation = Sequential(\n",
-    "    [\n",
-    "        preprocessing.RandomRotation(factor=0.15),\n",
-    "        preprocessing.RandomTranslation(height_factor=0.1, width_factor=0.1),\n",
-    "        preprocessing.RandomFlip(),\n",
-    "        preprocessing.RandomContrast(factor=0.1),\n",
-    "    ],\n",
-    "    name=\"img_augmentation\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "This `Sequential` model object can be used both as a part of\n",
-    "the model we later build, and as a function to preprocess\n",
-    "data before feeding into the model. Using them as function makes\n",
-    "it easy to visualize the augmented images. Here we plot 9 examples\n",
-    "of augmentation result of a given figure."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "for image, label in ds_train.take(1):\n",
-    "    for i in range(9):\n",
-    "        ax = plt.subplot(3, 3, i + 1)\n",
-    "        aug_img = img_augmentation(tf.expand_dims(image, axis=0))\n",
-    "        plt.imshow(aug_img[0].numpy().astype(\"uint8\"))\n",
-    "        plt.title(\"{}\".format(format_label(label)))\n",
-    "        plt.axis(\"off\")\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "### Prepare inputs\n",
-    "\n",
-    "Once we verify the input data and augmentation are working correctly,\n",
-    "we prepare dataset for training. The input data are resized to uniform\n",
-    "`IMG_SIZE`. The labels are put into one-hot\n",
-    "(a.k.a. categorical) encoding. The dataset is batched.\n",
-    "\n",
-    "Note: `prefetch` and `AUTOTUNE` may in some situation improve\n",
-    "performance, but depends on environment and the specific dataset used.\n",
-    "See this [guide](https://www.tensorflow.org/guide/data_performance)\n",
-    "for more information on data pipeline performance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "# One-hot / categorical encoding\n",
-    "def input_preprocess(image, label):\n",
-    "    label = tf.one_hot(label, NUM_CLASSES)\n",
-    "    return image, label\n",
-    "\n",
-    "\n",
-    "ds_train = ds_train.map(\n",
-    "    input_preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE\n",
-    ")\n",
-    "ds_train = ds_train.batch(batch_size=batch_size, drop_remainder=True)\n",
-    "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)\n",
-    "\n",
-    "ds_test = ds_test.map(input_preprocess)\n",
-    "ds_test = ds_test.batch(batch_size=batch_size, drop_remainder=True)\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Training a model from scratch\n",
-    "\n",
-    "We build an EfficientNetB0 with 120 output classes, that is initialized from scratch:\n",
-    "\n",
-    "Note: the accuracy will increase very slowly and may overfit."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from tensorflow.keras.applications import EfficientNetB0\n",
-    "\n",
-    "with strategy.scope():\n",
-    "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
-    "    x = img_augmentation(inputs)\n",
-    "    outputs = EfficientNetB0(include_top=True, weights=None, classes=NUM_CLASSES)(x)\n",
-    "\n",
-    "    model = tf.keras.Model(inputs, outputs)\n",
-    "    model.compile(\n",
-    "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-    "    )\n",
-    "\n",
-    "model.summary()\n",
-    "\n",
-    "epochs = 40  # @param {type: \"slider\", min:10, max:100}\n",
-    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "Training the model is relatively fast (takes only 20 seconds per epoch on TPUv2 that is\n",
-    "available on Colab). This might make it sounds easy to simply train EfficientNet on any\n",
-    "dataset wanted from scratch. However, training EfficientNet on smaller datasets,\n",
-    "especially those with lower resolution like CIFAR-100, faces the significant challenge of\n",
-    "overfitting.\n",
-    "\n",
-    "Hence training from scratch requires very careful choice of hyperparameters and is\n",
-    "difficult to find suitable regularization. It would also be much more demanding in resources.\n",
-    "Plotting the training and validation accuracy\n",
-    "makes it clear that validation accuracy stagnates at a low value."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "\n",
-    "def plot_hist(hist):\n",
-    "    plt.plot(hist.history[\"accuracy\"])\n",
-    "    plt.plot(hist.history[\"val_accuracy\"])\n",
-    "    plt.title(\"model accuracy\")\n",
-    "    plt.ylabel(\"accuracy\")\n",
-    "    plt.xlabel(\"epoch\")\n",
-    "    plt.legend([\"train\", \"validation\"], loc=\"upper left\")\n",
-    "    plt.show()\n",
-    "\n",
-    "\n",
-    "plot_hist(hist)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Transfer learning from pre-trained weights\n",
-    "\n",
-    "Here we initialize the model with pre-trained ImageNet weights,\n",
-    "and we fine-tune it on our own dataset."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from tensorflow.keras.layers.experimental import preprocessing\n",
-    "\n",
-    "\n",
-    "def build_model(num_classes):\n",
-    "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
-    "    x = img_augmentation(inputs)\n",
-    "    model = EfficientNetB0(include_top=False, input_tensor=x, weights=\"imagenet\")\n",
-    "\n",
-    "    # Freeze the pretrained weights\n",
-    "    model.trainable = False\n",
-    "\n",
-    "    # Rebuild top\n",
-    "    x = layers.GlobalAveragePooling2D(name=\"avg_pool\")(model.output)\n",
-    "    x = layers.BatchNormalization()(x)\n",
-    "\n",
-    "    top_dropout_rate = 0.2\n",
-    "    x = layers.Dropout(top_dropout_rate, name=\"top_dropout\")(x)\n",
-    "    outputs = layers.Dense(NUM_CLASSES, activation=\"softmax\", name=\"pred\")(x)\n",
-    "\n",
-    "    # Compile\n",
-    "    model = tf.keras.Model(inputs, outputs, name=\"EfficientNet\")\n",
-    "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-2)\n",
-    "    model.compile(\n",
-    "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-    "    )\n",
-    "    return model\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "The first step to transfer learning is to freeze all layers and train only the top\n",
-    "layers. For this step, a relatively large learning rate (1e-2) can be used.\n",
-    "Note that validation accuracy and loss will usually be better than training\n",
-    "accuracy and loss. This is because the regularization is strong, which only\n",
-    "suppresses training-time metrics.\n",
-    "\n",
-    "Note that the convergence may take up to 50 epochs depending on choice of learning rate.\n",
-    "If image augmentation layers were not\n",
-    "applied, the validation accuracy may only reach ~60%."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "with strategy.scope():\n",
-    "    model = build_model(num_classes=NUM_CLASSES)\n",
-    "\n",
-    "epochs = 25  # @param {type: \"slider\", min:8, max:80}\n",
-    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
-    "plot_hist(hist)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "The second step is to unfreeze a number of layers and fit the model using smaller\n",
-    "learning rate. In this example we show unfreezing all layers, but depending on\n",
-    "specific dataset it may be desireble to only unfreeze a fraction of all layers.\n",
-    "\n",
-    "When the feature extraction with\n",
-    "pretrained model works good enough, this step would give a very limited gain on\n",
-    "validation accuracy. In our case we only see a small improvement,\n",
-    "as ImageNet pretraining already exposed the model to a good amount of dogs.\n",
-    "\n",
-    "On the other hand, when we use pretrained weights on a dataset that is more different\n",
-    "from ImageNet, this fine-tuning step can be crucial as the feature extractor also\n",
-    "needs to be adjusted by a considerable amount. Such a situation can be demonstrated\n",
-    "if choosing CIFAR-100 dataset instead, where fine-tuning boosts validation accuracy\n",
-    "by about 10% to pass 80% on `EfficientNetB0`.\n",
-    "In such a case the convergence may take more than 50 epochs.\n",
-    "\n",
-    "A side note on freezing/unfreezing models: setting `trainable` of a `Model` will\n",
-    "simultaneously set all layers belonging to the `Model` to the same `trainable`\n",
-    "attribute. Each layer is trainable only if both the layer itself and the model\n",
-    "containing it are trainable. Hence when we need to partially freeze/unfreeze\n",
-    "a model, we need to make sure the `trainable` attribute of the model is set\n",
-    "to `True`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "\n",
-    "def unfreeze_model(model):\n",
-    "    # We unfreeze the top 20 layers while leaving BatchNorm layers frozen\n",
-    "    for layer in model.layers[-20:]:\n",
-    "        if not isinstance(layer, layers.BatchNormalization):\n",
-    "            layer.trainable = True\n",
-    "\n",
-    "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-4)\n",
-    "    model.compile(\n",
-    "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "unfreeze_model(model)\n",
-    "\n",
-    "epochs = 10  # @param {type: \"slider\", min:8, max:50}\n",
-    "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
-    "plot_hist(hist)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "### Tips for fine tuning EfficientNet\n",
-    "\n",
-    "On unfreezing layers:\n",
-    "\n",
-    "- The `BathcNormalization` layers need to be kept frozen\n",
-    "([more details](https://keras.io/guides/transfer_learning/)).\n",
-    "If they are also turned to trainable, the\n",
-    "first epoch after unfreezing will significantly reduce accuracy.\n",
-    "- In some cases it may be beneficial to open up only a portion of layers instead of\n",
-    "unfreezing all. This will make fine tuning much faster when going to larger models like\n",
-    "B7.\n",
-    "- Each block needs to be all turned on or off. This is because the architecture includes\n",
-    "a shortcut from the first layer to the last layer for each block. Not respecting blocks\n",
-    "also significantly harms the final performance.\n",
-    "\n",
-    "Some other tips for utilizing EfficientNet:\n",
-    "\n",
-    "- Larger variants of EfficientNet do not guarantee improved performance, especially for\n",
-    "tasks with less data or fewer classes. In such a case, the larger variant of EfficientNet\n",
-    "chosen, the harder it is to tune hyperparameters.\n",
-    "- EMA (Exponential Moving Average) is very helpful in training EfficientNet from scratch,\n",
-    "but not so much for transfer learning.\n",
-    "- Do not use the RMSprop setup as in the original paper for transfer learning. The\n",
-    "momentum and learning rate are too high for transfer learning. It will easily corrupt the\n",
-    "pretrained weight and blow up the loss. A quick check is to see if loss (as categorical\n",
-    "cross entropy) is getting significantly larger than log(NUM_CLASSES) after the same\n",
-    "epoch. If so, the initial learning rate/momentum is too high.\n",
-    "- Smaller batch size benefit validation accuracy, possibly due to effectively providing\n",
-    "regularization.\n",
-    "\n",
-    "## Using the latest EfficientNet weights\n",
-    "\n",
-    "Since the initial paper, the EfficientNet has been improved by various methods for data\n",
-    "preprocessing and for using unlabelled data to enhance learning results. These\n",
-    "improvements are relatively hard and computationally costly to reproduce, and require\n",
-    "extra code; but the weights are readily available in the form of TF checkpoint files. The\n",
-    "model architecture has not changed, so loading the improved checkpoints is possible.\n",
-    "\n",
-    "To use a checkpoint provided at\n",
-    "[the official model repository](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), first\n",
-    "download the checkpoint. As example, here we download noisy-student version of B1:\n",
-    "\n",
-    "```\n",
-    "!wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet\\\n",
-    "       /noisystudent/noisy_student_efficientnet-b1.tar.gz\n",
-    "!tar -xf noisy_student_efficientnet-b1.tar.gz\n",
-    "```\n",
-    "\n",
-    "Then use the script efficientnet_weight_update_util.py to convert ckpt file to h5 file.\n",
-    "\n",
-    "```\n",
-    "!python efficientnet_weight_update_util.py --model b1 --notop --ckpt \\\n",
-    "        efficientnet-b1/model.ckpt --o efficientnetb1_notop.h5\n",
-    "```\n",
-    "\n",
-    "When creating model, use the following to load new weight:\n",
-    "\n",
-    "```python\n",
-    "model = EfficientNetB0(weights=\"efficientnetb1_notop.h5\", include_top=False)\n",
-    "```"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "image_classification_efficientnet_fine_tuning",
-   "private_outputs": false,
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "uhDSOiAz6XNK"
+      },
+      "source": [
+        "# Image classification via fine-tuning with EfficientNet\n",
+        "\n",
+        "**Author:** [Yixing Fu](https://github.com/yixingfu)<br>\n",
+        "**Date created:** 2020/06/30<br>\n",
+        "**Last modified:** 2020/07/16<br>\n",
+        "**Description:** Use EfficientNet with weights pre-trained on imagenet for Stanford Dogs classification."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "gdhiJ7Cz6XNL"
+      },
+      "source": [
+        "## Introduction: what is EfficientNet\n",
+        "\n",
+        "EfficientNet, first introduced in [Tan and Le, 2019](https://arxiv.org/abs/1905.11946)\n",
+        "is among the most efficient models (i.e. requiring least FLOPS for inference)\n",
+        "that reaches State-of-the-Art accuracy on both\n",
+        "imagenet and common image classification transfer learning tasks.\n",
+        "\n",
+        "The smallest base model is similar to [MnasNet](https://arxiv.org/abs/1807.11626), which\n",
+        "reached near-SOTA with a significantly smaller model. By introducing a heuristic way to\n",
+        "scale the model, EfficientNet provides a family of models (B0 to B7) that represents a\n",
+        "good combination of efficiency and accuracy on a variety of scales. Such a scaling\n",
+        "heuristics (compound-scaling, details see\n",
+        "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946)) allows the\n",
+        "efficiency-oriented base model (B0) to surpass models at every scale, while avoiding\n",
+        "extensive grid-search of hyperparameters.\n",
+        "\n",
+        "A summary of the latest updates on the model is available at\n",
+        "[here](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), where various\n",
+        "augmentation schemes and semi-supervised learning approaches are applied to further\n",
+        "improve the imagenet performance of the models. These extensions of the model can be used\n",
+        "by updating weights without changing model architecture.\n",
+        "\n",
+        "## B0 to B7 variants of EfficientNet\n",
+        "\n",
+        "*(This section provides some details on \"compound scaling\", and can be skipped\n",
+        "if you're only interested in using the models)*\n",
+        "\n",
+        "Based on the [original paper](https://arxiv.org/abs/1905.11946) people may have the\n",
+        "impression that EfficientNet is a continuous family of models created by arbitrarily\n",
+        "choosing scaling factor in as Eq.(3) of the paper.  However, choice of resolution,\n",
+        "depth and width are also restricted by many factors:\n",
+        "\n",
+        "- Resolution: Resolutions not divisible by 8, 16, etc. cause zero-padding near boundaries\n",
+        "of some layers which wastes computational resources. This especially applies to smaller\n",
+        "variants of the model, hence the input resolution for B0 and B1 are chosen as 224 and\n",
+        "240.\n",
+        "\n",
+        "- Depth and width: The building blocks of EfficientNet demands channel size to be\n",
+        "multiples of 8.\n",
+        "\n",
+        "- Resource limit: Memory limitation may bottleneck resolution when depth\n",
+        "and width can still increase. In such a situation, increasing depth and/or\n",
+        "width but keep resolution can still improve performance.\n",
+        "\n",
+        "As a result, the depth, width and resolution of each variant of the EfficientNet models\n",
+        "are hand-picked and proven to produce good results, though they may be significantly\n",
+        "off from the compound scaling formula.\n",
+        "Therefore, the keras implementation (detailed below) only provide these 8 models, B0 to B7,\n",
+        "instead of allowing arbitray choice of width / depth / resolution parameters.\n",
+        "\n",
+        "## Keras implementation of EfficientNet\n",
+        "\n",
+        "An implementation of EfficientNet B0 to B7 has been shipped with tf.keras since TF2.3. To\n",
+        "use EfficientNetB0 for classifying 1000 classes of images from imagenet, run:\n",
+        "\n",
+        "```python\n",
+        "from tensorflow.keras.applications import EfficientNetB0\n",
+        "model = EfficientNetB0(weights='imagenet')\n",
+        "```\n",
+        "\n",
+        "This model takes input images of shape (224, 224, 3), and the input data should range\n",
+        "[0, 255]. Normalization is included as part of the model.\n",
+        "\n",
+        "Because training EfficientNet on ImageNet takes a tremendous amount of resources and\n",
+        "several techniques that are not a part of the model architecture itself. Hence the Keras\n",
+        "implementation by default loads pre-trained weights obtained via training with\n",
+        "[AutoAugment](https://arxiv.org/abs/1805.09501).\n",
+        "\n",
+        "For B0 to B7 base models, the input shapes are different. Here is a list of input shape\n",
+        "expected for each model:\n",
+        "\n",
+        "| Base model | resolution|\n",
+        "|----------------|-----|\n",
+        "| EfficientNetB0 | 224 |\n",
+        "| EfficientNetB1 | 240 |\n",
+        "| EfficientNetB2 | 260 |\n",
+        "| EfficientNetB3 | 300 |\n",
+        "| EfficientNetB4 | 380 |\n",
+        "| EfficientNetB5 | 456 |\n",
+        "| EfficientNetB6 | 528 |\n",
+        "| EfficientNetB7 | 600 |\n",
+        "\n",
+        "When the model is intended for transfer learning, the Keras implementation\n",
+        "provides a option to remove the top layers:\n",
+        "```\n",
+        "model = EfficientNetB0(include_top=False, weights='imagenet')\n",
+        "```\n",
+        "This option excludes the final `Dense` layer that turns 1280 features on the penultimate\n",
+        "layer into prediction of the 1000 ImageNet classes. Replacing the top layer with custom\n",
+        "layers allows using EfficientNet as a feature extractor in a transfer learning workflow.\n",
+        "\n",
+        "Another argument in the model constructor worth noticing is `drop_connect_rate` which controls\n",
+        "the dropout rate responsible for [stochastic depth](https://arxiv.org/abs/1603.09382).\n",
+        "This parameter serves as a toggle for extra regularization in finetuning, but does not\n",
+        "affect loaded weights. For example, when stronger regularization is desired, try:\n",
+        "\n",
+        "```python\n",
+        "model = EfficientNetB0(weights='imagenet', drop_connect_rate=0.4)\n",
+        "```\n",
+        "The default value is 0.2.\n",
+        "\n",
+        "## Example: EfficientNetB0 for Stanford Dogs.\n",
+        "\n",
+        "EfficientNet is capable of a wide range of image classification tasks.\n",
+        "This makes it a good model for transfer learning.\n",
+        "As an end-to-end example, we will show using pre-trained EfficientNetB0 on\n",
+        "[Stanford Dogs](http://vision.stanford.edu/aditya86/ImageNetDogs/main.html) dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "xDaDenvn6XNM",
+        "colab": {}
+      },
+      "source": [
+        "# IMG_SIZE is determined by EfficientNet model choice\n",
+        "IMG_SIZE = 224"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "ayahLyrr6XNR"
+      },
+      "source": [
+        "## Setup and data loading\n",
+        "\n",
+        "This example requires TensorFlow 2.3 or above.\n",
+        "\n",
+        "To use TPU, the TPU runtime must match current running TensorFlow\n",
+        "version. If there is a mismatch, try:\n",
+        "\n",
+        "```python\n",
+        "from cloud_tpu_client import Client\n",
+        "c = Client()\n",
+        "c.configure_tpu_version(tf.__version__, restart_type=\"always\")\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Wp5hiU2d6XNR",
+        "colab": {}
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "try:\n",
+        "    tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection\n",
+        "    print(\"Running on TPU \", tpu.cluster_spec().as_dict()[\"worker\"])\n",
+        "    tf.config.experimental_connect_to_cluster(tpu)\n",
+        "    tf.tpu.experimental.initialize_tpu_system(tpu)\n",
+        "    strategy = tf.distribute.experimental.TPUStrategy(tpu)\n",
+        "except ValueError:\n",
+        "    print(\"Not connected to a TPU runtime. Using CPU/GPU strategy\")\n",
+        "    strategy = tf.distribute.MirroredStrategy()\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "oYVEoTQw6XNU"
+      },
+      "source": [
+        "### Loading data\n",
+        "\n",
+        "Here we load data from [tensorflow_datasets](https://www.tensorflow.org/datasets)\n",
+        "(hereafter TFDS).\n",
+        "Stanford Dogs dataset is provided in\n",
+        "TFDS as [stanford_dogs](https://www.tensorflow.org/datasets/catalog/stanford_dogs).\n",
+        "It features 20,580 images that belong to 120 classes of dog breeds\n",
+        "(12,000 for training and 8,580 for testing).\n",
+        "\n",
+        "By simply changing `dataset_name` below, you may also try this notebook for\n",
+        "other datasets in TFDS such as\n",
+        "[cifar10](https://www.tensorflow.org/datasets/catalog/cifar10),\n",
+        "[cifar100](https://www.tensorflow.org/datasets/catalog/cifar100),\n",
+        "[food101](https://www.tensorflow.org/datasets/catalog/food101),\n",
+        "etc. When the images are much smaller than the size of EfficientNet input,\n",
+        "we can simply upsample the input images. It has been shown in\n",
+        "[Tan and Le, 2019](https://arxiv.org/abs/1905.11946) that transfer learning\n",
+        "result is better for increased resolution even if input images remain small.\n",
+        "\n",
+        "For TPU: if using TFDS datasets,\n",
+        "a [GCS bucket](https://cloud.google.com/storage/docs/key-terms#buckets)\n",
+        "location is required to save the datasets. For example:\n",
+        "\n",
+        "```python\n",
+        "tfds.load(dataset_name, data_dir=\"gs://example-bucket/datapath\")\n",
+        "```\n",
+        "\n",
+        "Also, both the current environment and the TPU service account have\n",
+        "proper [access](https://cloud.google.com/tpu/docs/storage-buckets#authorize_the_service_account)\n",
+        "to the bucket. Alternatively, for small datasets you may try loading data\n",
+        "into the memory and use `tf.data.Dataset.from_tensor_slices()`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "tHwO62kr6XNV",
+        "colab": {}
+      },
+      "source": [
+        "import tensorflow_datasets as tfds\n",
+        "\n",
+        "batch_size = 64\n",
+        "\n",
+        "dataset_name = \"stanford_dogs\"\n",
+        "(ds_train, ds_test), ds_info = tfds.load(\n",
+        "    dataset_name, split=[\"train\", \"test\"], with_info=True, as_supervised=True\n",
+        ")\n",
+        "NUM_CLASSES = ds_info.features[\"label\"].num_classes\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "8EZo6pZv6XNY"
+      },
+      "source": [
+        "When the dataset include images with various size, we need to resize them into a\n",
+        "shared size. The Stanford Dogs dataset includes only images at least 200x200\n",
+        "pixels in size. Here we resize the images to the input size needed for EfficientNet."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "-IGjHUEU6XNZ",
+        "colab": {}
+      },
+      "source": [
+        "size = (IMG_SIZE, IMG_SIZE)\n",
+        "ds_train = ds_train.map(lambda image, label: (tf.image.resize(image, size), label))\n",
+        "ds_test = ds_test.map(lambda image, label: (tf.image.resize(image, size), label))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "APtEC9ch6XNb"
+      },
+      "source": [
+        "### Visualizing the data\n",
+        "\n",
+        "The following code shows the first 9 images with their labels."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "TKUH-Uvx6XNc",
+        "colab": {}
+      },
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "def format_label(label):\n",
+        "    string_label = label_info.int2str(label)\n",
+        "    return string_label.split(\"-\")[1]\n",
+        "\n",
+        "\n",
+        "label_info = ds_info.features[\"label\"]\n",
+        "for i, (image, label) in enumerate(ds_train.take(9)):\n",
+        "    ax = plt.subplot(3, 3, i + 1)\n",
+        "    plt.imshow(image.numpy().astype(\"uint8\"))\n",
+        "    plt.title(\"{}\".format(format_label(label)))\n",
+        "    plt.axis(\"off\")\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "miHK6as56XNf"
+      },
+      "source": [
+        "### Data augmentation\n",
+        "\n",
+        "We can use preprocessing layers APIs for image augmentation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "H-_3Jwc86XNf",
+        "colab": {}
+      },
+      "source": [
+        "from tensorflow.keras.layers.experimental import preprocessing\n",
+        "from tensorflow.keras.models import Sequential\n",
+        "from tensorflow.keras import layers\n",
+        "\n",
+        "img_augmentation = Sequential(\n",
+        "    [\n",
+        "        preprocessing.RandomRotation(factor=0.15),\n",
+        "        preprocessing.RandomTranslation(height_factor=0.1, width_factor=0.1),\n",
+        "        preprocessing.RandomFlip(),\n",
+        "        preprocessing.RandomContrast(factor=0.1),\n",
+        "    ],\n",
+        "    name=\"img_augmentation\",\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "HKDK6ZDQ6XNk"
+      },
+      "source": [
+        "This `Sequential` model object can be used both as a part of\n",
+        "the model we later build, and as a function to preprocess\n",
+        "data before feeding into the model. Using them as function makes\n",
+        "it easy to visualize the augmented images. Here we plot 9 examples\n",
+        "of augmentation result of a given figure."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "XKv5HnFH6XNk",
+        "colab": {}
+      },
+      "source": [
+        "for image, label in ds_train.take(1):\n",
+        "    for i in range(9):\n",
+        "        ax = plt.subplot(3, 3, i + 1)\n",
+        "        aug_img = img_augmentation(tf.expand_dims(image, axis=0))\n",
+        "        plt.imshow(aug_img[0].numpy().astype(\"uint8\"))\n",
+        "        plt.title(\"{}\".format(format_label(label)))\n",
+        "        plt.axis(\"off\")\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "HAlPMmv26XNo"
+      },
+      "source": [
+        "### Prepare inputs\n",
+        "\n",
+        "Once we verify the input data and augmentation are working correctly,\n",
+        "we prepare dataset for training. The input data are resized to uniform\n",
+        "`IMG_SIZE`. The labels are put into one-hot\n",
+        "(a.k.a. categorical) encoding. The dataset is batched.\n",
+        "\n",
+        "Note: `prefetch` and `AUTOTUNE` may in some situation improve\n",
+        "performance, but depends on environment and the specific dataset used.\n",
+        "See this [guide](https://www.tensorflow.org/guide/data_performance)\n",
+        "for more information on data pipeline performance."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "en03mckm6XNo",
+        "colab": {}
+      },
+      "source": [
+        "# One-hot / categorical encoding\n",
+        "def input_preprocess(image, label):\n",
+        "    label = tf.one_hot(label, NUM_CLASSES)\n",
+        "    return image, label\n",
+        "\n",
+        "\n",
+        "ds_train = ds_train.map(\n",
+        "    input_preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE\n",
+        ")\n",
+        "ds_train = ds_train.batch(batch_size=batch_size, drop_remainder=True)\n",
+        "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)\n",
+        "\n",
+        "ds_test = ds_test.map(input_preprocess)\n",
+        "ds_test = ds_test.batch(batch_size=batch_size, drop_remainder=True)\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "DLBMqMFf6XNr"
+      },
+      "source": [
+        "## Training a model from scratch\n",
+        "\n",
+        "We build an EfficientNetB0 with 120 output classes, that is initialized from scratch:\n",
+        "\n",
+        "Note: the accuracy will increase very slowly and may overfit."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "XrmmaUL36XNs",
+        "colab": {}
+      },
+      "source": [
+        "from tensorflow.keras.applications import EfficientNetB0\n",
+        "\n",
+        "with strategy.scope():\n",
+        "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
+        "    x = img_augmentation(inputs)\n",
+        "    outputs = EfficientNetB0(include_top=True, weights=None, classes=NUM_CLASSES)(x)\n",
+        "\n",
+        "    model = tf.keras.Model(inputs, outputs)\n",
+        "    model.compile(\n",
+        "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+        "    )\n",
+        "\n",
+        "model.summary()\n",
+        "\n",
+        "epochs = 40  # @param {type: \"slider\", min:10, max:100}\n",
+        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "77GHLr_n6XNv"
+      },
+      "source": [
+        "Training the model is relatively fast (takes only 20 seconds per epoch on TPUv2 that is\n",
+        "available on Colab). This might make it sounds easy to simply train EfficientNet on any\n",
+        "dataset wanted from scratch. However, training EfficientNet on smaller datasets,\n",
+        "especially those with lower resolution like CIFAR-100, faces the significant challenge of\n",
+        "overfitting.\n",
+        "\n",
+        "Hence training from scratch requires very careful choice of hyperparameters and is\n",
+        "difficult to find suitable regularization. It would also be much more demanding in resources.\n",
+        "Plotting the training and validation accuracy\n",
+        "makes it clear that validation accuracy stagnates at a low value."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "dgnJVHA06XNv",
+        "colab": {}
+      },
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "\n",
+        "def plot_hist(hist):\n",
+        "    plt.plot(hist.history[\"accuracy\"])\n",
+        "    plt.plot(hist.history[\"val_accuracy\"])\n",
+        "    plt.title(\"model accuracy\")\n",
+        "    plt.ylabel(\"accuracy\")\n",
+        "    plt.xlabel(\"epoch\")\n",
+        "    plt.legend([\"train\", \"validation\"], loc=\"upper left\")\n",
+        "    plt.show()\n",
+        "\n",
+        "\n",
+        "plot_hist(hist)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "u0jKQzbc6XNy"
+      },
+      "source": [
+        "## Transfer learning from pre-trained weights\n",
+        "\n",
+        "Here we initialize the model with pre-trained ImageNet weights,\n",
+        "and we fine-tune it on our own dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "5mXgnyOb6XNz",
+        "colab": {}
+      },
+      "source": [
+        "from tensorflow.keras.layers.experimental import preprocessing\n",
+        "\n",
+        "\n",
+        "def build_model(num_classes):\n",
+        "    inputs = layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))\n",
+        "    x = img_augmentation(inputs)\n",
+        "    model = EfficientNetB0(include_top=False, input_tensor=x, weights=\"imagenet\")\n",
+        "\n",
+        "    # Freeze the pretrained weights\n",
+        "    model.trainable = False\n",
+        "\n",
+        "    # Rebuild top\n",
+        "    x = layers.GlobalAveragePooling2D(name=\"avg_pool\")(model.output)\n",
+        "    x = layers.BatchNormalization()(x)\n",
+        "\n",
+        "    top_dropout_rate = 0.2\n",
+        "    x = layers.Dropout(top_dropout_rate, name=\"top_dropout\")(x)\n",
+        "    outputs = layers.Dense(NUM_CLASSES, activation=\"softmax\", name=\"pred\")(x)\n",
+        "\n",
+        "    # Compile\n",
+        "    model = tf.keras.Model(inputs, outputs, name=\"EfficientNet\")\n",
+        "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-2)\n",
+        "    model.compile(\n",
+        "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+        "    )\n",
+        "    return model\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "aFdcpU826XN2"
+      },
+      "source": [
+        "The first step to transfer learning is to freeze all layers and train only the top\n",
+        "layers. For this step, a relatively large learning rate (1e-2) can be used.\n",
+        "Note that validation accuracy and loss will usually be better than training\n",
+        "accuracy and loss. This is because the regularization is strong, which only\n",
+        "suppresses training-time metrics.\n",
+        "\n",
+        "Note that the convergence may take up to 50 epochs depending on choice of learning rate.\n",
+        "If image augmentation layers were not\n",
+        "applied, the validation accuracy may only reach ~60%."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "MjiTeKht6XN2",
+        "colab": {}
+      },
+      "source": [
+        "with strategy.scope():\n",
+        "    model = build_model(num_classes=NUM_CLASSES)\n",
+        "\n",
+        "epochs = 25  # @param {type: \"slider\", min:8, max:80}\n",
+        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
+        "plot_hist(hist)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "e_521nOR6XN7"
+      },
+      "source": [
+        "The second step is to unfreeze a number of layers and fit the model using smaller\n",
+        "learning rate. In this example we show unfreezing all layers, but depending on\n",
+        "specific dataset it may be desireble to only unfreeze a fraction of all layers.\n",
+        "\n",
+        "When the feature extraction with\n",
+        "pretrained model works good enough, this step would give a very limited gain on\n",
+        "validation accuracy. In our case we only see a small improvement,\n",
+        "as ImageNet pretraining already exposed the model to a good amount of dogs.\n",
+        "\n",
+        "On the other hand, when we use pretrained weights on a dataset that is more different\n",
+        "from ImageNet, this fine-tuning step can be crucial as the feature extractor also\n",
+        "needs to be adjusted by a considerable amount. Such a situation can be demonstrated\n",
+        "if choosing CIFAR-100 dataset instead, where fine-tuning boosts validation accuracy\n",
+        "by about 10% to pass 80% on `EfficientNetB0`.\n",
+        "In such a case the convergence may take more than 50 epochs.\n",
+        "\n",
+        "A side note on freezing/unfreezing models: setting `trainable` of a `Model` will\n",
+        "simultaneously set all layers belonging to the `Model` to the same `trainable`\n",
+        "attribute. Each layer is trainable only if both the layer itself and the model\n",
+        "containing it are trainable. Hence when we need to partially freeze/unfreeze\n",
+        "a model, we need to make sure the `trainable` attribute of the model is set\n",
+        "to `True`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "EIkSxkXP6XN8",
+        "colab": {}
+      },
+      "source": [
+        "\n",
+        "def unfreeze_model(model):\n",
+        "    # We unfreeze the top 20 layers while leaving BatchNorm layers frozen\n",
+        "    for layer in model.layers[-20:]:\n",
+        "        if not isinstance(layer, layers.BatchNormalization):\n",
+        "            layer.trainable = True\n",
+        "\n",
+        "    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-4)\n",
+        "    model.compile(\n",
+        "        optimizer=optimizer, loss=\"categorical_crossentropy\", metrics=[\"accuracy\"]\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "unfreeze_model(model)\n",
+        "\n",
+        "epochs = 10  # @param {type: \"slider\", min:8, max:50}\n",
+        "hist = model.fit(ds_train, epochs=epochs, validation_data=ds_test, verbose=2)\n",
+        "plot_hist(hist)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "wt4CoBb86XN_"
+      },
+      "source": [
+        "### Tips for fine tuning EfficientNet\n",
+        "\n",
+        "On unfreezing layers:\n",
+        "\n",
+        "- The `BathcNormalization` layers need to be kept frozen\n",
+        "([more details](https://keras.io/guides/transfer_learning/)).\n",
+        "If they are also turned to trainable, the\n",
+        "first epoch after unfreezing will significantly reduce accuracy.\n",
+        "- In some cases it may be beneficial to open up only a portion of layers instead of\n",
+        "unfreezing all. This will make fine tuning much faster when going to larger models like\n",
+        "B7.\n",
+        "- Each block needs to be all turned on or off. This is because the architecture includes\n",
+        "a shortcut from the first layer to the last layer for each block. Not respecting blocks\n",
+        "also significantly harms the final performance.\n",
+        "\n",
+        "Some other tips for utilizing EfficientNet:\n",
+        "\n",
+        "- Larger variants of EfficientNet do not guarantee improved performance, especially for\n",
+        "tasks with less data or fewer classes. In such a case, the larger variant of EfficientNet\n",
+        "chosen, the harder it is to tune hyperparameters.\n",
+        "- EMA (Exponential Moving Average) is very helpful in training EfficientNet from scratch,\n",
+        "but not so much for transfer learning.\n",
+        "- Do not use the RMSprop setup as in the original paper for transfer learning. The\n",
+        "momentum and learning rate are too high for transfer learning. It will easily corrupt the\n",
+        "pretrained weight and blow up the loss. A quick check is to see if loss (as categorical\n",
+        "cross entropy) is getting significantly larger than log(NUM_CLASSES) after the same\n",
+        "epoch. If so, the initial learning rate/momentum is too high.\n",
+        "- Smaller batch size benefit validation accuracy, possibly due to effectively providing\n",
+        "regularization.\n",
+        "\n",
+        "## Using the latest EfficientNet weights\n",
+        "\n",
+        "Since the initial paper, the EfficientNet has been improved by various methods for data\n",
+        "preprocessing and for using unlabelled data to enhance learning results. These\n",
+        "improvements are relatively hard and computationally costly to reproduce, and require\n",
+        "extra code; but the weights are readily available in the form of TF checkpoint files. The\n",
+        "model architecture has not changed, so loading the improved checkpoints is possible.\n",
+        "\n",
+        "To use a checkpoint provided at\n",
+        "[the official model repository](https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet), first\n",
+        "download the checkpoint. As example, here we download noisy-student version of B1:\n",
+        "\n",
+        "```\n",
+        "!wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet\\\n",
+        "       /noisystudent/noisy_student_efficientnet-b1.tar.gz\n",
+        "!tar -xf noisy_student_efficientnet-b1.tar.gz\n",
+        "```\n",
+        "\n",
+        "Then use the script [efficientnet_weight_update_util.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/efficientnet_weight_update_util.py) to convert ckpt file to h5 file.\n",
+        "\n",
+        "```\n",
+        "!python efficientnet_weight_update_util.py --model b1 --notop --ckpt \\\n",
+        "        efficientnet-b1/model.ckpt --o efficientnetb1_notop.h5\n",
+        "```\n",
+        "\n",
+        "When creating model, use the following to load new weight:\n",
+        "\n",
+        "```python\n",
+        "model = EfficientNetB1(weights=\"efficientnetb1_notop.h5\", include_top=False)\n",
+        "```"
+      ]
+    }
+  ]
 }

--- a/examples/vision/md/image_classification_efficientnet_fine_tuning.md
+++ b/examples/vision/md/image_classification_efficientnet_fine_tuning.md
@@ -720,8 +720,7 @@ download the checkpoint. As example, here we download noisy-student version of B
 !tar -xf noisy_student_efficientnet-b1.tar.gz
 ```
 
-Then use the script efficientnet_weight_update_util.py to convert ckpt file to h5 file.
-
+Then use the script [efficientnet_weight_update_util.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/applications/efficientnet_weight_update_util.py) to convert ckpt file to h5 file.
 ```
 !python efficientnet_weight_update_util.py --model b1 --notop --ckpt \
         efficientnet-b1/model.ckpt --o efficientnetb1_notop.h5
@@ -730,5 +729,5 @@ Then use the script efficientnet_weight_update_util.py to convert ckpt file to h
 When creating model, use the following to load new weight:
 
 ```python
-model = EfficientNetB0(weights="efficientnetb1_notop.h5", include_top=False)
+model = EfficientNetB1(weights="efficientnetb1_notop.h5", include_top=False)
 ```


### PR DESCRIPTION
With reference to the [EfficientNet tutorial](https://keras.io/examples/vision/image_classification_efficientnet_fine_tuning/) the last line tries to load B1 weights into B0 which results in incompatibility problems. Additionally, I think it would be useful to just provide a link to the `efficientnet_weight_update_util.py` since[ it does not come with the standard installation](https://github.com/tensorflow/tensorflow/pull/40621#issuecomment-697340955). 

This PR address the above pointers. 