### PR TITLE
Load model from the correct path

### DIFF
--- a/examples/generative/cyclegan.py
+++ b/examples/generative/cyclegan.py
@@ -628,7 +628,7 @@ unzip -qq saved_checkpoints.zip
 
 
 # Load the checkpoints
-weight_file = "./saved_checkpoints/cyclegan_checkpoints.090"
+weight_file = "./model_checkpoints/cyclegan_checkpoints.090"
 cycle_gan_model.load_weights(weight_file).expect_partial()
 print("Weights loaded successfully")
 


### PR DESCRIPTION
The model was saved at the path **model_checkpoints** but it was getting loaded from the path **saved_checkpoints**.
**saved_checkpoints** does not exist.