### PR TITLE
Normalize headings in preprocessing guide.

### DIFF
--- a/guides/ipynb/preprocessing_layers.ipynb
+++ b/guides/ipynb/preprocessing_layers.ipynb
@@ -376,7 +376,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Encoding string categorical features via one-hot encoding"
+    "### Encoding string categorical features via one-hot encoding"
    ]
   },
   {
@@ -474,7 +474,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Applying the hashing trick to an integer categorical feature\n",
+    "### Applying the hashing trick to an integer categorical feature\n",
     "\n",
     "If you have a categorical feature that can take many different values (on the order of\n",
     "10e3 or higher), where each value only appears a few times in the data,\n",
@@ -510,7 +510,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Encoding text as a sequence of token indices\n",
+    "### Encoding text as a sequence of token indices\n",
     "\n",
     "This is how you should preprocess text to be passed to an `Embedding` layer."
    ]
@@ -574,7 +574,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Encoding text as a dense matrix of ngrams with multi-hot encoding\n",
+    "### Encoding text as a dense matrix of ngrams with multi-hot encoding\n",
     "\n",
     "This is how you should preprocess text to be passed to a `Dense` layer."
    ]
@@ -619,7 +619,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Encoding text as a dense matrix of ngrams with TF-IDF weighting\n",
+    "### Encoding text as a dense matrix of ngrams with TF-IDF weighting\n",
     "\n",
     "This is an alternative way of preprocessing text before passing it to a `Dense` layer."
    ]

--- a/guides/md/preprocessing_layers.md
+++ b/guides/md/preprocessing_layers.md
@@ -303,14 +303,16 @@ model.fit(x_train, y_train)
 
 <div class="k-default-codeblock">
 ```
-1563/1563 [==============================] - 1s 687us/step - loss: 2.1805
+A local file was found, but it seems to be incomplete or outdated because the auto file hash does not match the original value of 6d958be074577803d12ecdefd02955f39262c83c16fe9348329d7fe0b5c001ce so we will re-download the data.
+Downloading data from https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+170500096/170498071 [==============================] - 283s 2us/step
+1563/1563 [==============================] - 3s 2ms/step - loss: 2.1234
 
-<tensorflow.python.keras.callbacks.History at 0x154d5c490>
+<tensorflow.python.keras.callbacks.History at 0x7ff7d44f8040>
 
 ```
 </div>
----
-## Encoding string categorical features via one-hot encoding
+### Encoding string categorical features via one-hot encoding
 
 
 ```python
@@ -392,8 +394,7 @@ constructor arguments  of `IntegerLookup`.
 You can see the `IntegerLookup` and `CategoryEncoding` layers in action in the example
 [structured data classification from scratch](https://keras.io/examples/structured_data/structured_data_classification_from_scratch/).
 
----
-## Applying the hashing trick to an integer categorical feature
+### Applying the hashing trick to an integer categorical feature
 
 If you have a categorical feature that can take many different values (on the order of
 10e3 or higher), where each value only appears a few times in the data,
@@ -422,8 +423,7 @@ print(encoded_data.shape)
 
 ```
 </div>
----
-## Encoding text as a sequence of token indices
+### Encoding text as a sequence of token indices
 
 This is how you should preprocess text to be passed to an `Embedding` layer.
 
@@ -473,8 +473,7 @@ Note that when training such a model, for best performance, you should
 use the `TextVectorization` layer as part of the input pipeline (which is what we
 do in the text classification example above).
 
----
-## Encoding text as a dense matrix of ngrams with multi-hot encoding
+### Encoding text as a dense matrix of ngrams with multi-hot encoding
 
 This is how you should preprocess text to be passed to a `Dense` layer.
 
@@ -506,8 +505,7 @@ test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
 ```
 
----
-## Encoding text as a dense matrix of ngrams with TF-IDF weighting
+### Encoding text as a dense matrix of ngrams with TF-IDF weighting
 
 This is an alternative way of preprocessing text before passing it to a `Dense` layer.
 

--- a/guides/preprocessing_layers.py
+++ b/guides/preprocessing_layers.py
@@ -269,7 +269,7 @@ model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
 model.fit(x_train, y_train)
 
 """
-## Encoding string categorical features via one-hot encoding
+### Encoding string categorical features via one-hot encoding
 """
 
 # Define some toy data
@@ -329,7 +329,7 @@ You can see the `IntegerLookup` and `CategoryEncoding` layers in action in the e
 """
 
 """
-## Applying the hashing trick to an integer categorical feature
+### Applying the hashing trick to an integer categorical feature
 
 If you have a categorical feature that can take many different values (on the order of
 10e3 or higher), where each value only appears a few times in the data,
@@ -351,7 +351,7 @@ encoded_data = encoder(hasher(data))
 print(encoded_data.shape)
 
 """
-## Encoding text as a sequence of token indices
+### Encoding text as a sequence of token indices
 
 This is how you should preprocess text to be passed to an `Embedding` layer.
 """
@@ -396,7 +396,7 @@ do in the text classification example above).
 """
 
 """
-## Encoding text as a dense matrix of ngrams with multi-hot encoding
+### Encoding text as a dense matrix of ngrams with multi-hot encoding
 
 This is how you should preprocess text to be passed to a `Dense` layer.
 """
@@ -427,7 +427,7 @@ test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
 
 """
-## Encoding text as a dense matrix of ngrams with TF-IDF weighting
+### Encoding text as a dense matrix of ngrams with TF-IDF weighting
 
 This is an alternative way of preprocessing text before passing it to a `Dense` layer.
 """

--- a/tf/preprocessing_layers.ipynb
+++ b/tf/preprocessing_layers.ipynb
@@ -445,7 +445,7 @@
     "id": "z6a3gJL7tMbS"
    },
    "source": [
-    "## Encoding string categorical features via one-hot encoding"
+    "### Encoding string categorical features via one-hot encoding"
    ]
   },
   {
@@ -549,7 +549,7 @@
     "id": "Kpkz20kZeqTD"
    },
    "source": [
-    "## Applying the hashing trick to an integer categorical feature\n",
+    "### Applying the hashing trick to an integer categorical feature\n",
     "\n",
     "If you have a categorical feature that can take many different values (on the order of\n",
     "10e3 or higher), where each value only appears a few times in the data,\n",
@@ -587,7 +587,7 @@
     "id": "Vz0SkEM1JusG"
    },
    "source": [
-    "## Encoding text as a sequence of token indices\n",
+    "### Encoding text as a sequence of token indices\n",
     "\n",
     "This is how you should preprocess text to be passed to an `Embedding` layer."
    ]
@@ -654,7 +654,7 @@
     "id": "eoaxL82yXTe8"
    },
    "source": [
-    "## Encoding text as a dense matrix of ngrams with multi-hot encoding\n",
+    "### Encoding text as a dense matrix of ngrams with multi-hot encoding\n",
     "\n",
     "This is how you should preprocess text to be passed to a `Dense` layer."
    ]
@@ -701,7 +701,7 @@
     "id": "qUsUte9T1UAa"
    },
    "source": [
-    "## Encoding text as a dense matrix of ngrams with TF-IDF weighting\n",
+    "### Encoding text as a dense matrix of ngrams with TF-IDF weighting\n",
     "\n",
     "This is an alternative way of preprocessing text before passing it to a `Dense` layer."
    ]


### PR DESCRIPTION
See the [right side TOC](https://www.tensorflow.org/guide/keras/preprocessing_layers), everything under "quick recipes" should be H3s.

```
python autogen.py generate_tf_guides preprocessing_layers.py
python autogen.py add_guide preprocessing_layers.py
```