### PR TITLE
Use absolute link to TensorBoard callback in Training & evaluation with the built-in methods guide

### DIFF
--- a/guides/ipynb/training_with_built_in_methods.ipynb
+++ b/guides/ipynb/training_with_built_in_methods.ipynb
@@ -1835,7 +1835,7 @@
    },
    "source": [
     "For more information, see the\n",
-    "[documentation for the `TensorBoard` callback](/api/callbacks/tensorboard/)."
+    "[documentation for the `TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/)."
    ]
   }
  ],

--- a/guides/md/training_with_built_in_methods.md
+++ b/guides/md/training_with_built_in_methods.md
@@ -1501,4 +1501,4 @@ keras.callbacks.TensorBoard(
 ```
 </div>
 For more information, see the
-[documentation for the `TensorBoard` callback](/api/callbacks/tensorboard/).
+[documentation for the `TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/).

--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -1195,5 +1195,5 @@ keras.callbacks.TensorBoard(
 
 """
 For more information, see the
-[documentation for the `TensorBoard` callback](/api/callbacks/tensorboard/).
+[documentation for the `TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/).
 """


### PR DESCRIPTION
A proposed solution to fix a 404 on tensorflow.org. Because of case-sensitivity in URLs, the link on the same guide -  https://www.tensorflow.org/guide/keras/train_and_evaluate - points to https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/tensorboard/ which is a "404" (requires `...TensorBoard/`)