### PR TITLE
Speech recognition example - sequence to sequence using transformer

### DIFF
--- a/examples/audio/ipynb/transformer_asr.ipynb
+++ b/examples/audio/ipynb/transformer_asr.ipynb
@@ -1,0 +1,722 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Automatic Speech Recognition with Transformer\n",
+    "\n",
+    "**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>\n",
+    "**Date created:** 2021/01/13<br>\n",
+    "**Last modified:** 2021/01/13<br>\n",
+    "**Description:** Training a sequence-to-sequence Transformer for automatic speech recognition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Automatic speech recognition (ASR) consists of transcribing audio speech segments into text.\n",
+    "ASR can be treated as a sequence-to-sequence problem, where the\n",
+    "audio can be represented as a sequence of feature vectors\n",
+    "and the text as a sequence of characters, words, or subword tokens.\n",
+    "\n",
+    "For this demonstration, we will use the LJSpeech dataset from the\n",
+    "[LibriVox](https://librivox.org/) project. It consists of short\n",
+    "audio clips of a single speaker reading passages from 7 non-fiction books.\n",
+    "Our model will be similar to the original Transformer (both encoder and decoder)\n",
+    "as proposed in the paper, \"Attention is All You Need\".\n",
+    "\n",
+    "\n",
+    "**References:**\n",
+    "\n",
+    "- [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)\n",
+    "- [Very Deep Self-Attention Networks for End-to-End Speech Recognition](https://arxiv.org/pdf/1904.13377.pdf)\n",
+    "- [Speech Transformers](https://ieeexplore.ieee.org/document/8462506)\n",
+    "- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "import os\n",
+    "import random\n",
+    "from glob import glob\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Define the Transformer Input Layer\n",
+    "\n",
+    "When processing past target tokens for the decoder, we compute the sum of\n",
+    "position embeddings and token embeddings.\n",
+    "\n",
+    "When processing audio features, we apply convolutional layers to downsample\n",
+    "them (via convolution stides) and process local relationships."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TokenEmbedding(layers.Layer):\n",
+    "    def __init__(self, num_vocab=1000, maxlen=100, num_hid=64):\n",
+    "        super().__init__()\n",
+    "        self.emb = tf.keras.layers.Embedding(num_vocab, num_hid)\n",
+    "        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        maxlen = tf.shape(x)[-1]\n",
+    "        x = self.emb(x)\n",
+    "        positions = tf.range(start=0, limit=maxlen, delta=1)\n",
+    "        positions = self.pos_emb(positions)\n",
+    "        return x + positions\n",
+    "\n",
+    "\n",
+    "class SpeechFeatureEmbedding(layers.Layer):\n",
+    "    def __init__(self, num_hid=64, maxlen=100):\n",
+    "        super().__init__()\n",
+    "        self.conv1 = tf.keras.layers.Conv1D(\n",
+    "            num_hid, 11, strides=2, padding=\"same\", activation=\"relu\"\n",
+    "        )\n",
+    "        self.conv2 = tf.keras.layers.Conv1D(\n",
+    "            num_hid, 11, strides=2, padding=\"same\", activation=\"relu\"\n",
+    "        )\n",
+    "        self.conv3 = tf.keras.layers.Conv1D(\n",
+    "            num_hid, 11, strides=2, padding=\"same\", activation=\"relu\"\n",
+    "        )\n",
+    "        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        x = self.conv1(x)\n",
+    "        x = self.conv2(x)\n",
+    "        return self.conv3(x)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Transformer Encoder Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TransformerEncoder(layers.Layer):\n",
+    "    def __init__(self, embed_dim, num_heads, feed_forward_dim, rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)\n",
+    "        self.ffn = keras.Sequential(\n",
+    "            [\n",
+    "                layers.Dense(feed_forward_dim, activation=\"relu\"),\n",
+    "                layers.Dense(embed_dim),\n",
+    "            ]\n",
+    "        )\n",
+    "        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.dropout1 = layers.Dropout(rate)\n",
+    "        self.dropout2 = layers.Dropout(rate)\n",
+    "\n",
+    "    def call(self, inputs, training):\n",
+    "        attn_output = self.att(inputs, inputs)\n",
+    "        attn_output = self.dropout1(attn_output, training=training)\n",
+    "        out1 = self.layernorm1(inputs + attn_output)\n",
+    "        ffn_output = self.ffn(out1)\n",
+    "        ffn_output = self.dropout2(ffn_output, training=training)\n",
+    "        return self.layernorm2(out1 + ffn_output)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Transformer Decoder Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TransformerDecoder(layers.Layer):\n",
+    "    def __init__(self, embed_dim, num_heads, feed_forward_dim, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.layernorm3 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "        self.self_att = layers.MultiHeadAttention(\n",
+    "            num_heads=num_heads, key_dim=embed_dim\n",
+    "        )\n",
+    "        self.enc_att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)\n",
+    "        self.self_dropout = layers.Dropout(0.5)\n",
+    "        self.enc_dropout = layers.Dropout(0.1)\n",
+    "        self.ffn_dropout = layers.Dropout(0.1)\n",
+    "        self.ffn = keras.Sequential(\n",
+    "            [\n",
+    "                layers.Dense(feed_forward_dim, activation=\"relu\"),\n",
+    "                layers.Dense(embed_dim),\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "    def causal_attention_mask(self, batch_size, n_dest, n_src, dtype):\n",
+    "        \"\"\"Masks the upper half of the dot product matrix in self attention.\n",
+    "\n",
+    "        This prevents flow of information from future tokens to current token.\n",
+    "        1's in the lower triangle, counting from the lower right corner.\n",
+    "        \"\"\"\n",
+    "        i = tf.range(n_dest)[:, None]\n",
+    "        j = tf.range(n_src)\n",
+    "        m = i >= j - n_src + n_dest\n",
+    "        mask = tf.cast(m, dtype)\n",
+    "        mask = tf.reshape(mask, [1, n_dest, n_src])\n",
+    "        mult = tf.concat(\n",
+    "            [tf.expand_dims(batch_size, -1), tf.constant([1, 1], dtype=tf.int32)], 0\n",
+    "        )\n",
+    "        return tf.tile(mask, mult)\n",
+    "\n",
+    "    def call(self, enc_out, target):\n",
+    "        input_shape = tf.shape(target)\n",
+    "        batch_size = input_shape[0]\n",
+    "        seq_len = input_shape[1]\n",
+    "        causal_mask = self.causal_attention_mask(batch_size, seq_len, seq_len, tf.bool)\n",
+    "        target_att = self.self_att(target, target, attention_mask=causal_mask)\n",
+    "        target_norm = self.layernorm1(target + self.self_dropout(target_att))\n",
+    "        enc_out = self.enc_att(target_norm, enc_out)\n",
+    "        enc_out_norm = self.layernorm2(self.enc_dropout(enc_out) + target_norm)\n",
+    "        ffn_out = self.ffn(enc_out_norm)\n",
+    "        ffn_out_norm = self.layernorm3(enc_out_norm + self.ffn_dropout(ffn_out))\n",
+    "        return ffn_out_norm\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Complete the Transformer model\n",
+    "\n",
+    "Our model takes audio spectrograms as inputs and predicts a sequence of characters.\n",
+    "During training, we give the decoder the target character sequence shifted to the left\n",
+    "as input. During inference, the decoder uses its own past predictions to predict the\n",
+    "next token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class Transformer(keras.Model):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        num_hid=64,\n",
+    "        num_head=2,\n",
+    "        num_feed_forward=128,\n",
+    "        source_maxlen=100,\n",
+    "        target_maxlen=100,\n",
+    "        num_layers_enc=4,\n",
+    "        num_layers_dec=1,\n",
+    "        num_classes=10,\n",
+    "    ):\n",
+    "        super().__init__()\n",
+    "        self.loss_metric = keras.metrics.Mean(name=\"loss\")\n",
+    "        self.num_layers_enc = num_layers_enc\n",
+    "        self.num_layers_dec = num_layers_dec\n",
+    "        self.target_maxlen = target_maxlen\n",
+    "        self.num_classes = num_classes\n",
+    "\n",
+    "        self.enc_input = SpeechFeatureEmbedding(num_hid=num_hid, maxlen=source_maxlen)\n",
+    "        self.dec_input = TokenEmbedding(\n",
+    "            num_vocab=num_classes, maxlen=target_maxlen, num_hid=num_hid\n",
+    "        )\n",
+    "\n",
+    "        self.encoder = keras.Sequential(\n",
+    "            [self.enc_input]\n",
+    "            + [\n",
+    "                TransformerEncoder(num_hid, num_head, num_feed_forward)\n",
+    "                for _ in range(num_layers_enc)\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "        for i in range(num_layers_dec):\n",
+    "            setattr(\n",
+    "                self,\n",
+    "                f\"dec_layer_{i}\",\n",
+    "                TransformerDecoder(num_hid, num_head, num_feed_forward),\n",
+    "            )\n",
+    "\n",
+    "        self.classifier = layers.Dense(num_classes)\n",
+    "\n",
+    "    def decode(self, enc_out, target):\n",
+    "        y = self.dec_input(target)\n",
+    "        for i in range(self.num_layers_dec):\n",
+    "            y = getattr(self, f\"dec_layer_{i}\")(enc_out, y)\n",
+    "        return y\n",
+    "\n",
+    "    def call(self, inputs):\n",
+    "        source = inputs[0]\n",
+    "        target = inputs[1]\n",
+    "        x = self.encoder(source)\n",
+    "        y = self.decode(x, target)\n",
+    "        return self.classifier(y)\n",
+    "\n",
+    "    @property\n",
+    "    def metrics(self):\n",
+    "        return [self.loss_metric]\n",
+    "\n",
+    "    def train_step(self, batch):\n",
+    "        \"\"\"Processes one batch inside model.fit().\"\"\"\n",
+    "        source = batch[\"source\"]\n",
+    "        target = batch[\"target\"]\n",
+    "        dec_input = target[:, :-1]\n",
+    "        dec_target = target[:, 1:]\n",
+    "        with tf.GradientTape() as tape:\n",
+    "            preds = self([source, dec_input])\n",
+    "            one_hot = tf.one_hot(dec_target, depth=self.num_classes)\n",
+    "            mask = tf.math.logical_not(tf.math.equal(dec_target, 0))\n",
+    "            loss = self.compiled_loss(one_hot, preds, sample_weight=mask)\n",
+    "        trainable_vars = self.trainable_variables\n",
+    "        gradients = tape.gradient(loss, trainable_vars)\n",
+    "        self.optimizer.apply_gradients(zip(gradients, trainable_vars))\n",
+    "        self.loss_metric.update_state(loss)\n",
+    "        return {\"loss\": self.loss_metric.result()}\n",
+    "\n",
+    "    def test_step(self, batch):\n",
+    "        source = batch[\"source\"]\n",
+    "        target = batch[\"target\"]\n",
+    "        dec_input = target[:, :-1]\n",
+    "        dec_target = target[:, 1:]\n",
+    "        preds = self([source, dec_input])\n",
+    "        one_hot = tf.one_hot(dec_target, depth=self.num_classes)\n",
+    "        mask = tf.math.logical_not(tf.math.equal(dec_target, 0))\n",
+    "        loss = self.compiled_loss(one_hot, preds, sample_weight=mask)\n",
+    "        self.loss_metric.update_state(loss)\n",
+    "        return {\"loss\": self.loss_metric.result()}\n",
+    "\n",
+    "    def generate(self, source, target_start_token_idx):\n",
+    "        \"\"\"Performs inference over one batch of inputs using greedy decoding.\"\"\"\n",
+    "        bs = tf.shape(source)[0]\n",
+    "        enc = self.encoder(source)\n",
+    "        dec_input = tf.ones((bs, 1), dtype=tf.int32) * target_start_token_idx\n",
+    "        dec_logits = []\n",
+    "        for i in range(self.target_maxlen - 1):\n",
+    "            dec_out = self.decode(enc, dec_input)\n",
+    "            logits = self.classifier(dec_out)\n",
+    "            logits = tf.argmax(logits, axis=-1, output_type=tf.int32)\n",
+    "            last_logit = tf.expand_dims(logits[:, -1], axis=-1)\n",
+    "            dec_logits.append(last_logit)\n",
+    "            dec_input = tf.concat([dec_input, last_logit], axis=-1)\n",
+    "        return dec_input\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Download the dataset\n",
+    "\n",
+    "Note: This requires ~3.6 GB of disk space and\n",
+    "takes ~5 minutes for the extraction of files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "keras.utils.get_file(\n",
+    "    os.path.join(os.getcwd(), \"data.tar.gz\"),\n",
+    "    \"https://data.keithito.com/data/speech/LJSpeech-1.1.tar.bz2\",\n",
+    "    extract=True,\n",
+    "    archive_format=\"tar\",\n",
+    "    cache_dir=\".\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "saveto = \"./datasets/LJSpeech-1.1\"\n",
+    "wavs = glob(\"{}/**/*.wav\".format(saveto), recursive=True)\n",
+    "\n",
+    "id_to_text = {}\n",
+    "with open(os.path.join(saveto, \"metadata.csv\"), encoding=\"utf-8\") as f:\n",
+    "    for line in f:\n",
+    "        id = line.strip().split(\"|\")[0]\n",
+    "        text = line.strip().split(\"|\")[2]\n",
+    "        id_to_text[id] = text\n",
+    "\n",
+    "\n",
+    "def get_data(wavs, id_to_text, maxlen=50):\n",
+    "    \"\"\" returns mapping of audio paths and transcription texts \"\"\"\n",
+    "    data = []\n",
+    "    for w in wavs:\n",
+    "        id = w.split(\"/\")[-1].split(\".\")[0]\n",
+    "        if len(id_to_text[id]) < maxlen:\n",
+    "            data.append({\"audio\": w, \"text\": id_to_text[id]})\n",
+    "    return data\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Preprocess the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class VectorizeChar:\n",
+    "    def __init__(self, max_len=50):\n",
+    "        self.vocab = (\n",
+    "            [\"-\", \"#\", \"<\", \">\"]\n",
+    "            + [chr(i + 96) for i in range(1, 27)]\n",
+    "            + [\" \", \".\", \",\", \"?\"]\n",
+    "        )\n",
+    "        self.max_len = max_len\n",
+    "        self.char_to_idx = {}\n",
+    "        for i, ch in enumerate(self.vocab):\n",
+    "            self.char_to_idx[ch] = i\n",
+    "\n",
+    "    def __call__(self, text):\n",
+    "        text = text.lower()\n",
+    "        text = text[: self.max_len - 2]\n",
+    "        text = \"<\" + text + \">\"\n",
+    "        pad_len = self.max_len - len(text)\n",
+    "        return [self.char_to_idx.get(ch, 1) for ch in text] + [0] * pad_len\n",
+    "\n",
+    "    def get_vocabulary(self):\n",
+    "        return self.vocab\n",
+    "\n",
+    "\n",
+    "max_target_len = 200  # all transcripts in out data are < 200 characters\n",
+    "data = get_data(wavs, id_to_text, max_target_len)\n",
+    "vectorizer = VectorizeChar(max_target_len)\n",
+    "print(\"vocab size\", len(vectorizer.get_vocabulary()))\n",
+    "\n",
+    "\n",
+    "def create_text_ds(data):\n",
+    "    texts = [_[\"text\"] for _ in data]\n",
+    "    text_ds = [vectorizer(t) for t in texts]\n",
+    "    text_ds = tf.data.Dataset.from_tensor_slices(text_ds)\n",
+    "    return text_ds\n",
+    "\n",
+    "\n",
+    "def path_to_audio(path):\n",
+    "    # spectrogram using stft\n",
+    "    audio = tf.io.read_file(path)\n",
+    "    audio, _ = tf.audio.decode_wav(audio, 1)\n",
+    "    audio = tf.squeeze(audio, axis=-1)\n",
+    "    stfts = tf.signal.stft(audio, frame_length=200, frame_step=80, fft_length=256)\n",
+    "    x = tf.math.pow(tf.abs(stfts), 0.5)\n",
+    "    # normalisation\n",
+    "    means = tf.math.reduce_mean(x, 1, keepdims=True)\n",
+    "    stddevs = tf.math.reduce_std(x, 1, keepdims=True)\n",
+    "    x = (x - means) / stddevs\n",
+    "    audio_len = tf.shape(x)[0]\n",
+    "    # padding to 10 seconds\n",
+    "    pad_len = 2754\n",
+    "    paddings = tf.constant([[0, pad_len], [0, 0]])\n",
+    "    x = tf.pad(x, paddings, \"CONSTANT\")[:pad_len, :]\n",
+    "    return x\n",
+    "\n",
+    "\n",
+    "def create_audio_ds(data):\n",
+    "    flist = [_[\"audio\"] for _ in data]\n",
+    "    audio_ds = tf.data.Dataset.from_tensor_slices(flist)\n",
+    "    audio_ds = audio_ds.map(\n",
+    "        path_to_audio, num_parallel_calls=tf.data.experimental.AUTOTUNE\n",
+    "    )\n",
+    "    return audio_ds\n",
+    "\n",
+    "\n",
+    "def create_tf_dataset(data, bs=4):\n",
+    "    audio_ds = create_audio_ds(data)\n",
+    "    text_ds = create_text_ds(data)\n",
+    "    ds = tf.data.Dataset.zip((audio_ds, text_ds))\n",
+    "    ds = ds.map(lambda x, y: {\"source\": x, \"target\": y})\n",
+    "    ds = ds.batch(bs)\n",
+    "    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)\n",
+    "    return ds\n",
+    "\n",
+    "\n",
+    "split = int(len(data) * 0.99)\n",
+    "train_data = data[:split]\n",
+    "test_data = data[split:]\n",
+    "ds = create_tf_dataset(train_data, bs=64)\n",
+    "val_ds = create_tf_dataset(test_data, bs=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Callbacks to display predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class DisplayOutputs(keras.callbacks.Callback):\n",
+    "    def __init__(\n",
+    "        self, batch, idx_to_token, target_start_token_idx=27, target_end_token_idx=28\n",
+    "    ):\n",
+    "        \"\"\"Displays a batch of outputs after every epoch\n",
+    "\n",
+    "        Args:\n",
+    "            batch: A test batch containing the keys \"source\" and \"target\"\n",
+    "            idx_to_token: A List containing the vocabulary tokens corresponding to their indices\n",
+    "            target_start_token_idx: A start token index in the target vocabulary\n",
+    "            target_end_token_idx: An end token index in the target vocabulary\n",
+    "        \"\"\"\n",
+    "        self.batch = batch\n",
+    "        self.target_start_token_idx = target_start_token_idx\n",
+    "        self.target_end_token_idx = target_end_token_idx\n",
+    "        self.idx_to_char = idx_to_token\n",
+    "\n",
+    "    def on_epoch_end(self, epoch, logs=None):\n",
+    "        if epoch % 5 != 0:\n",
+    "            return\n",
+    "        source = self.batch[\"source\"]\n",
+    "        target = self.batch[\"target\"].numpy()\n",
+    "        bs = tf.shape(source)[0]\n",
+    "        preds = self.model.generate(source, self.target_start_token_idx)\n",
+    "        preds = preds.numpy()\n",
+    "        for i in range(bs):\n",
+    "            target_text = \"\".join([self.idx_to_char[_] for _ in target[i, :]])\n",
+    "            prediction = \"\"\n",
+    "            for idx in preds[i, :]:\n",
+    "                prediction += self.idx_to_char[idx]\n",
+    "                if idx == self.target_end_token_idx:\n",
+    "                    break\n",
+    "            print(f\"target:     {target_text.replace('-','')}\")\n",
+    "            print(f\"prediction: {prediction}\\n\")\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Learning rate schedule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class CustomSchedule(keras.optimizers.schedules.LearningRateSchedule):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        init_lr=0.00001,\n",
+    "        lr_after_warmup=0.001,\n",
+    "        final_lr=0.00001,\n",
+    "        warmup_epochs=15,\n",
+    "        decay_epochs=85,\n",
+    "        steps_per_epoch=203,\n",
+    "    ):\n",
+    "        super().__init__()\n",
+    "        self.init_lr = init_lr\n",
+    "        self.lr_after_warmup = lr_after_warmup\n",
+    "        self.final_lr = final_lr\n",
+    "        self.warmup_epochs = warmup_epochs\n",
+    "        self.decay_epochs = decay_epochs\n",
+    "        self.steps_per_epoch = steps_per_epoch\n",
+    "\n",
+    "    def calculate_lr(self, epoch):\n",
+    "        \"\"\" linear warm up - linear decay \"\"\"\n",
+    "        warmup_lr = (\n",
+    "            self.init_lr\n",
+    "            + ((self.lr_after_warmup - self.init_lr) / (self.warmup_epochs - 1)) * epoch\n",
+    "        )\n",
+    "        decay_lr = tf.math.maximum(\n",
+    "            self.final_lr,\n",
+    "            self.lr_after_warmup\n",
+    "            - (epoch - self.warmup_epochs)\n",
+    "            * (self.lr_after_warmup - self.final_lr)\n",
+    "            / (self.decay_epochs),\n",
+    "        )\n",
+    "        return tf.math.minimum(warmup_lr, decay_lr)\n",
+    "\n",
+    "    def __call__(self, step):\n",
+    "        epoch = step // self.steps_per_epoch\n",
+    "        return self.calculate_lr(epoch)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Create & train the end-to-end model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "batch = next(iter(val_ds))\n",
+    "\n",
+    "# The vocabulary to convert predicted indices into characters\n",
+    "idx_to_char = vectorizer.get_vocabulary()\n",
+    "display_cb = DisplayOutputs(\n",
+    "    batch, idx_to_char, target_start_token_idx=2, target_end_token_idx=3\n",
+    ")  # set the arguments as per vocabulary index for '<' and '>'\n",
+    "\n",
+    "model = Transformer(\n",
+    "    num_hid=200,\n",
+    "    num_head=2,\n",
+    "    num_feed_forward=400,\n",
+    "    target_maxlen=max_target_len,\n",
+    "    num_layers_enc=4,\n",
+    "    num_layers_dec=1,\n",
+    "    num_classes=34,\n",
+    ")\n",
+    "loss_fn = tf.keras.losses.CategoricalCrossentropy(\n",
+    "    from_logits=True, label_smoothing=0.1,\n",
+    ")\n",
+    "\n",
+    "learning_rate = CustomSchedule(\n",
+    "    init_lr=0.00001,\n",
+    "    lr_after_warmup=0.001,\n",
+    "    final_lr=0.00001,\n",
+    "    warmup_epochs=15,\n",
+    "    decay_epochs=85,\n",
+    "    steps_per_epoch=len(ds),\n",
+    ")\n",
+    "optimizer = keras.optimizers.Adam(learning_rate)\n",
+    "model.compile(optimizer=optimizer, loss=loss_fn)\n",
+    "\n",
+    "history = model.fit(ds, validation_data=val_ds, callbacks=[display_cb], epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "In practice, you should train for around 100 epochs or more.\n",
+    "\n",
+    "Some of the predicted text at or around epoch 35 may look as follows:\n",
+    "```\n",
+    "target:     <as they sat in the car, frazier asked oswald where his lunch was>\n",
+    "prediction: <as they sat in the car frazier his lunch ware mis lunch was>\n",
+    "\n",
+    "target:     <under the entry for may one, nineteen sixty,>\n",
+    "prediction: <under the introus for may monee, nin the sixty,>\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "transformer_asr",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/audio/md/transformer_asr.md
+++ b/examples/audio/md/transformer_asr.md
@@ -1,0 +1,605 @@
+
+# Automatic Speech Recognition with Transformer
+
+**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>
+**Date created:** 2021/01/13<br>
+**Last modified:** 2021/01/13<br>
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/audio/ipynb/transformer_asr.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/audio/transformer_asr.py)
+
+
+**Description:** Training a sequence-to-sequence Transformer for automatic speech recognition.
+
+---
+## Introduction
+
+Automatic speech recognition (ASR) consists of transcribing audio speech segments into text.
+ASR can be treated as a sequence-to-sequence problem, where the
+audio can be represented as a sequence of feature vectors
+and the text as a sequence of characters, words, or subword tokens.
+
+For this demonstration, we will use the LJSpeech dataset from the
+[LibriVox](https://librivox.org/) project. It consists of short
+audio clips of a single speaker reading passages from 7 non-fiction books.
+Our model will be similar to the original Transformer (both encoder and decoder)
+as proposed in the paper, "Attention is All You Need".
+
+
+**References:**
+
+- [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
+- [Very Deep Self-Attention Networks for End-to-End Speech Recognition](https://arxiv.org/pdf/1904.13377.pdf)
+- [Speech Transformers](https://ieeexplore.ieee.org/document/8462506)
+- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)
+
+
+```python
+
+import os
+import random
+from glob import glob
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+
+```
+
+---
+## Define the Transformer Input Layer
+
+When processing past target tokens for the decoder, we compute the sum of
+position embeddings and token embeddings.
+
+When processing audio features, we apply convolutional layers to downsample
+them (via convolution stides) and process local relationships.
+
+
+```python
+
+class TokenEmbedding(layers.Layer):
+    def __init__(self, num_vocab=1000, maxlen=100, num_hid=64):
+        super().__init__()
+        self.emb = tf.keras.layers.Embedding(num_vocab, num_hid)
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)
+
+    def call(self, x):
+        maxlen = tf.shape(x)[-1]
+        x = self.emb(x)
+        positions = tf.range(start=0, limit=maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        return x + positions
+
+
+class SpeechFeatureEmbedding(layers.Layer):
+    def __init__(self, num_hid=64, maxlen=100):
+        super().__init__()
+        self.conv1 = tf.keras.layers.Conv1D(
+            num_hid, 11, strides=2, padding="same", activation="relu"
+        )
+        self.conv2 = tf.keras.layers.Conv1D(
+            num_hid, 11, strides=2, padding="same", activation="relu"
+        )
+        self.conv3 = tf.keras.layers.Conv1D(
+            num_hid, 11, strides=2, padding="same", activation="relu"
+        )
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)
+
+    def call(self, x):
+        x = self.conv1(x)
+        x = self.conv2(x)
+        return self.conv3(x)
+
+```
+
+---
+## Transformer Encoder Layer
+
+
+```python
+
+class TransformerEncoder(layers.Layer):
+    def __init__(self, embed_dim, num_heads, feed_forward_dim, rate=0.1):
+        super().__init__()
+        self.att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.ffn = keras.Sequential(
+            [
+                layers.Dense(feed_forward_dim, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
+
+    def call(self, inputs, training):
+        attn_output = self.att(inputs, inputs)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(inputs + attn_output)
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        return self.layernorm2(out1 + ffn_output)
+
+```
+
+---
+## Transformer Decoder Layer
+
+
+```python
+
+class TransformerDecoder(layers.Layer):
+    def __init__(self, embed_dim, num_heads, feed_forward_dim, dropout_rate=0.1):
+        super().__init__()
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm3 = layers.LayerNormalization(epsilon=1e-6)
+        self.self_att = layers.MultiHeadAttention(
+            num_heads=num_heads, key_dim=embed_dim
+        )
+        self.enc_att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.self_dropout = layers.Dropout(0.5)
+        self.enc_dropout = layers.Dropout(0.1)
+        self.ffn_dropout = layers.Dropout(0.1)
+        self.ffn = keras.Sequential(
+            [
+                layers.Dense(feed_forward_dim, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+
+    def causal_attention_mask(self, batch_size, n_dest, n_src, dtype):
+        """Masks the upper half of the dot product matrix in self attention.
+
+        This prevents flow of information from future tokens to current token.
+        1's in the lower triangle, counting from the lower right corner.
+        """
+        i = tf.range(n_dest)[:, None]
+        j = tf.range(n_src)
+        m = i >= j - n_src + n_dest
+        mask = tf.cast(m, dtype)
+        mask = tf.reshape(mask, [1, n_dest, n_src])
+        mult = tf.concat(
+            [tf.expand_dims(batch_size, -1), tf.constant([1, 1], dtype=tf.int32)], 0
+        )
+        return tf.tile(mask, mult)
+
+    def call(self, enc_out, target):
+        input_shape = tf.shape(target)
+        batch_size = input_shape[0]
+        seq_len = input_shape[1]
+        causal_mask = self.causal_attention_mask(batch_size, seq_len, seq_len, tf.bool)
+        target_att = self.self_att(target, target, attention_mask=causal_mask)
+        target_norm = self.layernorm1(target + self.self_dropout(target_att))
+        enc_out = self.enc_att(target_norm, enc_out)
+        enc_out_norm = self.layernorm2(self.enc_dropout(enc_out) + target_norm)
+        ffn_out = self.ffn(enc_out_norm)
+        ffn_out_norm = self.layernorm3(enc_out_norm + self.ffn_dropout(ffn_out))
+        return ffn_out_norm
+
+```
+
+---
+## Complete the Transformer model
+
+Our model takes audio spectrograms as inputs and predicts a sequence of characters.
+During training, we give the decoder the target character sequence shifted to the left
+as input. During inference, the decoder uses its own past predictions to predict the
+next token.
+
+
+```python
+
+class Transformer(keras.Model):
+    def __init__(
+        self,
+        num_hid=64,
+        num_head=2,
+        num_feed_forward=128,
+        source_maxlen=100,
+        target_maxlen=100,
+        num_layers_enc=4,
+        num_layers_dec=1,
+        num_classes=10,
+    ):
+        super().__init__()
+        self.loss_metric = keras.metrics.Mean(name="loss")
+        self.num_layers_enc = num_layers_enc
+        self.num_layers_dec = num_layers_dec
+        self.target_maxlen = target_maxlen
+        self.num_classes = num_classes
+
+        self.enc_input = SpeechFeatureEmbedding(num_hid=num_hid, maxlen=source_maxlen)
+        self.dec_input = TokenEmbedding(
+            num_vocab=num_classes, maxlen=target_maxlen, num_hid=num_hid
+        )
+
+        self.encoder = keras.Sequential(
+            [self.enc_input]
+            + [
+                TransformerEncoder(num_hid, num_head, num_feed_forward)
+                for _ in range(num_layers_enc)
+            ]
+        )
+
+        for i in range(num_layers_dec):
+            setattr(
+                self,
+                f"dec_layer_{i}",
+                TransformerDecoder(num_hid, num_head, num_feed_forward),
+            )
+
+        self.classifier = layers.Dense(num_classes)
+
+    def decode(self, enc_out, target):
+        y = self.dec_input(target)
+        for i in range(self.num_layers_dec):
+            y = getattr(self, f"dec_layer_{i}")(enc_out, y)
+        return y
+
+    def call(self, inputs):
+        source = inputs[0]
+        target = inputs[1]
+        x = self.encoder(source)
+        y = self.decode(x, target)
+        return self.classifier(y)
+
+    @property
+    def metrics(self):
+        return [self.loss_metric]
+
+    def train_step(self, batch):
+        """Processes one batch inside model.fit()."""
+        source = batch["source"]
+        target = batch["target"]
+        dec_input = target[:, :-1]
+        dec_target = target[:, 1:]
+        with tf.GradientTape() as tape:
+            preds = self([source, dec_input])
+            one_hot = tf.one_hot(dec_target, depth=self.num_classes)
+            mask = tf.math.logical_not(tf.math.equal(dec_target, 0))
+            loss = self.compiled_loss(one_hot, preds, sample_weight=mask)
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        self.loss_metric.update_state(loss)
+        return {"loss": self.loss_metric.result()}
+
+    def test_step(self, batch):
+        source = batch["source"]
+        target = batch["target"]
+        dec_input = target[:, :-1]
+        dec_target = target[:, 1:]
+        preds = self([source, dec_input])
+        one_hot = tf.one_hot(dec_target, depth=self.num_classes)
+        mask = tf.math.logical_not(tf.math.equal(dec_target, 0))
+        loss = self.compiled_loss(one_hot, preds, sample_weight=mask)
+        self.loss_metric.update_state(loss)
+        return {"loss": self.loss_metric.result()}
+
+    def generate(self, source, target_start_token_idx):
+        """Performs inference over one batch of inputs using greedy decoding."""
+        bs = tf.shape(source)[0]
+        enc = self.encoder(source)
+        dec_input = tf.ones((bs, 1), dtype=tf.int32) * target_start_token_idx
+        dec_logits = []
+        for i in range(self.target_maxlen - 1):
+            dec_out = self.decode(enc, dec_input)
+            logits = self.classifier(dec_out)
+            logits = tf.argmax(logits, axis=-1, output_type=tf.int32)
+            last_logit = tf.expand_dims(logits[:, -1], axis=-1)
+            dec_logits.append(last_logit)
+            dec_input = tf.concat([dec_input, last_logit], axis=-1)
+        return dec_input
+
+```
+
+---
+## Download the dataset
+
+Note: This requires ~3.6 GB of disk space and
+takes ~5 minutes for the extraction of files.
+
+
+```python
+keras.utils.get_file(
+    os.path.join(os.getcwd(), "data.tar.gz"),
+    "https://data.keithito.com/data/speech/LJSpeech-1.1.tar.bz2",
+    extract=True,
+    archive_format="tar",
+    cache_dir=".",
+)
+
+
+saveto = "./datasets/LJSpeech-1.1"
+wavs = glob("{}/**/*.wav".format(saveto), recursive=True)
+
+id_to_text = {}
+with open(os.path.join(saveto, "metadata.csv"), encoding="utf-8") as f:
+    for line in f:
+        id = line.strip().split("|")[0]
+        text = line.strip().split("|")[2]
+        id_to_text[id] = text
+
+
+def get_data(wavs, id_to_text, maxlen=50):
+    """ returns mapping of audio paths and transcription texts """
+    data = []
+    for w in wavs:
+        id = w.split("/")[-1].split(".")[0]
+        if len(id_to_text[id]) < maxlen:
+            data.append({"audio": w, "text": id_to_text[id]})
+    return data
+
+```
+
+<div class="k-default-codeblock">
+```
+Downloading data from https://data.keithito.com/data/speech/LJSpeech-1.1.tar.bz2
+2748579840/2748572632 [==============================] - 57s 0us/step
+
+```
+</div>
+---
+## Preprocess the dataset
+
+
+```python
+
+class VectorizeChar:
+    def __init__(self, max_len=50):
+        self.vocab = (
+            ["-", "#", "<", ">"]
+            + [chr(i + 96) for i in range(1, 27)]
+            + [" ", ".", ",", "?"]
+        )
+        self.max_len = max_len
+        self.char_to_idx = {}
+        for i, ch in enumerate(self.vocab):
+            self.char_to_idx[ch] = i
+
+    def __call__(self, text):
+        text = text.lower()
+        text = text[: self.max_len - 2]
+        text = "<" + text + ">"
+        pad_len = self.max_len - len(text)
+        return [self.char_to_idx.get(ch, 1) for ch in text] + [0] * pad_len
+
+    def get_vocabulary(self):
+        return self.vocab
+
+
+max_target_len = 200  # all transcripts in out data are < 200 characters
+data = get_data(wavs, id_to_text, max_target_len)
+vectorizer = VectorizeChar(max_target_len)
+print("vocab size", len(vectorizer.get_vocabulary()))
+
+
+def create_text_ds(data):
+    texts = [_["text"] for _ in data]
+    text_ds = [vectorizer(t) for t in texts]
+    text_ds = tf.data.Dataset.from_tensor_slices(text_ds)
+    return text_ds
+
+
+def path_to_audio(path):
+    # spectrogram using stft
+    audio = tf.io.read_file(path)
+    audio, _ = tf.audio.decode_wav(audio, 1)
+    audio = tf.squeeze(audio, axis=-1)
+    stfts = tf.signal.stft(audio, frame_length=200, frame_step=80, fft_length=256)
+    x = tf.math.pow(tf.abs(stfts), 0.5)
+    # normalisation
+    means = tf.math.reduce_mean(x, 1, keepdims=True)
+    stddevs = tf.math.reduce_std(x, 1, keepdims=True)
+    x = (x - means) / stddevs
+    audio_len = tf.shape(x)[0]
+    # padding to 10 seconds
+    pad_len = 2754
+    paddings = tf.constant([[0, pad_len], [0, 0]])
+    x = tf.pad(x, paddings, "CONSTANT")[:pad_len, :]
+    return x
+
+
+def create_audio_ds(data):
+    flist = [_["audio"] for _ in data]
+    audio_ds = tf.data.Dataset.from_tensor_slices(flist)
+    audio_ds = audio_ds.map(
+        path_to_audio, num_parallel_calls=tf.data.experimental.AUTOTUNE
+    )
+    return audio_ds
+
+
+def create_tf_dataset(data, bs=4):
+    audio_ds = create_audio_ds(data)
+    text_ds = create_text_ds(data)
+    ds = tf.data.Dataset.zip((audio_ds, text_ds))
+    ds = ds.map(lambda x, y: {"source": x, "target": y})
+    ds = ds.batch(bs)
+    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
+    return ds
+
+
+split = int(len(data) * 0.99)
+train_data = data[:split]
+test_data = data[split:]
+ds = create_tf_dataset(train_data, bs=64)
+val_ds = create_tf_dataset(test_data, bs=4)
+```
+
+<div class="k-default-codeblock">
+```
+vocab size 34
+
+```
+</div>
+---
+## Callbacks to display predictions
+
+
+```python
+
+class DisplayOutputs(keras.callbacks.Callback):
+    def __init__(
+        self, batch, idx_to_token, target_start_token_idx=27, target_end_token_idx=28
+    ):
+        """Displays a batch of outputs after every epoch
+
+        Args:
+            batch: A test batch containing the keys "source" and "target"
+            idx_to_token: A List containing the vocabulary tokens corresponding to their indices
+            target_start_token_idx: A start token index in the target vocabulary
+            target_end_token_idx: An end token index in the target vocabulary
+        """
+        self.batch = batch
+        self.target_start_token_idx = target_start_token_idx
+        self.target_end_token_idx = target_end_token_idx
+        self.idx_to_char = idx_to_token
+
+    def on_epoch_end(self, epoch, logs=None):
+        if epoch % 5 != 0:
+            return
+        source = self.batch["source"]
+        target = self.batch["target"].numpy()
+        bs = tf.shape(source)[0]
+        preds = self.model.generate(source, self.target_start_token_idx)
+        preds = preds.numpy()
+        for i in range(bs):
+            target_text = "".join([self.idx_to_char[_] for _ in target[i, :]])
+            prediction = ""
+            for idx in preds[i, :]:
+                prediction += self.idx_to_char[idx]
+                if idx == self.target_end_token_idx:
+                    break
+            print(f"target:     {target_text.replace('-','')}")
+            print(f"prediction: {prediction}\n")
+
+```
+
+---
+## Learning rate schedule
+
+
+```python
+
+class CustomSchedule(keras.optimizers.schedules.LearningRateSchedule):
+    def __init__(
+        self,
+        init_lr=0.00001,
+        lr_after_warmup=0.001,
+        final_lr=0.00001,
+        warmup_epochs=15,
+        decay_epochs=85,
+        steps_per_epoch=203,
+    ):
+        super().__init__()
+        self.init_lr = init_lr
+        self.lr_after_warmup = lr_after_warmup
+        self.final_lr = final_lr
+        self.warmup_epochs = warmup_epochs
+        self.decay_epochs = decay_epochs
+        self.steps_per_epoch = steps_per_epoch
+
+    def calculate_lr(self, epoch):
+        """ linear warm up - linear decay """
+        warmup_lr = (
+            self.init_lr
+            + ((self.lr_after_warmup - self.init_lr) / (self.warmup_epochs - 1)) * epoch
+        )
+        decay_lr = tf.math.maximum(
+            self.final_lr,
+            self.lr_after_warmup
+            - (epoch - self.warmup_epochs)
+            * (self.lr_after_warmup - self.final_lr)
+            / (self.decay_epochs),
+        )
+        return tf.math.minimum(warmup_lr, decay_lr)
+
+    def __call__(self, step):
+        epoch = step // self.steps_per_epoch
+        return self.calculate_lr(epoch)
+
+```
+
+---
+## Create & train the end-to-end model
+
+
+```python
+batch = next(iter(val_ds))
+
+# The vocabulary to convert predicted indices into characters
+idx_to_char = vectorizer.get_vocabulary()
+display_cb = DisplayOutputs(
+    batch, idx_to_char, target_start_token_idx=2, target_end_token_idx=3
+)  # set the arguments as per vocabulary index for '<' and '>'
+
+model = Transformer(
+    num_hid=200,
+    num_head=2,
+    num_feed_forward=400,
+    target_maxlen=max_target_len,
+    num_layers_enc=4,
+    num_layers_dec=1,
+    num_classes=34,
+)
+loss_fn = tf.keras.losses.CategoricalCrossentropy(
+    from_logits=True, label_smoothing=0.1,
+)
+
+learning_rate = CustomSchedule(
+    init_lr=0.00001,
+    lr_after_warmup=0.001,
+    final_lr=0.00001,
+    warmup_epochs=15,
+    decay_epochs=85,
+    steps_per_epoch=len(ds),
+)
+optimizer = keras.optimizers.Adam(learning_rate)
+model.compile(optimizer=optimizer, loss=loss_fn)
+
+history = model.fit(ds, validation_data=val_ds, callbacks=[display_cb], epochs=1)
+```
+
+<div class="k-default-codeblock">
+```
+203/203 [==============================] - 349s 2s/step - loss: 1.7437 - val_loss: 1.4650
+target:     <he had neither a bed to lie upon nor a coat to his back.>
+prediction: <the iaio the t h aint oohe te te an he t te o e t  as e t t he te the the o t t ie o so o  te o the te s s t tre olin o o oon cnt theaie to o te s te o soo hete te tte  o e the th s oas pe te the ad 
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+target:     <in all of these roles the president must go to the people.>
+prediction: <the iaio the t h aint oohe te te an he t te o e t  as e t t he te the the o t t ie o so o  te o the te s s t tre olin o o oon cnt theaie to o te s te o soo hete te tte  o e the th s oas pe te the ad 
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+target:     <and to have succeeded in other speculations.>
+prediction: <the iaio the t h aint oohe te te an he t te o e t  as e t t he te the the o t t ie o so o  te o the te s s t tre olin o o oon cnt theaie to o te s te o soo hete te tte  o e the th s oas pe te the ad 
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+target:     <and which certainly hold good for the vast majority of animals and plants, are of universal application.>
+prediction: <the iaio the t h aint oohe te te an he t te o e t  as e t t he te the the o t t ie o s s t te o the te s s t tre olin o o oon cnt theaie to o te s te o soo hete te tte  o e the th s oas pe te the ad 
+```
+</div>
+    
+
+
+In practice, you should train for around 100 epochs or more.
+
+Some of the predicted text at or around epoch 35 may look as follows:
+```
+target:     <as they sat in the car, frazier asked oswald where his lunch was>
+prediction: <as they sat in the car frazier his lunch ware mis lunch was>
+
+target:     <under the entry for may one, nineteen sixty,>
+prediction: <under the introus for may monee, nin the sixty,>
+```

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -235,7 +235,7 @@ class Transformer(keras.Model):
         return [self.loss_metric]
 
     def train_step(self, batch):
-        """ Process one batch inside model.fit() """
+        """Processes one batch inside model.fit()."""
         source = batch["source"]
         target = batch["target"]
         dec_input = target[:, :-1]

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -524,8 +524,7 @@ model = Transformer(
     num_classes=34,
 )
 loss_fn = tf.keras.losses.CategoricalCrossentropy(
-    from_logits=True,
-    label_smoothing=0.1,
+    from_logits=True, label_smoothing=0.1,
 )
 
 learning_rate = CustomSchedule(

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -264,7 +264,7 @@ class Transformer(keras.Model):
         return {"loss": self.loss_metric.result()}
 
     def generate(self, source, target_start_token_idx):
-        """ inference for one batch of inputs using greedy decoding """
+        """Performs inference over one batch of inputs using greedy decoding."""
         bs = tf.shape(source)[0]
         enc = self.encoder(source)
         dec_input = tf.ones((bs, 1), dtype=tf.int32) * target_start_token_idx

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -13,22 +13,24 @@ A popular way to handle this task is to treat it as a sequence-to-sequence
 problem. The audio can be represented as a sequence of feature vectors,
 and the text can be represented as a sequence of characters, words, or subword tokens.
 
-ASR models typically require huge datasets and take a lot of time to train.
-For this demonstration, we will use a simple dataset so as to reduce training time yet
-display interesting results. Our model will be a Transformer (both encoder and decoder)
+For this demonstration, we will use LJSpeech dataset from the
+[LibriVox](https://librivox.org/) project. It consists of short
+audio clips of a single speaker reading passages from 7 non-fiction books.
+Our model will be similar to the original Transformer (both encoder and decoder)
 as proposed in the paper, "Attention is All You Need".
 
-Our data consists of audio segments with a person speaking out one of the ten digits
-(0-9). We convert the digits as a sequence of characters (e.g. 9 -> n,i,n,e) to form
-a small dataset. The method shown below, however, can be applied to a real world
-speech dataset, to learn the mapping from audio to a sequence of characters.
 
 **References:**
 - [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
-- [Free Spoken Digit Dataset](https://github.com/Jakobovski/free-spoken-digit-dataset)
+- [Very Deep Self-Attention Networks for End-to-End Speech Recognition](https://arxiv.org/pdf/1904.13377.pdf)
+- [Speech Transformers](https://ieeexplore.ieee.org/document/8462506)
+- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)
 """
+
+
 import os
 import random
+from glob import glob
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
@@ -37,32 +39,47 @@ from tensorflow.keras import layers
 """
 ## Transformer Input Layer
 
-This layer computes the sum of position embeddings and feature embeddings to feed to
-the transformer layers.
+When processing past target tokens for the decoder, we compute the sum of 
+position embeddings and token embeddings.
+
+When processing audio features, we apply convolutional layers to downsample
+them and process local relationships. It makes the training stable.
 """
 
 
 class TransformerInput(layers.Layer):
     def __init__(
-        self, input_type="tokens", nvocab=1000, nhid=64, nff=128, maxlen=100,
+        self, input_type="tokens", num_vocab=1000, num_hid=64, num_ff=128, maxlen=100,
     ):
         super().__init__()
         self.input_type = input_type
         if input_type == "tokens":
-            self.emb = tf.keras.layers.Embedding(nvocab, nhid)
-        elif input_type == "feats":
-            self.emb = tf.keras.layers.Dense(nhid)
-        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=nhid)
+            self.emb = tf.keras.layers.Embedding(num_vocab, num_hid)
+        elif input_type == "features":
+            self.conv1 = tf.keras.layers.Conv1D(
+                num_hid, 11, strides=2, padding="same", activation="relu"
+            )
+            self.conv2 = tf.keras.layers.Conv1D(
+                num_hid, 11, strides=2, padding="same", activation="relu"
+            )
+            self.conv3 = tf.keras.layers.Conv1D(
+                num_hid, 11, strides=2, padding="same", activation="relu"
+            )
+        else:
+            raise ValueError("input_type must be one of ('tokens', 'features')")
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)
 
     def call(self, x):
         if self.input_type == "tokens":
             maxlen = tf.shape(x)[-1]
-        elif self.input_type == "feats":
-            maxlen = tf.shape(x)[1]
-        x = self.emb(x)
-        positions = tf.range(start=0, limit=maxlen, delta=1)
-        positions = self.pos_emb(positions)
-        return x + positions
+            x = self.emb(x)
+            positions = tf.range(start=0, limit=maxlen, delta=1)
+            positions = self.pos_emb(positions)
+            return x + positions
+        else:
+            x = self.conv1(x)
+            x = self.conv2(x)
+            return self.conv3(x)
 
 
 """
@@ -106,7 +123,9 @@ class TransformerDecoderLayer(layers.Layer):
             num_heads=num_heads, key_dim=embed_dim
         )
         self.enc_att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
-        self.drop = layers.Dropout(rate)
+        self.self_drop = layers.Dropout(0.5)
+        self.enc_drop = layers.Dropout(0.0)
+        self.ffn_drop = layers.Dropout(0.0)
         self.ffn = keras.Sequential(
             [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim),]
         )
@@ -133,27 +152,33 @@ class TransformerDecoderLayer(layers.Layer):
         seq_len = input_shape[1]
         causal_mask = self.causal_attention_mask(batch_size, seq_len, seq_len, tf.bool)
         trg_att = self.self_att(trg, trg, attention_mask=causal_mask)
-        trg_norm = self.ln1(trg + self.drop(trg_att))
+        trg_norm = self.ln1(trg + self.self_drop(trg_att))
         enc_out = self.enc_att(trg_norm, enc_out)
-        enc_out_norm = self.ln2(self.drop(enc_out) + trg_norm)
+        enc_out_norm = self.ln2(self.enc_drop(enc_out) + trg_norm)
         ffn_out = self.ffn(enc_out_norm)
-        ffn_out_norm = self.ln3(enc_out_norm + self.drop(ffn_out))
+        ffn_out_norm = self.ln3(enc_out_norm + self.ffn_drop(ffn_out))
         return ffn_out_norm
 
 
 """
 ## Complete Transformer Model
+
+Our model takes audio spectrograms as input, and predicts a sequence of characters.
+During training, we give the decoder the target character sequence shifted to the left
+as input. During inference, the decoder uses its own past predictions to predict the 
+next token.
 """
 
-loss_object = tf.keras.losses.SparseCategoricalCrossentropy(
-    from_logits=True, reduction="none"
+loss_object = tf.keras.losses.CategoricalCrossentropy(
+    from_logits=True, label_smoothing=0.1, reduction="none"
 )
 
 
 def masked_loss(real, pred):
     """ assuming pad token index = 0 """
+    one_hot = tf.one_hot(real, depth=34)
     mask = tf.math.logical_not(tf.math.equal(real, 0))
-    loss_ = loss_object(real, pred)
+    loss_ = loss_object(one_hot, pred)
     mask = tf.cast(mask, dtype=loss_.dtype)
     loss_ *= mask
     return tf.reduce_mean(loss_)
@@ -162,43 +187,54 @@ def masked_loss(real, pred):
 class Transformer(keras.Model):
     def __init__(
         self,
-        input_type="tokens",
-        nvocab=1000,
-        ninp=32,
-        nhid=64,
-        nhead=2,
-        nff=128,
+        num_hid=64,
+        num_head=2,
+        num_ff=128,
         src_maxlen=100,
         trg_maxlen=100,
-        nlayers=2,
-        nclasses=10,
+        num_layers_enc=4,
+        num_layers_dec=1,
+        num_classes=10,
     ):
         super().__init__()
-        self.nlayers = nlayers
+        self.loss_metric = keras.metrics.Mean(name="loss")
+        self.num_layers_enc = num_layers_enc
+        self.num_layers_dec = num_layers_dec
         self.trg_maxlen = trg_maxlen
-        self.input_type = input_type
 
         self.enc_input = TransformerInput(
-            input_type=input_type, nvocab=1000, nhid=64, maxlen=src_maxlen
+            input_type="features", num_hid=num_hid, maxlen=src_maxlen
         )
         self.dec_input = TransformerInput(
-            input_type="tokens", nvocab=nclasses, nhid=nhid, maxlen=trg_maxlen
+            input_type="tokens",
+            num_vocab=num_classes,
+            num_hid=num_hid,
+            maxlen=trg_maxlen,
         )
-        for i in range(nlayers):
-            setattr(self, f"enc_layer_{i}", TransformerEncoderLayer(nhid, nhead, nff))
-            setattr(self, f"dec_layer_{i}", TransformerDecoderLayer(nhid, nhead, nff))
+        for i in range(num_layers_enc):
+            setattr(
+                self,
+                f"enc_layer_{i}",
+                TransformerEncoderLayer(num_hid, num_head, num_ff),
+            )
+        for i in range(num_layers_dec):
+            setattr(
+                self,
+                f"dec_layer_{i}",
+                TransformerDecoderLayer(num_hid, num_head, num_ff),
+            )
 
-        self.final = layers.Dense(nclasses)
+        self.final = layers.Dense(num_classes)
 
     def encode_src(self, src):
         x = self.enc_input(src)
-        for i in range(self.nlayers):
+        for i in range(self.num_layers_enc):
             x = getattr(self, f"enc_layer_{i}")(x)
         return x
 
     def decode(self, enc_out, trg):
         y = self.dec_input(trg)
-        for i in range(self.nlayers):
+        for i in range(self.num_layers_dec):
             y = getattr(self, f"dec_layer_{i}")(enc_out, y)
         return y
 
@@ -208,6 +244,10 @@ class Transformer(keras.Model):
         x = self.encode_src(src)
         y = self.decode(x, trg)
         return self.final(y)
+
+    @property
+    def metrics(self):
+        return [self.loss_metric]
 
     def train_step(self, batch):
         """ Process one batch inside model.fit() """
@@ -221,141 +261,187 @@ class Transformer(keras.Model):
         trainable_vars = self.trainable_variables
         gradients = tape.gradient(loss, trainable_vars)
         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
-        return {"loss": loss}
+        self.loss_metric.update_state(loss)
+        return {"loss": self.loss_metric.result()}
 
     def generate(self, src, trg_start_token_idx):
-        """ Return a batch of predicted token indices with greedy deecoding """
+        """ inference for one batch of inputs using greedy decoding """
         bs = tf.shape(src)[0]
-        dec_inp = tf.ones((bs, self.trg_maxlen), dtype=tf.int32) * trg_start_token_idx
-        for i in range(self.trg_maxlen):
-            preds = self([src, dec_inp])
-            pred_idx = tf.argmax(preds, axis=-1, output_type=tf.int32)
-            current_pred = tf.expand_dims(pred_idx[:, i], axis=-1)
-            if i < self.trg_maxlen - 1:
-                future_pad = tf.ones((bs, self.trg_maxlen - (i + 2)), dtype=tf.int32)
-                dec_inp = tf.concat(
-                    [dec_inp[:, : i + 1], current_pred, future_pad], axis=-1
-                )
-            else:
-                dec_inp = tf.concat([dec_inp[:, : i + 1], current_pred], axis=-1)
-        return pred_idx
+        enc = self.encode_src(src)
+        dec_inp = tf.ones((bs, 1), dtype=tf.int32) * trg_start_token_idx
+        dec_logits = []
+        for i in range(self.trg_maxlen - 1):
+            dec_out = self.decode(enc, dec_inp)
+            logits = self.final(dec_out)
+            logits = tf.argmax(logits, axis=-1, output_type=tf.int32)
+            last_logit = tf.expand_dims(logits[:, -1], axis=-1)
+            dec_logits.append(last_logit)
+            dec_inp = tf.concat([dec_inp, last_logit], axis=-1)
+        return dec_inp
 
 
 """
-## Preprocess the ASR data
+## Download dataset
 
-Due to the nature of our data, we already know that the vocabulary for our target characters
-is 'a'-'z'. We add 3 extra tokens to this vocabulary:
-
-- `'<'`: start token
-- `'>'`: end token
-- `'-'`: pad token
-
-We tokenize the text labels with the above vocabulary.
-For the audio, we compute Log Mel-spectrograms from the wav file using signal
-processing functions present in TensorFlow. Log Mel-spectrogram is a popular
-feature preprocessing setup in ASR experiments.
+Note: This requires ~3.6 GB of disk space and
+takes ~5 minutes for the extraction of files.
 """
 
 
-def char_to_idx(ch):
-    if ch == "<":
-        return 27  # start token
-    if ch == ">":
-        return 28  # end token
-    if ch == "-":
-        return 0  # pad token
-    return ord(ch) - 96  # a->1, b->2, etc
+import keras
+import os
 
-
-def filename_to_label(f):
-    m = {
-        "0": [char_to_idx(ch) for ch in "<zero>-"],
-        "1": [char_to_idx(ch) for ch in "<one>--"],
-        "2": [char_to_idx(ch) for ch in "<two>--"],
-        "3": [char_to_idx(ch) for ch in "<three>"],
-        "4": [char_to_idx(ch) for ch in "<four>-"],
-        "5": [char_to_idx(ch) for ch in "<five>-"],
-        "6": [char_to_idx(ch) for ch in "<six>--"],
-        "7": [char_to_idx(ch) for ch in "<seven>"],
-        "8": [char_to_idx(ch) for ch in "<eight>"],
-        "9": [char_to_idx(ch) for ch in "<nine>-"],
-    }
-    return m[f.split("/")[-1][0]]
-
-
-def fpath_to_logmelspec(f):
-    sample_rate = 8000
-    audio = tf.io.read_file(f)
-    audio, _ = tf.audio.decode_wav(audio, 1, sample_rate)
-    audio = tf.squeeze(audio, axis=-1)
-    audio = tf.expand_dims(audio, axis=0)
-    stfts = tf.signal.stft(
-        audio, frame_length=1024, frame_step=256, fft_length=1024
-    )  # A 1024-point STFT with frames of 64 ms and 75% overlap.
-    spectrograms = tf.abs(stfts)
-
-    # Warp the linear scale spectrograms into the mel-scale.
-    num_spectrogram_bins = stfts.shape[-1]
-    lower_edge_hertz, upper_edge_hertz, num_mel_bins = 80.0, 2000.0, 80
-    linear_to_mel_weight_matrix = tf.signal.linear_to_mel_weight_matrix(
-        num_mel_bins,
-        num_spectrogram_bins,
-        sample_rate,
-        lower_edge_hertz,
-        upper_edge_hertz,
-    )
-    mel_spectrograms = tf.tensordot(spectrograms, linear_to_mel_weight_matrix, 1)
-    mel_spectrograms.set_shape(
-        spectrograms.shape[:-1].concatenate(linear_to_mel_weight_matrix.shape[-1:])
-    )
-
-    # Compute a stabilized log to get log-magnitude mel-scale spectrograms.
-    log_mel_spectrograms = tf.math.log(mel_spectrograms + 1e-6)
-    return tf.squeeze(log_mel_spectrograms, axis=0)
-
-
-def create_dataset(flist, bs=4):
-    label_data = [filename_to_label(f) for f in flist]
-    audio_ds = tf.data.Dataset.from_tensor_slices(flist)
-    audio_ds = audio_ds.map(fpath_to_logmelspec)
-    label_ds = tf.data.Dataset.from_tensor_slices(label_data)
-    ds = tf.data.Dataset.zip((audio_ds, label_ds))
-    ds = ds.map(lambda x, y: {"src": x, "trg": y})
-    return ds.batch(bs)
-
-
-"""
-## Create a Dataset object
-"""
-
-data_path = keras.utils.get_file(
-    "spoken_digit.tar.gz",
-    "https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.9.tar.gz",
+keras.utils.get_file(
+    os.path.join(os.getcwd(), "data.tar.gz"),
+    "https://data.keithito.com/data/speech/LJSpeech-1.1.tar.bz2",
+    extract=True,
+    archive_format="tar",
+    cache_dir=".",
 )
-command = f"tar -xvf {data_path} --directory ."
-os.system(command)
 
-root = "free-spoken-digit-dataset-1.0.9/recordings"
-flist = [os.path.join(root, x) for x in os.listdir(root)]
-random.shuffle(flist)
-train_list = flist[:1800]
-val_list = flist[1800:]
-ds = create_dataset(train_list)
-val_ds = create_dataset(val_list)
+
+saveto = "./datasets/LJSpeech-1.1"
+wavs = glob("{}/**/*.wav".format(saveto), recursive=True)
+
+id_to_text = {}
+with open(os.path.join(saveto, "metadata.csv")) as f:
+    for line in f:
+        id = line.strip().split("|")[0]
+        text = line.strip().split("|")[2]
+        id_to_text[id] = text
+
+
+def get_data(wavs, id_to_text, maxlen=50):
+    """ returns mapping of audio paths and transcription texts """
+    data = []
+    for w in wavs:
+        id = w.split("/")[-1].split(".")[0]
+        if len(id_to_text[id]) < maxlen:
+            data.append({"audio": w, "text": id_to_text[id]})
+    return data
+
 
 """
-## Callback to display predictions
+## Preprocess dataset
+"""
+
+
+class VectorizeChar:
+    def __init__(self, max_len=50):
+        self.vocab = (
+            ["-", "#", "<", ">"]
+            + [chr(i + 96) for i in range(1, 27)]
+            + [" ", ".", ",", "?"]
+        )
+        self.max_len = max_len
+        self.char_to_idx = {}
+        for i, ch in enumerate(self.vocab):
+            self.char_to_idx[ch] = i
+
+    def __call__(self, text):
+        text = text.lower()
+        text = text[: self.max_len - 2]
+        text = "<" + text + ">"
+        pad_len = self.max_len - len(text)
+        return [self.char_to_idx.get(ch, 1) for ch in text] + [0] * pad_len
+
+    def get_vocabulary(self):
+        return self.vocab
+
+
+max_target_len = 200  # all transcripts in out data are < 200 characters
+data = get_data(wavs, id_to_text, max_target_len)
+vectorize_layer = VectorizeChar(max_target_len)
+len(vectorize_layer.get_vocabulary())
+
+
+def create_text_ds(data):
+    texts = [_["text"] for _ in data]
+    text_ds = [vectorize_layer(t) for t in texts]
+    text_ds = tf.data.Dataset.from_tensor_slices(text_ds)
+    return text_ds
+
+
+def path_to_audio(path):
+    # spectrogram using stft
+    audio = tf.io.read_file(path)
+    audio, _ = tf.audio.decode_wav(audio, 1)
+    audio = tf.squeeze(audio, axis=-1)
+    stfts = tf.signal.stft(audio, frame_length=200, frame_step=80, fft_length=256)
+    x = tf.math.pow(tf.abs(stfts), 0.5)
+    # normalisation
+    means = tf.math.reduce_mean(x, 1, keepdims=True)
+    stddevs = tf.math.reduce_std(x, 1, keepdims=True)
+    x = tf.divide(tf.subtract(x, means), stddevs)
+    audio_len = tf.shape(x)[0]
+    # padding to 10 seconds
+    pad_len = 2754
+    paddings = tf.constant([[0, pad_len], [0, 0]])
+    x = tf.pad(x, paddings, "CONSTANT")[:pad_len, :]
+    return x
+
+
+def create_audio_ds(data):
+    flist = [_["audio"] for _ in data]
+    audio_ds = tf.data.Dataset.from_tensor_slices(flist)
+    audio_ds = audio_ds.map(
+        path_to_audio, num_parallel_calls=tf.data.experimental.AUTOTUNE
+    )
+    return audio_ds
+
+
+def create_tf_dataset(data, bs=4):
+    audio_ds = create_audio_ds(data)
+    text_ds = create_text_ds(data)
+    ds = tf.data.Dataset.zip((audio_ds, text_ds))
+    ds = ds.map(lambda x, y: {"src": x, "trg": y})
+    ds = ds.batch(bs)
+    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
+    return ds
+
+
+"""
+Check contents of one batch
+"""
+
+
+split = int(len(data) * 0.99)
+train_data = data[:split]
+test_data = data[split:]
+
+ds = create_tf_dataset(train_data, bs=64)
+val_ds = create_tf_dataset(test_data, bs=4)
+
+for i in ds.take(1):
+    print(i["src"].shape)
+    print(i["trg"])
+
+
+"""
+## Callbacks to display predictions and to change learning rate
 """
 
 
 class DisplayOutputs(keras.callbacks.Callback):
-    def __init__(self, batch, trg_start_token_idx=27, trg_end_token_idx=28):
+    def __init__(
+        self, batch, idx_to_token, trg_start_token_idx=27, trg_end_token_idx=28
+    ):
+        """ Displays a batch of outputs after every epoch 
+        Arguments:
+        - batch: test batch containing the keys "src" and "trg"
+        - idx_to_token: a List containing the vocabulary tokens corresponding to their indices
+        - trg_start_token_idx: start token index in the target vocabulary
+        - trg_end_token_idx: end token index in the target vocabulary
+        """
         self.batch = batch
         self.trg_start_token_idx = trg_start_token_idx
-        self.idx_to_char = ["-"] + [chr(i + 96) for i in range(1, 27)] + ["<", ">"]
+        self.trg_end_token_idx = trg_end_token_idx
+        self.idx_to_char = idx_to_token
 
     def on_epoch_end(self, epoch, logs=None):
+        if epoch % 5 != 0:
+            return
+        print('lr', self.model.optimizer.lr.numpy())
         src = self.batch["src"]
         trg = self.batch["trg"].numpy()
         bs = tf.shape(src)[0]
@@ -364,40 +450,75 @@ class DisplayOutputs(keras.callbacks.Callback):
         for i in range(bs):
             target = ""
             for idx in trg[i, :]:
-                target += self.idx_to_char[idx]
-            prediction = "<"
+                target += "" + self.idx_to_char[idx]
+            prediction = ""
             over = False
             for idx in preds[i, :]:
                 if over:  # Add padding token once end token has beeen predicted
                     prediction += "-"
                     continue
-                if idx == 28:
+                if idx == self.trg_end_token_idx:
                     over = True
-                prediction += self.idx_to_char[idx]
+                prediction += "" + self.idx_to_char[idx]
             print(f"target:     {target}")
             print(f"prediction: {prediction}")
             print()
+
+
+def scheduler(epoch, lr):
+    """ linear warm up - linear decay """
+    init_lr = 0.00001
+    lr_after_warmup = 0.001
+    final_lr = 0.00001
+    warmup_epochs = 15
+    decay_epochs = 85
+    if epoch < warmup_epochs:
+        return init_lr + ((lr_after_warmup - init_lr) / (warmup_epochs - 1)) * epoch
+    return max(
+        final_lr,
+        lr_after_warmup
+        - (epoch - warmup_epochs) * (lr_after_warmup - final_lr) / (decay_epochs),
+    )
 
 
 """
 ## Create & train the end-to-end model
 """
 
-model = Transformer(
-    input_type="feats",
-    nvocab=1000,
-    ninp=80,
-    nhid=64,
-    nhead=2,
-    nff=128,
-    src_maxlen=28,
-    trg_maxlen=6,
-    nlayers=2,
-    nclasses=29,
-)
+
 for i in val_ds.take(1):
     batch = i  # Use the first batch of validation set to display outputs
 
-cb = DisplayOutputs(batch)
+# vocabulary to convert predicted indices to characters
+idx_to_char = vectorize_layer.get_vocabulary()
+display_cb = DisplayOutputs(
+    batch, idx_to_char, trg_start_token_idx=2, trg_end_token_idx=3
+)  # set the arguments as per vocabulary index for '<' and '>'
+
+schedule_cb = tf.keras.callbacks.LearningRateScheduler(scheduler)
+
+model = Transformer(
+    num_hid=200,
+    num_head=2,
+    num_ff=400,
+    trg_maxlen=max_target_len,
+    num_layers_enc=4,
+    num_layers_dec=1,
+    num_classes=34,
+)
 model.compile(optimizer="adam")
-model.fit(ds, callbacks=[cb], epochs=4)
+
+history = model.fit(ds, callbacks=[display_cb, schedule_cb], epochs=1)
+
+"""
+In practice, train for ~100 epochs. 
+
+Some of the predicted text around epoch 35.
+```
+target:     <as they sat in the car, frazier asked oswald where his lunch was>
+prediction: <as they sat in the car frazier his lunch ware mis lunch was>
+
+target:     <under the entry for may one, nineteen sixty,>
+prediction: <under the introus for may monee, nin the sixty,>
+```
+"""

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -169,7 +169,7 @@ class TransformerDecoder(layers.Layer):
 """
 ## Complete Transformer Model
 
-Our model takes audio spectrograms as input, and predicts a sequence of characters.
+Our model takes audio spectrograms as inputs and predicts a sequence of characters.
 During training, we give the decoder the target character sequence shifted to the left
 as input. During inference, the decoder uses its own past predictions to predict the 
 next token.

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -7,18 +7,22 @@ Description: Implement a complete transformer and train it on sequence to sequen
 """
 """
 ## Introduction
-Automatic speech recognition is the task of predicting text from an audio segment.
-One of the popular ways to solve this task, is by treating it as a sequence to
-sequence problem. The audio can be represented as a sequence of feature vectors
-and the text can be considered as a sequence of characters, words, or subword tokens.
+
+Automatic speech recognition (ASR) consists of transcribing audio segments into text.
+A popular way to handle this task is to treat it as a sequence-to-sequence
+problem. The audio can be represented as a sequence of feature vectors,
+and the text can be represented as a sequence of characters, words, or subword tokens.
+
 ASR models typically require huge datasets and take a lot of time to train.
-For this demonstration, we will use a simple dataset to reduce the training time and
-display some results. Our model will be a complete transformer (both encoder and decoder)
+For this demonstration, we will use a simple dataset so as to reduce training time yet
+display interesting results. Our model will be a Transformer (both encoder and decoder)
 as proposed in the paper, "Attention is All You Need".
+
 Our data consists of audio segments with a person speaking out one of the ten digits
 (0-9). We convert the digits as a sequence of characters (e.g. 9 -> n,i,n,e) to form
 a small dataset. The method shown below, however, can be applied to a real world
 speech dataset, to learn the mapping from audio to a sequence of characters.
+
 **References:**
 - [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
 - [Free Spoken Digit Dataset](https://github.com/Jakobovski/free-spoken-digit-dataset)
@@ -29,9 +33,10 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
-tf.__version__
+
 """
 ## Transformer Input Layer
+
 This layer computes the sum of position embeddings and feature embeddings to feed to
 the transformer layers.
 """
@@ -107,8 +112,8 @@ class TransformerDecoderLayer(layers.Layer):
         )
 
     def causal_attention_mask(self, batch_size, n_dest, n_src, dtype):
-        """
-        Mask the upper half of the dot product matrix in self attention.
+        """Mask the upper half of the dot product matrix in self attention.
+
         This prevents flow of information from future tokens to current token.
         1's in the lower triangle, counting from the lower right corner.
         """
@@ -139,6 +144,7 @@ class TransformerDecoderLayer(layers.Layer):
 """
 ## Complete Transformer Model
 """
+
 loss_object = tf.keras.losses.SparseCategoricalCrossentropy(
     from_logits=True, reduction="none"
 )
@@ -236,16 +242,19 @@ class Transformer(keras.Model):
 
 
 """
-# Preprocess the ASR data
-Due to the nature of our data, we already know the vocabulary for our target characters
-is 'a'-'z'. We add 3 extra tokens to this vocabulary.
+## Preprocess the ASR data
+
+Due to the nature of our data, we already know that the vocabulary for our target characters
+is 'a'-'z'. We add 3 extra tokens to this vocabulary:
+
 - `'<'`: start token
 - `'>'`: end token
 - `'-'`: pad token
+
 We tokenize the text labels with the above vocabulary.
-For the audio, we compute Log Mel spectrograms from the wav file using signal
-processing functions present in Tensorflow. Log Mel spectrogram is a popular
-feature for in ASR experiments.
+For the audio, we compute Log Mel-spectrograms from the wav file using signal
+processing functions present in TensorFlow. Log Mel-spectrogram is a popular
+feature preprocessing setup in ASR experiments.
 """
 
 
@@ -317,8 +326,9 @@ def create_dataset(flist, bs=4):
 
 
 """
-# Create ASR dataset object
+## Create a Dataset object
 """
+
 data_path = keras.utils.get_file(
     "spoken_digit.tar.gz",
     "https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.9.tar.gz",
@@ -333,8 +343,9 @@ train_list = flist[:1800]
 val_list = flist[1800:]
 ds = create_dataset(train_list)
 val_ds = create_dataset(val_list)
+
 """
-# Callback to display predictions
+## Callback to display predictions
 """
 
 
@@ -369,8 +380,9 @@ class DisplayOutputs(keras.callbacks.Callback):
 
 
 """
-# Create model and train
+## Create & train the end-to-end model
 """
+
 model = Transformer(
     input_type="feats",
     nvocab=1000,

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -167,7 +167,7 @@ class TransformerDecoder(layers.Layer):
 
 
 """
-## Complete Transformer Model
+## Complete the Transformer model
 
 Our model takes audio spectrograms as inputs and predicts a sequence of characters.
 During training, we give the decoder the target character sequence shifted to the left

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -8,12 +8,12 @@ Description: Training a sequence-to-sequence Transformer for automatic speech re
 """
 ## Introduction
 
-Automatic speech recognition (ASR) consists of transcribing audio segments into text.
-ASK tasks can be treat sequence-to-sequence problems, where the
+Automatic speech recognition (ASR) consists of transcribing audio speech segments into text.
+ASR can be treated as a sequence-to-sequence problem, where the
 audio can be represented as a sequence of feature vectors
-and the text—as a sequence of characters, words, or subword tokens.
+and the text as a sequence of characters, words, or subword tokens.
 
-For this demonstration, we will use LJSpeech dataset from the
+For this demonstration, we will use the LJSpeech dataset from the
 [LibriVox](https://librivox.org/) project. It consists of short
 audio clips of a single speaker reading passages from 7 non-fiction books.
 Our model will be similar to the original Transformer (both encoder and decoder)
@@ -21,6 +21,7 @@ as proposed in the paper, "Attention is All You Need".
 
 
 **References:**
+
 - [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
 - [Very Deep Self-Attention Networks for End-to-End Speech Recognition](https://arxiv.org/pdf/1904.13377.pdf)
 - [Speech Transformers](https://ieeexplore.ieee.org/document/8462506)
@@ -37,13 +38,13 @@ from tensorflow.keras import layers
 
 
 """
-## Define the Transformer's Input Layer
+## Define the Transformer Input Layer
 
 When processing past target tokens for the decoder, we compute the sum of 
 position embeddings and token embeddings.
 
 When processing audio features, we apply convolutional layers to downsample
-them and process local relationships. It makes the training stable.
+them (via convolution stides) and process local relationships.
 """
 
 

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -441,7 +441,6 @@ class DisplayOutputs(keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         if epoch % 5 != 0:
             return
-        print('lr', self.model.optimizer.lr.numpy())
         src = self.batch["src"]
         trg = self.batch["trg"].numpy()
         bs = tf.shape(src)[0]

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -1,0 +1,391 @@
+"""
+Title: Automatic Speech Recognition with Transformer
+Author: [Apoorv Nandan](https://twitter.com/NandanApoorv)
+Date created: 2021/01/13
+Last modified: 2021/01/13
+Description: Implement a complete transformer and train it on sequence to sequence ASR.
+"""
+"""
+## Introduction
+Automatic speech recognition is the task of predicting text from an audio segment.
+One of the popular ways to solve this task, is by treating it as a sequence to
+sequence problem. The audio can be represented as a sequence of feature vectors
+and the text can be considered as a sequence of characters, words, or subword tokens.
+ASR models typically require huge datasets and take a lot of time to train.
+For this demonstration, we will use a simple dataset to reduce the training time and
+display some results. Our model will be a complete transformer (both encoder and decoder)
+as proposed in the paper, "Attention is All You Need".
+Our data consists of audio segments with a person speaking out one of the ten digits
+(0-9). We convert the digits as a sequence of characters (e.g. 9 -> n,i,n,e) to form
+a small dataset. The method shown below, however, can be applied to a real world
+speech dataset, to learn the mapping from audio to a sequence of characters.
+**References:**
+- [Attention is All You Need](https://papers.nips.cc/paper/2017/file/3f5ee243547dee91fbd053c1c4a845aa-Paper.pdf)
+- [Free Spoken Digit Dataset](https://github.com/Jakobovski/free-spoken-digit-dataset)
+"""
+import os
+import random
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+
+tf.__version__
+"""
+## Transformer Input Layer
+This layer computes the sum of position embeddings and feature embeddings to feed to
+the transformer layers.
+"""
+
+
+class TransformerInput(layers.Layer):
+    def __init__(
+        self, input_type="tokens", nvocab=1000, nhid=64, nff=128, maxlen=100,
+    ):
+        super().__init__()
+        self.input_type = input_type
+        if input_type == "tokens":
+            self.emb = tf.keras.layers.Embedding(nvocab, nhid)
+        elif input_type == "feats":
+            self.emb = tf.keras.layers.Dense(nhid)
+        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=nhid)
+
+    def call(self, x):
+        if self.input_type == "tokens":
+            maxlen = tf.shape(x)[-1]
+        elif self.input_type == "feats":
+            maxlen = tf.shape(x)[1]
+        x = self.emb(x)
+        positions = tf.range(start=0, limit=maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        return x + positions
+
+
+"""
+## Transformer Encoder Layer
+"""
+
+
+class TransformerEncoderLayer(layers.Layer):
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super().__init__()
+        self.att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.ffn = keras.Sequential(
+            [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim),]
+        )
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
+
+    def call(self, inputs, training):
+        attn_output = self.att(inputs, inputs)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(inputs + attn_output)
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        return self.layernorm2(out1 + ffn_output)
+
+
+"""
+## Transformer Decoder Layer
+"""
+
+
+class TransformerDecoderLayer(layers.Layer):
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super().__init__()
+        self.ln1 = layers.LayerNormalization(epsilon=1e-6)
+        self.ln2 = layers.LayerNormalization(epsilon=1e-6)
+        self.ln3 = layers.LayerNormalization(epsilon=1e-6)
+        self.self_att = layers.MultiHeadAttention(
+            num_heads=num_heads, key_dim=embed_dim
+        )
+        self.enc_att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.drop = layers.Dropout(rate)
+        self.ffn = keras.Sequential(
+            [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim),]
+        )
+
+    def causal_attention_mask(self, batch_size, n_dest, n_src, dtype):
+        """
+        Mask the upper half of the dot product matrix in self attention.
+        This prevents flow of information from future tokens to current token.
+        1's in the lower triangle, counting from the lower right corner.
+        """
+        i = tf.range(n_dest)[:, None]
+        j = tf.range(n_src)
+        m = i >= j - n_src + n_dest
+        mask = tf.cast(m, dtype)
+        mask = tf.reshape(mask, [1, n_dest, n_src])
+        mult = tf.concat(
+            [tf.expand_dims(batch_size, -1), tf.constant([1, 1], dtype=tf.int32)], 0
+        )
+        return tf.tile(mask, mult)
+
+    def call(self, enc_out, trg):
+        input_shape = tf.shape(trg)
+        batch_size = input_shape[0]
+        seq_len = input_shape[1]
+        causal_mask = self.causal_attention_mask(batch_size, seq_len, seq_len, tf.bool)
+        trg_att = self.self_att(trg, trg, attention_mask=causal_mask)
+        trg_norm = self.ln1(trg + self.drop(trg_att))
+        enc_out = self.enc_att(trg_norm, enc_out)
+        enc_out_norm = self.ln2(self.drop(enc_out) + trg_norm)
+        ffn_out = self.ffn(enc_out_norm)
+        ffn_out_norm = self.ln3(enc_out_norm + self.drop(ffn_out))
+        return ffn_out_norm
+
+
+"""
+## Complete Transformer Model
+"""
+loss_object = tf.keras.losses.SparseCategoricalCrossentropy(
+    from_logits=True, reduction="none"
+)
+
+
+def masked_loss(real, pred):
+    """ assuming pad token index = 0 """
+    mask = tf.math.logical_not(tf.math.equal(real, 0))
+    loss_ = loss_object(real, pred)
+    mask = tf.cast(mask, dtype=loss_.dtype)
+    loss_ *= mask
+    return tf.reduce_mean(loss_)
+
+
+class Transformer(keras.Model):
+    def __init__(
+        self,
+        input_type="tokens",
+        nvocab=1000,
+        ninp=32,
+        nhid=64,
+        nhead=2,
+        nff=128,
+        src_maxlen=100,
+        trg_maxlen=100,
+        nlayers=2,
+        nclasses=10,
+    ):
+        super().__init__()
+        self.nlayers = nlayers
+        self.trg_maxlen = trg_maxlen
+        self.input_type = input_type
+
+        self.enc_input = TransformerInput(
+            input_type=input_type, nvocab=1000, nhid=64, maxlen=src_maxlen
+        )
+        self.dec_input = TransformerInput(
+            input_type="tokens", nvocab=nclasses, nhid=nhid, maxlen=trg_maxlen
+        )
+        for i in range(nlayers):
+            setattr(self, f"enc_layer_{i}", TransformerEncoderLayer(nhid, nhead, nff))
+            setattr(self, f"dec_layer_{i}", TransformerDecoderLayer(nhid, nhead, nff))
+
+        self.final = layers.Dense(nclasses)
+
+    def encode_src(self, src):
+        x = self.enc_input(src)
+        for i in range(self.nlayers):
+            x = getattr(self, f"enc_layer_{i}")(x)
+        return x
+
+    def decode(self, enc_out, trg):
+        y = self.dec_input(trg)
+        for i in range(self.nlayers):
+            y = getattr(self, f"dec_layer_{i}")(enc_out, y)
+        return y
+
+    def call(self, inputs):
+        src = inputs[0]
+        trg = inputs[1]
+        x = self.encode_src(src)
+        y = self.decode(x, trg)
+        return self.final(y)
+
+    def train_step(self, batch):
+        """ Process one batch inside model.fit() """
+        src = batch["src"]
+        trg = batch["trg"]
+        dec_inp = trg[:, :-1]
+        dec_trg = trg[:, 1:]
+        with tf.GradientTape() as tape:
+            preds = self([src, dec_inp])
+            loss = masked_loss(dec_trg, preds)
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        return {"loss": loss}
+
+    def generate(self, src, trg_start_token_idx):
+        """ Return a batch of predicted token indices with greedy deecoding """
+        bs = tf.shape(src)[0]
+        dec_inp = tf.ones((bs, self.trg_maxlen), dtype=tf.int32) * trg_start_token_idx
+        for i in range(self.trg_maxlen):
+            preds = self([src, dec_inp])
+            pred_idx = tf.argmax(preds, axis=-1, output_type=tf.int32)
+            current_pred = tf.expand_dims(pred_idx[:, i], axis=-1)
+            if i < self.trg_maxlen - 1:
+                future_pad = tf.ones((bs, self.trg_maxlen - (i + 2)), dtype=tf.int32)
+                dec_inp = tf.concat(
+                    [dec_inp[:, : i + 1], current_pred, future_pad], axis=-1
+                )
+            else:
+                dec_inp = tf.concat([dec_inp[:, : i + 1], current_pred], axis=-1)
+        return pred_idx
+
+
+"""
+# Preprocess the ASR data
+Due to the nature of our data, we already know the vocabulary for our target characters
+is 'a'-'z'. We add 3 extra tokens to this vocabulary.
+- `'<'`: start token
+- `'>'`: end token
+- `'-'`: pad token
+We tokenize the text labels with the above vocabulary.
+For the audio, we compute Log Mel spectrograms from the wav file using signal
+processing functions present in Tensorflow. Log Mel spectrogram is a popular
+feature for in ASR experiments.
+"""
+
+
+def char_to_idx(ch):
+    if ch == "<":
+        return 27  # start token
+    if ch == ">":
+        return 28  # end token
+    if ch == "-":
+        return 0  # pad token
+    return ord(ch) - 96  # a->1, b->2, etc
+
+
+def filename_to_label(f):
+    m = {
+        "0": [char_to_idx(ch) for ch in "<zero>-"],
+        "1": [char_to_idx(ch) for ch in "<one>--"],
+        "2": [char_to_idx(ch) for ch in "<two>--"],
+        "3": [char_to_idx(ch) for ch in "<three>"],
+        "4": [char_to_idx(ch) for ch in "<four>-"],
+        "5": [char_to_idx(ch) for ch in "<five>-"],
+        "6": [char_to_idx(ch) for ch in "<six>--"],
+        "7": [char_to_idx(ch) for ch in "<seven>"],
+        "8": [char_to_idx(ch) for ch in "<eight>"],
+        "9": [char_to_idx(ch) for ch in "<nine>-"],
+    }
+    return m[f.split("/")[-1][0]]
+
+
+def fpath_to_logmelspec(f):
+    sample_rate = 8000
+    audio = tf.io.read_file(f)
+    audio, _ = tf.audio.decode_wav(audio, 1, sample_rate)
+    audio = tf.squeeze(audio, axis=-1)
+    audio = tf.expand_dims(audio, axis=0)
+    stfts = tf.signal.stft(
+        audio, frame_length=1024, frame_step=256, fft_length=1024
+    )  # A 1024-point STFT with frames of 64 ms and 75% overlap.
+    spectrograms = tf.abs(stfts)
+
+    # Warp the linear scale spectrograms into the mel-scale.
+    num_spectrogram_bins = stfts.shape[-1]
+    lower_edge_hertz, upper_edge_hertz, num_mel_bins = 80.0, 2000.0, 80
+    linear_to_mel_weight_matrix = tf.signal.linear_to_mel_weight_matrix(
+        num_mel_bins,
+        num_spectrogram_bins,
+        sample_rate,
+        lower_edge_hertz,
+        upper_edge_hertz,
+    )
+    mel_spectrograms = tf.tensordot(spectrograms, linear_to_mel_weight_matrix, 1)
+    mel_spectrograms.set_shape(
+        spectrograms.shape[:-1].concatenate(linear_to_mel_weight_matrix.shape[-1:])
+    )
+
+    # Compute a stabilized log to get log-magnitude mel-scale spectrograms.
+    log_mel_spectrograms = tf.math.log(mel_spectrograms + 1e-6)
+    return tf.squeeze(log_mel_spectrograms, axis=0)
+
+
+def create_dataset(flist, bs=4):
+    label_data = [filename_to_label(f) for f in flist]
+    audio_ds = tf.data.Dataset.from_tensor_slices(flist)
+    audio_ds = audio_ds.map(fpath_to_logmelspec)
+    label_ds = tf.data.Dataset.from_tensor_slices(label_data)
+    ds = tf.data.Dataset.zip((audio_ds, label_ds))
+    ds = ds.map(lambda x, y: {"src": x, "trg": y})
+    return ds.batch(bs)
+
+
+"""
+# Create ASR dataset object
+"""
+data_path = keras.utils.get_file(
+    "spoken_digit.tar.gz",
+    "https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.9.tar.gz",
+)
+command = f"tar -xvf {data_path} --directory ."
+os.system(command)
+
+root = "free-spoken-digit-dataset-1.0.9/recordings"
+flist = [os.path.join(root, x) for x in os.listdir(root)]
+random.shuffle(flist)
+train_list = flist[:1800]
+val_list = flist[1800:]
+ds = create_dataset(train_list)
+val_ds = create_dataset(val_list)
+"""
+# Callback to display predictions
+"""
+
+
+class DisplayOutputs(keras.callbacks.Callback):
+    def __init__(self, batch, trg_start_token_idx=27, trg_end_token_idx=28):
+        self.batch = batch
+        self.trg_start_token_idx = trg_start_token_idx
+        self.idx_to_char = ["-"] + [chr(i + 96) for i in range(1, 27)] + ["<", ">"]
+
+    def on_epoch_end(self, epoch, logs=None):
+        src = self.batch["src"]
+        trg = self.batch["trg"].numpy()
+        bs = tf.shape(src)[0]
+        preds = self.model.generate(src, self.trg_start_token_idx)
+        preds = preds.numpy()
+        for i in range(bs):
+            target = ""
+            for idx in trg[i, :]:
+                target += self.idx_to_char[idx]
+            prediction = "<"
+            over = False
+            for idx in preds[i, :]:
+                if over:  # Add padding token once end token has beeen predicted
+                    prediction += "-"
+                    continue
+                if idx == 28:
+                    over = True
+                prediction += self.idx_to_char[idx]
+            print(f"target:     {target}")
+            print(f"prediction: {prediction}")
+            print()
+
+
+"""
+# Create model and train
+"""
+model = Transformer(
+    input_type="feats",
+    nvocab=1000,
+    ninp=80,
+    nhid=64,
+    nhead=2,
+    nff=128,
+    src_maxlen=28,
+    trg_maxlen=6,
+    nlayers=2,
+    nclasses=29,
+)
+for i in val_ds.take(1):
+    batch = i  # Use the first batch of validation set to display outputs
+
+cb = DisplayOutputs(batch)
+model.compile(optimizer="adam")
+model.fit(ds, callbacks=[cb], epochs=4)


### PR DESCRIPTION
Some decisions I made to keep this example short and easy to train:

- Model - Transformer (both encoder and decoder):
I picked a sequence to sequence approach instead of a CTC pipeline because we already have a good example showing the CTC setup. (OCR Captcha Recognition) and a CTC based example will be very similar to it.

- Data - Free spoken digit dataset:
A standard (and more realistic) dataset like LibriSpeech requires few hours for training (even with a V100) to reach a WER < 10%. Free spoken digit contains small segments of audio (<= 1 second) and a single word as the transcript (treated as a sequence of characters). This data is very easy to train on but demonstrates a complete sequence to sequence pipeline.
 
- To make it slightly more difficult I prepared another dataset from this, by combining 2 random audio files and their transcripts, to create longer audio segments and character sequences. This requires more iterations to achieve good performance.

- I was not sure if the extra lines of code to create the modified dataset would be useful for this demo, so I have committed the script with the original one-word dataset.

- I am aware that a real-world speech recognition system involves a lot more bells and whistles (especially with a transformer model), but this is just a minimal example.

