### PR TITLE
Minor correction to SupervisedContrastiveLoss

### DIFF
--- a/examples/vision/ipynb/supervised-contrastive-learning.ipynb
+++ b/examples/vision/ipynb/supervised-contrastive-learning.ipynb
@@ -279,7 +279,7 @@
     "            tf.matmul(\n",
     "                feature_vectors_normalized, tf.transpose(feature_vectors_normalized)\n",
     "            ),\n",
-    "            temperature,\n",
+    "            self.temperature,\n",
     "        )\n",
     "        return tfa.losses.npairs_loss(tf.squeeze(labels), logits)\n",
     "\n",

--- a/examples/vision/md/supervised-contrastive-learning.md
+++ b/examples/vision/md/supervised-contrastive-learning.md
@@ -299,7 +299,7 @@ class SupervisedContrastiveLoss(keras.losses.Loss):
             tf.matmul(
                 feature_vectors_normalized, tf.transpose(feature_vectors_normalized)
             ),
-            temperature,
+            self.temperature,
         )
         return tfa.losses.npairs_loss(tf.squeeze(labels), logits)
 

--- a/examples/vision/supervised-contrastive-learning.py
+++ b/examples/vision/supervised-contrastive-learning.py
@@ -174,7 +174,7 @@ class SupervisedContrastiveLoss(keras.losses.Loss):
             tf.matmul(
                 feature_vectors_normalized, tf.transpose(feature_vectors_normalized)
             ),
-            temperature,
+            self.temperature,
         )
         return tfa.losses.npairs_loss(tf.squeeze(labels), logits)
 


### PR DESCRIPTION
Minor correction : in the SupervisedContrastiveLoss class, the logits should use the temperature class attribute instead of the global variable.