### PR TITLE
add ',' in sequential model guide

### DIFF
--- a/guides/sequential_model.py
+++ b/guides/sequential_model.py
@@ -321,7 +321,7 @@ last one. Like this:
 
 ```python
 model = keras.Sequential([
-    keras.Input(shape=(784))
+    keras.Input(shape=(784)),
     layers.Dense(32, activation='relu'),
     layers.Dense(32, activation='relu'),
     layers.Dense(32, activation='relu'),


### PR DESCRIPTION
very very minor issue.

I found it when I use it.