### PR TITLE
Delete extraneous conv layer from example

### DIFF
--- a/examples/nlp/text_classification_from_scratch.py
+++ b/examples/nlp/text_classification_from_scratch.py
@@ -250,7 +250,6 @@ x = layers.Dropout(0.5)(x)
 
 # Conv1D + global max pooling
 x = layers.Conv1D(128, 7, padding="valid", activation="relu", strides=3)(x)
-x = layers.Conv1D(128, 7, padding="valid", activation="relu", strides=3)(x)
 x = layers.GlobalMaxPooling1D()(x)
 
 # We add a vanilla hidden layer:


### PR DESCRIPTION
The second Conv1D layer is strange and does make a significant difference in the accuracy of model. Seems like a typo?

Results with only a single Conv1D layer:

<img width="736" alt="Screen Shot 2021-06-20 at 6 12 39 AM" src="https://user-images.githubusercontent.com/1220444/122675494-84e39280-d18e-11eb-8ed9-b2c0ce9e6937.png">
