### PR TITLE
Fix typo in gradient centralisation example.

### DIFF
--- a/examples/vision/gradient_centralization.py
+++ b/examples/vision/gradient_centralization.py
@@ -156,7 +156,7 @@ Also, for simplicity at the moment we are not implementing gradient cliiping fun
 however this quite easy to implement.
 
 At the moment we are just creating a subclass for the `RMSProp` optimizer
-however you could easily reproduce this for any toher optimizer or on a custom
+however you could easily reproduce this for any other optimizer or on a custom
 optimizer in the same way. We will be using this class in the later section when
 we train a model with Gradient Centralization.
 """

--- a/examples/vision/ipynb/gradient_centralization.ipynb
+++ b/examples/vision/ipynb/gradient_centralization.ipynb
@@ -245,7 +245,7 @@
     "however this quite easy to implement.\n",
     "\n",
     "At the moment we are just creating a subclass for the `RMSProp` optimizer\n",
-    "however you could easily reproduce this for any toher optimizer or on a custom\n",
+    "however you could easily reproduce this for any other optimizer or on a custom\n",
     "optimizer in the same way. We will be using this class in the later section when\n",
     "we train a model with Gradient Centralization."
    ]

--- a/examples/vision/md/gradient_centralization.md
+++ b/examples/vision/md/gradient_centralization.md
@@ -171,7 +171,7 @@ Also, for simplicity at the moment we are not implementing gradient cliiping fun
 however this quite easy to implement.
 
 At the moment we are just creating a subclass for the `RMSProp` optimizer
-however you could easily reproduce this for any toher optimizer or on a custom
+however you could easily reproduce this for any other optimizer or on a custom
 optimizer in the same way. We will be using this class in the later section when
 we train a model with Gradient Centralization.
 


### PR DESCRIPTION
This PR fixes a minor typo in the gradient centralisation example.