### PR TITLE
Show the encoded text in the preprocessing guide

### DIFF
--- a/guides/ipynb/preprocessing_layers.ipynb
+++ b/guides/ipynb/preprocessing_layers.ipynb
@@ -602,6 +602,12 @@
     "# Index the bigrams via `adapt()`\n",
     "text_vectorizer.adapt(data)\n",
     "\n",
+    "print(\n",
+    "    \"Encoded text:\\n\",\n",
+    "    text_vectorizer([\"The Brain is deeper than the sea\"]).numpy(),\n",
+    "    \"\\n\",\n",
+    ")\n",
+    "\n",
     "# Create a Dense model\n",
     "inputs = keras.Input(shape=(1,), dtype=\"string\")\n",
     "x = text_vectorizer(inputs)\n",
@@ -610,7 +616,9 @@
     "\n",
     "# Call the model on test data (which includes unknown tokens)\n",
     "test_data = tf.constant([\"The Brain is deeper than the sea\"])\n",
-    "test_output = model(test_data)"
+    "test_output = model(test_data)\n",
+    "\n",
+    "print(\"Model output:\", test_output)"
    ]
   },
   {
@@ -647,6 +655,12 @@
     "# Index the bigrams and learn the TF-IDF weights via `adapt()`\n",
     "text_vectorizer.adapt(data)\n",
     "\n",
+    "print(\n",
+    "    \"Encoded text:\\n\",\n",
+    "    text_vectorizer([\"The Brain is deeper than the sea\"]).numpy(),\n",
+    "    \"\\n\",\n",
+    ")\n",
+    "\n",
     "# Create a Dense model\n",
     "inputs = keras.Input(shape=(1,), dtype=\"string\")\n",
     "x = text_vectorizer(inputs)\n",
@@ -655,7 +669,8 @@
     "\n",
     "# Call the model on test data (which includes unknown tokens)\n",
     "test_data = tf.constant([\"The Brain is deeper than the sea\"])\n",
-    "test_output = model(test_data)"
+    "test_output = model(test_data)\n",
+    "print(\"Model output:\", test_output)"
    ]
   }
  ],

--- a/guides/md/preprocessing_layers.md
+++ b/guides/md/preprocessing_layers.md
@@ -303,11 +303,9 @@ model.fit(x_train, y_train)
 
 <div class="k-default-codeblock">
 ```
-Downloading data from https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
-170500096/170498071 [==============================] - 283s 2us/step
-1563/1563 [==============================] - 3s 2ms/step - loss: 2.1234
+1563/1563 [==============================] - 4s 2ms/step - loss: 2.1193
 
-<tensorflow.python.keras.callbacks.History at 0x7ff7d44f8040>
+<tensorflow.python.keras.callbacks.History at 0x7f5b1409a250>
 
 ```
 </div>
