### PR TITLE
Minor changes to correct spellings

### DIFF
--- a/guides/md/transfer_learning.md
+++ b/guides/md/transfer_learning.md
@@ -429,7 +429,7 @@ you'll probably want to use the utility
 `tf.keras.preprocessing.image_dataset_from_directory` to generate similar labeled
  dataset objects from a set of images on disk filed into class-specific folders.
 
-Tansfer learning is most useful when working with very small datases. To keep our
+Transfer learning is most useful when working with very small datasets. To keep our
 dataset small, we will use 40% of the original training data (25,000 images) for
  training, 10% for validation, and 10% for testing.
 


### PR DESCRIPTION
Tanser corrected to Transfer
datases corrected to datasets

These words are spelt correctly in the .ipynb and .py files