### PR TITLE
Update serialization_and_saving.py

### DIFF
--- a/guides/ipynb/serialization_and_saving.ipynb
+++ b/guides/ipynb/serialization_and_saving.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "- The model's architecture/config\n",
     "- The model's weight values (which were learned during training)\n",
-    "- The model's compilation information (if `compile()`) was called\n",
+    "- The model's compilation information (if `compile()` was called)\n",
     "- The optimizer and its state, if any (this enables you to restart training\n",
     "where you left)\n",
     "\n",
@@ -825,7 +825,7 @@
     "layer_1 = create_layer()\n",
     "layer_2 = create_layer()\n",
     "\n",
-    "# Copy weights from layer 2 to layer 1\n",
+    "# Copy weights from layer 1 to layer 2\n",
     "layer_2.set_weights(layer_1.get_weights())"
    ]
   },

--- a/guides/md/serialization_and_saving.md
+++ b/guides/md/serialization_and_saving.md
@@ -71,7 +71,7 @@ You can save an entire model to a single artifact. It will include:
 
 - The model's architecture/config
 - The model's weight values (which were learned during training)
-- The model's compilation information (if `compile()`) was called
+- The model's compilation information (if `compile()` was called)
 - The optimizer and its state, if any (this enables you to restart training
 where you left)
 
@@ -608,7 +608,7 @@ def create_layer():
 layer_1 = create_layer()
 layer_2 = create_layer()
 
-# Copy weights from layer 2 to layer 1
+# Copy weights from layer 1 to layer 2
 layer_2.set_weights(layer_1.get_weights())
 ```
 

--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -67,7 +67,7 @@ You can save an entire model to a single artifact. It will include:
 
 - The model's architecture/config
 - The model's weight values (which were learned during training)
-- The model's compilation information (if `compile()`) was called
+- The model's compilation information (if `compile()` was called)
 - The optimizer and its state, if any (this enables you to restart training
 where you left)
 
@@ -575,7 +575,7 @@ def create_layer():
 layer_1 = create_layer()
 layer_2 = create_layer()
 
-# Copy weights from layer 2 to layer 1
+# Copy weights from layer 1 to layer 2
 layer_2.set_weights(layer_1.get_weights())
 
 """


### PR DESCRIPTION
1. Trivial bracket typo.
2. Changed the order.
3. I can see the sentence 'Below is an example of ... from he SavedModel format without overwriting the config methods.' on the page, but somehow I can't find it in the sourcecode. Hope 'he -> the'.

I read it many times, it's been a great help!
So I can resume the training from the where I left even it's a subclassed model with a lot of custom-layers and a bunch of compilation information, if I use the SavedFormat and define the `get_config()`?