### PR TITLE
Fix broken url in sequential model

### DIFF
--- a/guides/sequential_model.py
+++ b/guides/sequential_model.py
@@ -254,7 +254,7 @@ Once your model architecture is ready, you will want to:
 - Save your model to disk and restore it. See our
 [guide to serialization & saving](/guides/serialization_and_saving/).
 - Speed up model training by leveraging multiple GPUs. See our
-[guide to multi-GPU and distributed training](/guides/distributed_training).
+[guide to multi-GPU and distributed training](/guides/distributed_training/).
 """
 
 """


### PR DESCRIPTION
It seems that on the [`sequential model`'s doc page](https://www.tensorflow.org/guide/keras/sequential_model#what_to_do_once_you_have_a_model) the link referencing the `distributed_training` guide (third bullet point) is broken.

As the other links in the document work as expected my (unverified and untested) guess to fix this is to add the missing tailing slash.