### PR TITLE
Fixed section heading in transfer_learning.py

### DIFF
--- a/guides/ipynb/transfer_learning.ipynb
+++ b/guides/ipynb/transfer_learning.ipynb
@@ -489,8 +489,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs\n",
-    " dataset\n",
+    "## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs dataset\n",
     "\n",
     "To solidify these concepts, let's walk you through a concrete end-to-end transfer\n",
     "learning & fine-tuning example. We will load the Xception model, pre-trained on\n",

--- a/guides/md/transfer_learning.md
+++ b/guides/md/transfer_learning.md
@@ -415,8 +415,7 @@ Likewise for fine-tuning.
 
 
 ---
-## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs
- dataset
+## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs dataset
 
 To solidify these concepts, let's walk you through a concrete end-to-end transfer
 learning & fine-tuning example. We will load the Xception model, pre-trained on

--- a/guides/transfer_learning.py
+++ b/guides/transfer_learning.py
@@ -364,8 +364,7 @@ Likewise for fine-tuning.
 """
 
 """
-## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs
- dataset
+## An end-to-end example: fine-tuning an image classification model on a cats vs. dogs dataset
 
 To solidify these concepts, let's walk you through a concrete end-to-end transfer
 learning & fine-tuning example. We will load the Xception model, pre-trained on


### PR DESCRIPTION
Fixed an error in a heading which made some part of it get displayed on a new line (without the ## format).