### PR TITLE
Fix model subclassing guide link

### DIFF
--- a/templates/api/models/index.md
+++ b/templates/api/models/index.md
@@ -6,7 +6,7 @@ There are three ways to create Keras models:
     but is limited to single-input, single-output stacks of layers (as the name gives away).
 - The [Functional API](/guides/functional_api), which is an easy-to-use, fully-featured API that supports arbitrary model architectures.
     For most people and most use cases, this is what you should be using. This is the Keras "industry strength" model.
-- [Model subclassing](/guides/model_subclassing), where you implement everything from scratch on your own.
+- [Model subclassing](/guides/making_new_layers_and_models_via_subclassing), where you implement everything from scratch on your own.
     Use this if you have complex, out-of-the-box research use cases.
 
 


### PR DESCRIPTION
This PR updates the guide slug used in the `api/models` page in order to redirect to an existing page.
Indeed, it looks like the `model_subclassing` guide does not exist anymore and causes a 404.