### PR TITLE
Fixed typo in serialization and saving

### DIFF
--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -162,7 +162,7 @@ See the section about [Custom objects](save_and_serialize.ipynb#custom-objects)
 for more information.
 
 Below is an example of what happens when loading custom layers from
-he SavedModel format **without** overwriting the config methods.
+the SavedModel format **without** overwriting the config methods.
 """
 
 


### PR DESCRIPTION
Very small PR to fix a typo from `he` to `the`