### PR TITLE
Update training_keras_models_on_cloud.py

### DIFF
--- a/guides/training_keras_models_on_cloud.py
+++ b/guides/training_keras_models_on_cloud.py
@@ -27,7 +27,7 @@ will need in this guide.
 """
 
 """shell
-pip install -q tensorflow_cloud
+pip install -q --use-deprecated=legacy-resolver tensorflow_cloud
 """
 
 import tensorflow as tf


### PR DESCRIPTION
In some cases `pip install tensorflow_cloud` goes into an infinite loop. 

`--use-deprecated=legacy-resolver` prevents that. 

See: cl/374546069