### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/examples/graph/ipynb/node2vec_movielens.ipynb
+++ b/examples/graph/ipynb/node2vec_movielens.ipynb
@@ -8,10 +8,13 @@
    "source": [
     "# Graph representation learning with node2vec\n",
     "\n",
-    "**Author:** [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)<br>\n",
-    "**Date created:** 2021/05/15<br>\n",
-    "**Last modified:** 2021/05/15<br>\n",
-    "**Description:** Implementing the node2vec model to generate embeddings for movies from the MovieLens dataset."
+    "<b>Author:</b> [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)<br>\n",
+    "<b>Date created:</b> 2021/05/15<br>\n",
+    "<b>Last modified:</b> 2021/05/15<br>\n",
+    "<b>Description:</b> Implementing the node2vec model to generate embeddings for movies from the MovieLens dataset.",
+    "<br></br>",
+    "<br></br>",
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/keras-team/keras-io/blob/master/examples/graph/ipynb/node2vec_movielens.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
    ]
   },
   {


### PR DESCRIPTION
I've added an example of a Kaggle Badge that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480.

Potentially I could in a further PR add this badge to all ipynbs that it would make sense to.

