### PR TITLE
Update mnist_convnet.py

### DIFF
--- a/examples/vision/mnist_convnet.py
+++ b/examples/vision/mnist_convnet.py
@@ -46,7 +46,7 @@ y_test = keras.utils.to_categorical(y_test, num_classes)
 
 model = keras.Sequential(
     [
-        keras.Input(shape=input_shape),
+        keras.layers.InputLayer(input_shape=input_shape),
         layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
         layers.MaxPooling2D(pool_size=(2, 2)),
         layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),


### PR DESCRIPTION
Based the [docs](https://www.tensorflow.org/api_docs/python/tf/keras/layers/InputLayer?version=nightly), the recommended approach is to use `keras.Input` with Functional models whereas `keras.layers.InputLayer` is recommended to be used with Sequential model.

In this tutorial, `keras.Input` was used with Sequential model which throws a warning as shown below. 

`WARNING:tensorflow:Please add `keras.layers.InputLayer` instead of `keras.Input` to Sequential model. `keras.Input` is intended to be used by Functional model.
`
So, this PR updates the tutorial with `keras.layers.InputLayer` instead of `keras.Input`.

With this update, the warning is gone. Please check the [gist here](https://colab.research.google.com/gist/jvishnuvardhan/8ed0152d7f9247510b75a90efb3611d1/mnist_convnet.ipynb). Thanks!