### PR TITLE
[TF issue #27120] Clarify usage of Keras models and Keras optimizers with TensorFlow Functions

### DIFF
--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -2,7 +2,7 @@
 Title: Writing a training loop from scratch
 Author: [fchollet](https://twitter.com/fchollet)
 Date created: 2019/03/01
-Last modified: 2020/04/15
+Last modified: 2020/12/15
 Description: Complete guide to writing low-level training & evaluation loops.
 """
 """
@@ -292,6 +292,12 @@ for epoch in range(epochs):
 
 """
 Much faster, isn't it?
+
+Caution: Note how `x` and `y` are the only arguments passed into `train_step`. 
+Passing in Keras optimizers or Keras models to functions that are decorated with
+`tf.function` may lead to an error. If you would like to call `train_step` with
+a new optimizer or new model, it is recommended to retrace the `train_step` or
+create a new `tf.function`-decorated training loop for that model or optimizer.
 """
 
 """

--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -295,7 +295,8 @@ Much faster, isn't it?
 
 Caution: Note how `x` and `y` are the only arguments passed into `train_step`. 
 Passing in Keras optimizers or Keras models to functions that are decorated with
-`tf.function` may lead to an error. If you would like to call `train_step` with
+`tf.function` may lead to `ValueError: tf.function-decorated function tried to
+create variables on non-first call`. If you would like to call `train_step` with
 a new optimizer or new model, it is recommended to retrace the `train_step` or
 create a new `tf.function`-decorated training loop for that model or optimizer.
 """

--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -297,9 +297,9 @@ Caution: Note how `x` and `y` are the only arguments passed into `train_step`.
 Passing in Keras optimizers or Keras models to functions that are decorated with
 `tf.function` may lead to `ValueError: tf.function-decorated function tried to
 create variables on non-first call`. If you see this error, you are most likely
-using the same traced graph with a new optimizer or new model. In this case, you
-should retrace the `train_step` or create a new `tf.function`-decorated training
-loop for that model or optimizer.
+trying to pass in a new optimizer or new model to the same graph. In this case,
+you should force retracing of the `train_step` or create a new 
+`tf.function`-decorated training loop for that model or optimizer.
 """
 
 """

--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -296,9 +296,10 @@ Much faster, isn't it?
 Caution: Note how `x` and `y` are the only arguments passed into `train_step`. 
 Passing in Keras optimizers or Keras models to functions that are decorated with
 `tf.function` may lead to `ValueError: tf.function-decorated function tried to
-create variables on non-first call`. If you would like to call `train_step` with
-a new optimizer or new model, it is recommended to retrace the `train_step` or
-create a new `tf.function`-decorated training loop for that model or optimizer.
+create variables on non-first call`. If you see this error, you are most likely
+using the same traced graph with a new optimizer or new model. In this case, you
+should retrace the `train_step` or create a new `tf.function`-decorated training
+loop for that model or optimizer.
 """
 
 """


### PR DESCRIPTION
This commit clarifies documentation in https://www.tensorflow.org/guide/keras/writing_a_training_loop_from_scratch#speeding-up_your_training_step_with_tffunction
about a common user pattern of passing in Keras optimizers or Keras models as arguments into a tf.function-decorated custom training loop. Confusion regarding this pattern is documented in https://github.com/tensorflow/tensorflow/issues/27120. 

