### PR TITLE
image_dataset_from_directory function exists in .preprocessing not in .image

### DIFF
--- a/templates/api/preprocessing/index.md
+++ b/templates/api/preprocessing/index.md
@@ -26,7 +26,7 @@ You could simply do:
 
 ```python
 from tensorflow import keras
-from tensorflow.keras.preprocessing.image import image_dataset_from_directory
+from tensorflow.keras.preprocessing import image_dataset_from_directory
 
 train_ds = image_dataset_from_directory(
     directory='training_data/',


### PR DESCRIPTION
- Fixing typo in importing `image_dataset_from_directory` function
- This function doesn't exist in the `.image` module, but in the `.preprocessing`
- And the same function used in this [article](https://keras.io/api/preprocessing/image/#image_dataset_from_directory-function) properly  