### PR TITLE
In a Sequential model we have to use InputLayer instead of Input

### DIFF
--- a/examples/timeseries/timeseries_anomaly_detection.py
+++ b/examples/timeseries/timeseries_anomaly_detection.py
@@ -126,7 +126,7 @@ output of the same shape. In this case, `sequence_length` is 288 and
 
 model = keras.Sequential(
     [
-        layers.Input(shape=(x_train.shape[1], x_train.shape[2])),
+        layers.InputLayer(input_shape=(x_train.shape[1], x_train.shape[2])),
         layers.Conv1D(
             filters=32, kernel_size=7, padding="same", strides=2, activation="relu"
         ),


### PR DESCRIPTION
The original code for the first layer raises a warning:

```` 
WARNING:tensorflow:Please add `keras.layers.InputLayer` instead of `keras.Input` to Sequential model. 
`keras.Input` is intended to be used by Functional model.
Model: "sequential_3"
```

This PR just updates that line of code to use `InputLayer` and the right parameter `input_shape` instead of `input` which is used in the `Input` layer.