### PR TITLE
Update writing_a_training_loop_from_scratch.py

### DIFF
--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -59,7 +59,7 @@ First, we're going to need an optimizer, a loss function, and a dataset:
 # Instantiate an optimizer.
 optimizer = keras.optimizers.SGD(learning_rate=1e-3)
 # Instantiate a loss function.
-loss_fn = keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+loss_fn = keras.losses.SparseCategoricalCrossentropy()
 
 # Prepare the training dataset.
 batch_size = 64


### PR DESCRIPTION
Removed the argument, `from_logits=True` from the line, 

`loss_fn = keras.losses.SparseCategoricalCrossentropy(from_logits=True)`

from the [Documentation of Gradients](https://www.tensorflow.org/guide/keras/writing_a_training_loop_from_scratch#using_the_gradienttape_a_first_end-to-end_example) so that Warning specified in [50190](https://github.com/tensorflow/tensorflow/issues/50190) goes away.

Please find the [Github Gist](https://colab.research.google.com/gist/rmothukuru/6f983112a2614655c10cfb90b5fe3308/gh_50190.ipynb) in which Warning has disappeared because of the above change