### PR TITLE
Fix: Plot of Data Augmentation example shows wrong labels

### DIFF
--- a/guides/transfer_learning.py
+++ b/guides/transfer_learning.py
@@ -497,7 +497,7 @@ for images, labels in train_ds.take(1):
             tf.expand_dims(first_image, 0), training=True
         )
         plt.imshow(augmented_image[0].numpy().astype("int32"))
-        plt.title(int(labels[i]))
+        plt.title(int(labels[0]))
         plt.axis("off")
 
 """


### PR DESCRIPTION
Plot of (Dog)[ Data Augmentation example](https://keras.io/guides/transfer_learning/#standardizing-the-data) shows wrong labels (label 0 and 1) although label 1 (for dog) should be present only.