### PR TITLE
fix typo for oxford_pets_image_segmentation

### DIFF
--- a/examples/vision/ipynb/oxford_pets_image_segmentation.ipynb
+++ b/examples/vision/ipynb/oxford_pets_image_segmentation.ipynb
@@ -172,7 +172,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Perpare U-Net Xception-style model"
+    "## Prepare U-Net Xception-style model"
    ]
   },
   {

--- a/examples/vision/md/oxford_pets_image_segmentation.md
+++ b/examples/vision/md/oxford_pets_image_segmentation.md
@@ -154,7 +154,7 @@ class OxfordPets(keras.utils.Sequence):
 ```
 
 ---
-## Perpare U-Net Xception-style model
+## Prepare U-Net Xception-style model
 
 
 ```python

--- a/examples/vision/oxford_pets_image_segmentation.py
+++ b/examples/vision/oxford_pets_image_segmentation.py
@@ -104,7 +104,7 @@ class OxfordPets(keras.utils.Sequence):
 
 
 """
-## Perpare U-Net Xception-style model
+## Prepare U-Net Xception-style model
 """
 
 from tensorflow.keras import layers


### PR DESCRIPTION
Very small PR to fix a typo from `Perpare` to `Prepare`