### PR TITLE
Corrected the order of Normalization layer in Transformer example

### DIFF
--- a/examples/timeseries/timeseries_classification_transformer.py
+++ b/examples/timeseries/timeseries_classification_transformer.py
@@ -76,7 +76,7 @@ def transformer_encoder(inputs, head_size, num_heads, ff_dim, dropout=0):
     # Normalization and Attention
     x = layers.MultiHeadAttention(
         key_dim=head_size, num_heads=num_heads, dropout=dropout
-    )(inputs,inputs)
+    )(inputs, inputs)
     x = layers.Dropout(dropout)(x)
     x = layers.LayerNormalization(epsilon=1e-6)(x)
     res = x + inputs

--- a/examples/timeseries/timeseries_classification_transformer.py
+++ b/examples/timeseries/timeseries_classification_transformer.py
@@ -2,7 +2,7 @@
 Title: Timeseries classification with a Transformer model
 Author: [Theodoros Ntakouris](https://github.com/ntakouris)
 Date created: 2021/06/25
-Last modified: 2021/06/25
+Last modified: 2021/08/05
 Description: This notebook demonstrates how to do timeseries classification using a Transformer model.
 """
 
@@ -74,18 +74,18 @@ The projection layers are implemented through `keras.layers.Conv1D`.
 
 def transformer_encoder(inputs, head_size, num_heads, ff_dim, dropout=0):
     # Normalization and Attention
-    x = layers.LayerNormalization(epsilon=1e-6)(inputs)
     x = layers.MultiHeadAttention(
         key_dim=head_size, num_heads=num_heads, dropout=dropout
-    )(x, x)
+    )(inputs,inputs)
     x = layers.Dropout(dropout)(x)
+    x = layers.LayerNormalization(epsilon=1e-6)(x)
     res = x + inputs
 
     # Feed Forward Part
-    x = layers.LayerNormalization(epsilon=1e-6)(res)
-    x = layers.Conv1D(filters=ff_dim, kernel_size=1, activation="relu")(x)
+    x = layers.Conv1D(filters=ff_dim, kernel_size=1, activation="relu")(res)
     x = layers.Dropout(dropout)(x)
     x = layers.Conv1D(filters=inputs.shape[-1], kernel_size=1)(x)
+    x = layers.LayerNormalization(epsilon=1e-6)(x)
     return x + res
 
 


### PR DESCRIPTION
According to the paper "Attention is all you need"The normalization layer goes after MultiheadAttenttionand after feed-forward layer