@@ -493,6 +491,12 @@ text_vectorizer = preprocessing.TextVectorization(output_mode="binary", ngrams=2
 # Index the bigrams via `adapt()`
 text_vectorizer.adapt(data)
 
+print(
+    "Encoded text:\n",
+    text_vectorizer(["The Brain is deeper than the sea"]).numpy(),
+    "\n",
+)
+
 # Create a Dense model
 inputs = keras.Input(shape=(1,), dtype="string")
 x = text_vectorizer(inputs)
@@ -502,8 +506,24 @@ model = keras.Model(inputs, outputs)
 # Call the model on test data (which includes unknown tokens)
 test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
+
+print("Model output:", test_output)
 ```
 
+<div class="k-default-codeblock">
+```
+Encoded text:
+ [[1. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 1. 1. 0. 0. 0. 0. 0.
+  0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 1. 1. 0. 0. 0.]] 
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Model output: tf.Tensor([[0.8250091]], shape=(1, 1), dtype=float32)
+
+```
+</div>
 ### Encoding text as a dense matrix of ngrams with TF-IDF weighting
 
 This is an alternative way of preprocessing text before passing it to a `Dense` layer.
@@ -525,6 +545,12 @@ text_vectorizer = preprocessing.TextVectorization(output_mode="tf-idf", ngrams=2
 # Index the bigrams and learn the TF-IDF weights via `adapt()`
 text_vectorizer.adapt(data)
 
+print(
+    "Encoded text:\n",
+    text_vectorizer(["The Brain is deeper than the sea"]).numpy(),
+    "\n",
+)
+
 # Create a Dense model
 inputs = keras.Input(shape=(1,), dtype="string")
 x = text_vectorizer(inputs)
@@ -534,4 +560,24 @@ model = keras.Model(inputs, outputs)
 # Call the model on test data (which includes unknown tokens)
 test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
+print("Model output:", test_output)
 ```
+
+<div class="k-default-codeblock">
+```
+Encoded text:
+ [[8.04719   1.6945957 0.        0.        0.        0.        0.
+  0.        0.        0.        0.        0.        0.        0.
+  0.        0.        1.0986123 1.0986123 1.0986123 0.        0.
+  0.        0.        0.        0.        0.        0.        0.
+  1.0986123 0.        0.        0.        0.        0.        0.
+  0.        1.0986123 1.0986123 0.        0.        0.       ]] 
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Model output: tf.Tensor([[-2.3685102]], shape=(1, 1), dtype=float32)
+
+```
+</div>

--- a/guides/preprocessing_layers.py
+++ b/guides/preprocessing_layers.py
@@ -416,6 +416,12 @@ text_vectorizer = preprocessing.TextVectorization(output_mode="binary", ngrams=2
 # Index the bigrams via `adapt()`
 text_vectorizer.adapt(data)
 
+print(
+    "Encoded text:\n",
+    text_vectorizer(["The Brain is deeper than the sea"]).numpy(),
+    "\n",
+)
+
 # Create a Dense model
 inputs = keras.Input(shape=(1,), dtype="string")
 x = text_vectorizer(inputs)
@@ -425,6 +431,8 @@ model = keras.Model(inputs, outputs)
 # Call the model on test data (which includes unknown tokens)
 test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
+
+print("Model output:", test_output)
 
 """
 ### Encoding text as a dense matrix of ngrams with TF-IDF weighting
@@ -447,6 +455,12 @@ text_vectorizer = preprocessing.TextVectorization(output_mode="tf-idf", ngrams=2
 # Index the bigrams and learn the TF-IDF weights via `adapt()`
 text_vectorizer.adapt(data)
 
+print(
+    "Encoded text:\n",
+    text_vectorizer(["The Brain is deeper than the sea"]).numpy(),
+    "\n",
+)
+
 # Create a Dense model
 inputs = keras.Input(shape=(1,), dtype="string")
 x = text_vectorizer(inputs)
@@ -456,3 +470,4 @@ model = keras.Model(inputs, outputs)
 # Call the model on test data (which includes unknown tokens)
 test_data = tf.constant(["The Brain is deeper than the sea"])
 test_output = model(test_data)
+print("Model output:", test_output)

--- a/tf/preprocessing_layers.ipynb
+++ b/tf/preprocessing_layers.ipynb
@@ -683,6 +683,12 @@
     "# Index the bigrams via `adapt()`\n",
     "text_vectorizer.adapt(data)\n",
     "\n",
+    "print(\n",
+    "    \"Encoded text:\\n\",\n",
+    "    text_vectorizer([\"The Brain is deeper than the sea\"]).numpy(),\n",
+    "    \"\\n\",\n",
+    ")\n",
+    "\n",
     "# Create a Dense model\n",
     "inputs = keras.Input(shape=(1,), dtype=\"string\")\n",
     "x = text_vectorizer(inputs)\n",
@@ -691,7 +697,9 @@
     "\n",
     "# Call the model on test data (which includes unknown tokens)\n",
     "test_data = tf.constant([\"The Brain is deeper than the sea\"])\n",
-    "test_output = model(test_data)"
+    "test_output = model(test_data)\n",
+    "\n",
+    "print(\"Model output:\", test_output)"
    ]
   },
   {
@@ -730,6 +738,12 @@
     "# Index the bigrams and learn the TF-IDF weights via `adapt()`\n",
     "text_vectorizer.adapt(data)\n",
     "\n",
+    "print(\n",
+    "    \"Encoded text:\\n\",\n",
+    "    text_vectorizer([\"The Brain is deeper than the sea\"]).numpy(),\n",
+    "    \"\\n\",\n",
+    ")\n",
+    "\n",
     "# Create a Dense model\n",
     "inputs = keras.Input(shape=(1,), dtype=\"string\")\n",
     "x = text_vectorizer(inputs)\n",
@@ -738,7 +752,8 @@
     "\n",
     "# Call the model on test data (which includes unknown tokens)\n",
     "test_data = tf.constant([\"The Brain is deeper than the sea\"])\n",
-    "test_output = model(test_data)"
+    "test_output = model(test_data)\n",
+    "print(\"Model output:\", test_output)"
    ]
   }
  ],


### PR DESCRIPTION
Show the encoded text in the last two examples of the preprocessing guide.

Requested by @yashk2810 

Regenerated dependent files:
```
python autogen.py generate_tf_guides
python autogen.py add_guide preprocessing_layers.py
```