### PR TITLE
Fixing the comment line where the sequence length about the dataset was incorrect. 

### DIFF
--- a/examples/timeseries/ipynb/timeseries_classification_from_scratch.ipynb
+++ b/examples/timeseries/ipynb/timeseries_classification_from_scratch.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [hfawaz](https://github.com/hfawaz/)<br>\n",
     "**Date created:** 2020/07/21<br>\n",
-    "**Last modified:** 2020/08/21<br>\n",
+    "**Last modified:** 2021/07/16<br>\n",
     "**Description:** Training a timeseries classifier from scratch on the FordA dataset from the UCR/UEA archive."
    ]
   },
@@ -135,7 +135,7 @@
    "source": [
     "## Standardize the data\n",
     "\n",
-    "Our timeseries are already in a single length (176). However, their values are\n",
+    "Our timeseries are already in a single length (500). However, their values are\n",
     "usually in various ranges. This is not ideal for a neural network;\n",
     "in general we should seek to make the input values normalized.\n",
     "For this specific dataset, the data is already z-normalized: each timeseries sample\n",
@@ -417,9 +417,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/timeseries/md/timeseries_classification_from_scratch.md
+++ b/examples/timeseries/md/timeseries_classification_from_scratch.md
@@ -2,7 +2,7 @@
 
 **Author:** [hfawaz](https://github.com/hfawaz/)<br>
 **Date created:** 2020/07/21<br>
-**Last modified:** 2020/08/21<br>
+**Last modified:** 2020/07/16<br>
 **Description:** Training a timeseries classifier from scratch on the FordA dataset from the UCR/UEA archive.
 
 
@@ -88,7 +88,7 @@ plt.close()
 ---
 ## Standardize the data
 
-Our timeseries are already in a single length (176). However, their values are
+Our timeseries are already in a single length (500). However, their values are
 usually in various ranges. This is not ideal for a neural network;
 in general we should seek to make the input values normalized.
 For this specific dataset, the data is already z-normalized: each timeseries sample

--- a/examples/timeseries/timeseries_classification_from_scratch.py
+++ b/examples/timeseries/timeseries_classification_from_scratch.py
@@ -2,7 +2,7 @@
 Title: Timeseries classification from scratch
 Author: [hfawaz](https://github.com/hfawaz/)
 Date created: 2020/07/21
-Last modified: 2020/08/21
+Last modified: 2021/07/16
 Description: Training a timeseries classifier from scratch on the FordA dataset from the UCR/UEA archive.
 """
 """
@@ -77,7 +77,7 @@ plt.close()
 """
 ## Standardize the data
 
-Our timeseries are already in a single length (176). However, their values are
+Our timeseries are already in a single length (500). However, their values are
 usually in various ranges. This is not ideal for a neural network;
 in general we should seek to make the input values normalized.
 For this specific dataset, the data is already z-normalized: each timeseries sample


### PR DESCRIPTION
The FordA sequences length value is 500 instead of 176. This situation can be seen in the jupyter notebook and the .py file.

According to the paper and the code, the sequences length value is 500 instead of 176. I know that this is a minor detail, but it might be important to have that value correct for learning purposes.



![image](https://user-images.githubusercontent.com/70129680/125911640-213bd53a-2010-4015-9968-c054b7ffbe0e.png)

Page 92 [Source](https://www.cs.ucr.edu/~eamonn/time_series_data_2018/BriefingDocument2018.pdf)
![image](https://user-images.githubusercontent.com/70129680/125911736-baa9d03a-75f7-47f1-9997-4aea1fdfcf52.png)

[Source](http://www.j-wichard.de/publications/FordPaper.pdf)
![image](https://user-images.githubusercontent.com/70129680/125912411-f21d565d-6212-41cc-880a-5396dadfa15c.png)

