### PR TITLE
Remove Model.predict_classes (deprecated) from FAQ

### DIFF
--- a/templates/getting_started/faq.md
+++ b/templates/getting_started/faq.md
@@ -1048,7 +1048,7 @@ model.reset_states()
 model.layers[0].reset_states()
 ```
 
-Note that the methods `predict`, `fit`, `train_on_batch`, `predict_classes`, etc. will *all* update the states of the stateful layers in a model. This allows you to do not only stateful training, but also stateful prediction.
+Note that the methods `predict`, `fit`, `train_on_batch`, etc. will *all* update the states of the stateful layers in a model. This allows you to do not only stateful training, but also stateful prediction.
 
 
 ---


### PR DESCRIPTION
```
.../tensorflow/python/keras/engine/sequential.py:455: UserWarning: `model.predict_classes()` is deprecated 
and will be removed after 2021-01-01. Please use instead:
* `np.argmax(model.predict(x), axis=-1)`,   if your model does multi-class classification
(e.g. if it uses a `softmax` last-layer activation).
* `(model.predict(x) > 0.5).astype("int32")`,   if your model does binary classification 
(e.g. if it uses a `sigmoid` last-layer activation).
```