### PR TITLE
Typo fix in gnn_citations.py

### DIFF
--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -267,7 +267,7 @@ def create_baseline_model(hidden_units, num_classes, dropout_rate=0.2):
         x = layers.Add(name=f"skip_connection{block_idx + 2}")([x, x1])
     # Compute logits.
     logits = layers.Dense(num_classes, name="logits")(x)
-    # Create the mode.
+    # Create the model.
     return keras.Model(inputs=inputs, outputs=logits, name="baseline")
 
 

--- a/examples/graph/ipynb/gnn_citations.ipynb
+++ b/examples/graph/ipynb/gnn_citations.ipynb
@@ -504,7 +504,7 @@
     "        x = layers.Add(name=f\"skip_connection{block_idx + 2}\")([x, x1])\n",
     "    # Compute logits.\n",
     "    logits = layers.Dense(num_classes, name=\"logits\")(x)\n",
-    "    # Create the mode.\n",
+    "    # Create the model.\n",
     "    return keras.Model(inputs=inputs, outputs=logits, name=\"baseline\")\n",
     "\n",
     "\n",

--- a/examples/graph/md/gnn_citations.md
+++ b/examples/graph/md/gnn_citations.md
@@ -430,7 +430,7 @@ def create_baseline_model(hidden_units, num_classes, dropout_rate=0.2):
         x = layers.Add(name=f"skip_connection{block_idx + 2}")([x, x1])
     # Compute logits.
     logits = layers.Dense(num_classes, name="logits")(x)
-    # Create the mode.
+    # Create the model.
     return keras.Model(inputs=inputs, outputs=logits, name="baseline")
 
 


### PR DESCRIPTION
Fixed typo in a comment in line 270. "model" instead of "mode".