### PR TITLE
Correcting filter size typo

### DIFF
--- a/examples/generative/cyclegan.py
+++ b/examples/generative/cyclegan.py
@@ -542,7 +542,7 @@ class GANMonitor(keras.callbacks.Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         _, ax = plt.subplots(4, 2, figsize=(12, 12))
-        for i, img in enumerate(test_horses.take(4)):
+        for i, img in enumerate(test_horses.take(self.num_img)):
             prediction = self.model.gen_G(img)[0].numpy()
             prediction = (prediction * 127.5 + 127.5).astype(np.uint8)
             img = (img[0] * 127.5 + 127.5).numpy().astype(np.uint8)

--- a/examples/generative/cyclegan.py
+++ b/examples/generative/cyclegan.py
@@ -281,7 +281,7 @@ R256 ====|
 u128 ====|
          |-> 2 upsampling blocks
 u64  ====|
-c7s1-3 => Last conv block with `tanh` activation, filter size of 1.
+c7s1-3 => Last conv block with `tanh` activation, filter size of 7.
 ```
 """
 

--- a/examples/generative/ipynb/cyclegan.ipynb
+++ b/examples/generative/ipynb/cyclegan.ipynb
@@ -369,7 +369,7 @@
     "u128 ====|\n",
     "         |-> 2 upsampling blocks\n",
     "u64  ====|\n",
-    "c7s1-3 => Last conv block with `tanh` activation, filter size of 1.\n",
+    "c7s1-3 => Last conv block with `tanh` activation, filter size of 7.\n",
     "```"
    ]
   },
@@ -680,7 +680,7 @@
     "\n",
     "    def on_epoch_end(self, epoch, logs=None):\n",
     "        _, ax = plt.subplots(4, 2, figsize=(12, 12))\n",
-    "        for i, img in enumerate(test_horses.take(4)):\n",
+    "        for i, img in enumerate(test_horses.take(self.num_img)):\n",
     "            prediction = self.model.gen_G(img)[0].numpy()\n",
     "            prediction = (prediction * 127.5 + 127.5).astype(np.uint8)\n",
     "            img = (img[0] * 127.5 + 127.5).numpy().astype(np.uint8)\n",

--- a/examples/generative/md/cyclegan.md
+++ b/examples/generative/md/cyclegan.md
@@ -298,7 +298,7 @@ R256 ====|
 u128 ====|
          |-> 2 upsampling blocks
 u64  ====|
-c7s1-3 => Last conv block with `tanh` activation, filter size of 1.
+c7s1-3 => Last conv block with `tanh` activation, filter size of 7.
 ```
 
 
@@ -566,7 +566,7 @@ class GANMonitor(keras.callbacks.Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         _, ax = plt.subplots(4, 2, figsize=(12, 12))
-        for i, img in enumerate(test_horses.take(4)):
+        for i, img in enumerate(test_horses.take(self.num_img)):
             prediction = self.model.gen_G(img)[0].numpy()
             prediction = (prediction * 127.5 + 127.5).astype(np.uint8)
             img = (img[0] * 127.5 + 127.5).numpy().astype(np.uint8)


### PR DESCRIPTION
At the "Build the generators" the last layer is said to have `filter size of 1` but actually, it also has `filter size of 7` as the first layer, what may have caused the type is that it has `stride size of 1`.

Also the code implementation is used `filter size of 7`.