### PR TITLE
Fix a small typo in GC example

### DIFF
--- a/examples/vision/gradient_centralization.py
+++ b/examples/vision/gradient_centralization.py
@@ -68,7 +68,7 @@ print(f"Test images: {metadata.splits['test'].num_examples}")
 """
 ## Use Data Augmentation
 
-We will rescale the data to `[0, 1]`  andperform simple augmentations to our data.
+We will rescale the data to `[0, 1]` and perform simple augmentations to our data.
 """
 
 rescale = layers.experimental.preprocessing.Rescaling(1.0 / 255)

--- a/examples/vision/ipynb/gradient_centralization.ipynb
+++ b/examples/vision/ipynb/gradient_centralization.ipynb
@@ -115,7 +115,7 @@
    "source": [
     "## Use Data Augmentation\n",
     "\n",
-    "We will rescale the data to `[0, 1]`  andperform simple augmentations to our data."
+    "We will rescale the data to `[0, 1]` and perform simple augmentations to our data."
    ]
   },
   {

--- a/examples/vision/md/gradient_centralization.md
+++ b/examples/vision/md/gradient_centralization.md
@@ -80,7 +80,7 @@ Test images: 256
 </div>
 ## Use Data Augmentation
 
-We will rescale the data to `[0, 1]`  andperform simple augmentations to our data.
+We will rescale the data to `[0, 1]` and perform simple augmentations to our data.
 
 
 ```python


### PR DESCRIPTION
I noticed a really small typo in the the [Gradient Centralization for Better Training Performance](https://keras.io/examples/vision/gradient_centralization/) example and this PR fixes that.

Earlier it was (notice spacing):
> We will rescale the data to [0, 1]  andperform simple augmentations to our data.

Which this PR changes to:
> We will rescale the data to [0, 1] and perform simple augmentations to our data.