### PR TITLE
Make the Swin Transformer example model savable

### DIFF
--- a/examples/vision/ipynb/swin_transformers.ipynb
+++ b/examples/vision/ipynb/swin_transformers.ipynb
@@ -2,9 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "# Image classification with Swin Transformers\n",
     "\n",
@@ -12,13 +9,13 @@
     "**Date created:** 2021/09/08<br>\n",
     "**Last modified:** 2021/09/08<br>\n",
     "**Description:** Image classification using Swin Transformers, a general-purpose backbone for computer vision."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "This example implements [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows](https://arxiv.org/abs/2103.14030)\n",
     "by Liu et al. for image classification, and demonstrates it on the\n",
@@ -34,35 +31,34 @@
     "\n",
     "This example requires TensorFlow 2.5 or higher, as well as TensorFlow Addons,\n",
     "which can be installed using the following commands:"
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "!pip install -U tensorflow-addons"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Setup"
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -70,27 +66,27 @@
     "import tensorflow_addons as tfa\n",
     "from tensorflow import keras\n",
     "from tensorflow.keras import layers"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Prepare the data\n",
     "\n",
     "We load the CIFAR-100 dataset through `tf.keras.datasets`,\n",
     "normalize the images, and convert the integer labels to one-hot encoded vectors."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "num_classes = 100\n",
     "input_shape = (32, 32, 3)\n",
@@ -110,13 +106,14 @@
     "    plt.grid(False)\n",
     "    plt.imshow(x_train[i])\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Configure the hyperparameters\n",
     "\n",
@@ -124,15 +121,14 @@
     "In order to use each pixel as an individual input, you can set `patch_size` to `(1, 1)`.\n",
     "Below, we take inspiration from the original paper settings\n",
     "for training on ImageNet-1K, keeping most of the original settings for this example."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "patch_size = (2, 2)  # 2-by-2 sized patches\n",
     "dropout_rate = 0.03  # Dropout rate\n",
@@ -153,27 +149,27 @@
     "validation_split = 0.1\n",
     "weight_decay = 0.0001\n",
     "label_smoothing = 0.1"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Helper functions\n",
     "\n",
     "We create two helper functions to help us get a sequence of\n",
     "patches from the image, merge patches, and apply dropout."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "\n",
     "def window_partition(x, window_size):\n",
@@ -208,20 +204,20 @@
     "    def call(self, x):\n",
     "        input_shape = tf.shape(x)\n",
     "        batch_size = input_shape[0]\n",
-    "        rank = len(input_shape)\n",
+    "        rank = input_shape.shape.as_list()[0]\n",
     "        shape = (batch_size,) + (1,) * (rank - 1)\n",
     "        random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)\n",
     "        path_mask = tf.floor(random_tensor)\n",
     "        output = tf.math.divide(x, 1 - self.drop_prob) * path_mask\n",
-    "        return output\n",
-    ""
-   ]
+    "        return output\n"
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Window based multi-head self-attention\n",
     "\n",
@@ -231,15 +227,14 @@
     "suggests, we compute self-attention within local windows, in a non-overlapping manner.\n",
     "Global self-attention leads to quadratic computational complexity in the number of patches,\n",
     "whereas window-based self-attention leads to linear complexity and is easily scalable."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "\n",
     "class WindowAttention(layers.Layer):\n",
@@ -324,15 +319,15 @@
     "        x_qkv = tf.reshape(x_qkv, shape=(-1, size, channels))\n",
     "        x_qkv = self.proj(x_qkv)\n",
     "        x_qkv = self.dropout(x_qkv)\n",
-    "        return x_qkv\n",
-    ""
-   ]
+    "        return x_qkv\n"
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## The complete Swin Transformer model\n",
     "\n",
@@ -347,15 +342,14 @@
     "2 Dropout layers. Often you will see models using ResNet-50 as the MLP which is\n",
     "quite standard in the literature. However in this paper the authors use a\n",
     "2-layer MLP with GELU nonlinearity in between."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "\n",
     "class SwinTransformer(layers.Layer):\n",
@@ -480,15 +474,15 @@
     "        x = self.mlp(x)\n",
     "        x = self.drop_path(x)\n",
     "        x = x_skip + x\n",
-    "        return x\n",
-    ""
-   ]
+    "        return x\n"
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "## Model training and evaluation\n",
     "\n",
@@ -496,15 +490,14 @@
     "\n",
     "We first create 3 layers to help us extract, embed and merge patches from the\n",
     "images on top of which we will later use the Swin Transformer class we built."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "\n",
     "class PatchExtract(layers.Layer):\n",
@@ -556,28 +549,27 @@
     "        x3 = x[:, 1::2, 1::2, :]\n",
     "        x = tf.concat((x0, x1, x2, x3), axis=-1)\n",
     "        x = tf.reshape(x, shape=(-1, (height // 2) * (width // 2), 4 * C))\n",
-    "        return self.linear_trans(x)\n",
-    ""
-   ]
+    "        return self.linear_trans(x)\n"
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "### Build the model\n",
     "\n",
     "We put together the Swin Transformer model."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "input = layers.Input(input_shape)\n",
     "x = layers.RandomCrop(image_dimension, image_dimension)(input)\n",
@@ -607,28 +599,28 @@
     "x = PatchMerging((num_patch_x, num_patch_y), embed_dim=embed_dim)(x)\n",
     "x = layers.GlobalAveragePooling1D()(x)\n",
     "output = layers.Dense(num_classes, activation=\"softmax\")(x)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "### Train on CIFAR-100\n",
     "\n",
     "We train the model on CIFAR-100. Here, we only train the model\n",
     "for 40 epochs to keep the training time short in this example.\n",
     "In practice, you should train for 150 epochs to reach convergence."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "model = keras.Model(input, output)\n",
     "model.compile(\n",
@@ -649,24 +641,24 @@
     "    epochs=num_epochs,\n",
     "    validation_split=validation_split,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "Let's visualize the training progress of the model."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "plt.plot(history.history[\"loss\"], label=\"train_loss\")\n",
     "plt.plot(history.history[\"val_loss\"], label=\"val_loss\")\n",
@@ -676,36 +668,37 @@
     "plt.legend()\n",
     "plt.grid()\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "Let's display the final results of the training on CIFAR-100."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
+   "execution_count": null,
    "source": [
     "loss, accuracy, top_5_accuracy = model.evaluate(x_test, y_test)\n",
     "print(f\"Test loss: {round(loss, 2)}\")\n",
     "print(f\"Test accuracy: {round(accuracy * 100, 2)}%\")\n",
     "print(f\"Test top 5 accuracy: {round(top_5_accuracy * 100, 2)}%\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "colab_type": "code"
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
    "source": [
     "The Swin Transformer model we just trained has just 152K parameters, and it gets\n",
     "us to ~75% test top-5 accuracy within just 40 epochs without any signs of overfitting\n",
@@ -729,7 +722,10 @@
     "This example takes inspiration from the official\n",
     "[PyTorch](https://github.com/microsoft/Swin-Transformer) and\n",
     "[TensorFlow](https://github.com/VcampSoldiers/Swin-Transformer-Tensorflow) implementations."
-   ]
+   ],
+   "metadata": {
+    "colab_type": "text"
+   }
   }
  ],
  "metadata": {
@@ -759,5 +755,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/examples/vision/ipynb/swin_transformers.ipynb
+++ b/examples/vision/ipynb/swin_transformers.ipynb
@@ -208,7 +208,7 @@
     "    def call(self, x):\n",
     "        input_shape = tf.shape(x)\n",
     "        batch_size = input_shape[0]\n",
-    "        rank = input_shape.shape.as_list()[0]\n",
+    "        rank = x.shape.rank\n",
     "        shape = (batch_size,) + (1,) * (rank - 1)\n",
     "        random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)\n",
     "        path_mask = tf.floor(random_tensor)\n",

--- a/examples/vision/ipynb/swin_transformers.ipynb
+++ b/examples/vision/ipynb/swin_transformers.ipynb
@@ -2,6 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "# Image classification with Swin Transformers\n",
     "\n",
@@ -9,13 +12,13 @@
     "**Date created:** 2021/09/08<br>\n",
     "**Last modified:** 2021/09/08<br>\n",
     "**Description:** Image classification using Swin Transformers, a general-purpose backbone for computer vision."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "This example implements [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows](https://arxiv.org/abs/2103.14030)\n",
     "by Liu et al. for image classification, and demonstrates it on the\n",
@@ -31,34 +34,35 @@
     "\n",
     "This example requires TensorFlow 2.5 or higher, as well as TensorFlow Addons,\n",
     "which can be installed using the following commands:"
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "!pip install -U tensorflow-addons"
-   ],
-   "outputs": [],
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -U tensorflow-addons"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Setup"
-   ],
    "metadata": {
     "colab_type": "text"
-   }
+   },
+   "source": [
+    "## Setup"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -66,27 +70,27 @@
     "import tensorflow_addons as tfa\n",
     "from tensorflow import keras\n",
     "from tensorflow.keras import layers"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## Prepare the data\n",
     "\n",
     "We load the CIFAR-100 dataset through `tf.keras.datasets`,\n",
     "normalize the images, and convert the integer labels to one-hot encoded vectors."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "num_classes = 100\n",
     "input_shape = (32, 32, 3)\n",
@@ -106,14 +110,13 @@
     "    plt.grid(False)\n",
     "    plt.imshow(x_train[i])\n",
     "plt.show()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## Configure the hyperparameters\n",
     "\n",
@@ -121,14 +124,15 @@
     "In order to use each pixel as an individual input, you can set `patch_size` to `(1, 1)`.\n",
     "Below, we take inspiration from the original paper settings\n",
     "for training on ImageNet-1K, keeping most of the original settings for this example."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "patch_size = (2, 2)  # 2-by-2 sized patches\n",
     "dropout_rate = 0.03  # Dropout rate\n",
@@ -149,27 +153,27 @@
     "validation_split = 0.1\n",
     "weight_decay = 0.0001\n",
     "label_smoothing = 0.1"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## Helper functions\n",
     "\n",
     "We create two helper functions to help us get a sequence of\n",
     "patches from the image, merge patches, and apply dropout."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "\n",
     "def window_partition(x, window_size):\n",
@@ -209,15 +213,15 @@
     "        random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)\n",
     "        path_mask = tf.floor(random_tensor)\n",
     "        output = tf.math.divide(x, 1 - self.drop_prob) * path_mask\n",
-    "        return output\n"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+    "        return output\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## Window based multi-head self-attention\n",
     "\n",
@@ -227,14 +231,15 @@
     "suggests, we compute self-attention within local windows, in a non-overlapping manner.\n",
     "Global self-attention leads to quadratic computational complexity in the number of patches,\n",
     "whereas window-based self-attention leads to linear complexity and is easily scalable."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "\n",
     "class WindowAttention(layers.Layer):\n",
@@ -319,15 +324,15 @@
     "        x_qkv = tf.reshape(x_qkv, shape=(-1, size, channels))\n",
     "        x_qkv = self.proj(x_qkv)\n",
     "        x_qkv = self.dropout(x_qkv)\n",
-    "        return x_qkv\n"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+    "        return x_qkv\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## The complete Swin Transformer model\n",
     "\n",
@@ -342,14 +347,15 @@
     "2 Dropout layers. Often you will see models using ResNet-50 as the MLP which is\n",
     "quite standard in the literature. However in this paper the authors use a\n",
     "2-layer MLP with GELU nonlinearity in between."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "\n",
     "class SwinTransformer(layers.Layer):\n",
@@ -474,15 +480,15 @@
     "        x = self.mlp(x)\n",
     "        x = self.drop_path(x)\n",
     "        x = x_skip + x\n",
-    "        return x\n"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+    "        return x\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "## Model training and evaluation\n",
     "\n",
@@ -490,14 +496,15 @@
     "\n",
     "We first create 3 layers to help us extract, embed and merge patches from the\n",
     "images on top of which we will later use the Swin Transformer class we built."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "\n",
     "class PatchExtract(layers.Layer):\n",
@@ -549,27 +556,28 @@
     "        x3 = x[:, 1::2, 1::2, :]\n",
     "        x = tf.concat((x0, x1, x2, x3), axis=-1)\n",
     "        x = tf.reshape(x, shape=(-1, (height // 2) * (width // 2), 4 * C))\n",
-    "        return self.linear_trans(x)\n"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+    "        return self.linear_trans(x)\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "### Build the model\n",
     "\n",
     "We put together the Swin Transformer model."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "input = layers.Input(input_shape)\n",
     "x = layers.RandomCrop(image_dimension, image_dimension)(input)\n",
@@ -599,28 +607,28 @@
     "x = PatchMerging((num_patch_x, num_patch_y), embed_dim=embed_dim)(x)\n",
     "x = layers.GlobalAveragePooling1D()(x)\n",
     "output = layers.Dense(num_classes, activation=\"softmax\")(x)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "### Train on CIFAR-100\n",
     "\n",
     "We train the model on CIFAR-100. Here, we only train the model\n",
     "for 40 epochs to keep the training time short in this example.\n",
     "In practice, you should train for 150 epochs to reach convergence."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "model = keras.Model(input, output)\n",
     "model.compile(\n",
@@ -641,24 +649,24 @@
     "    epochs=num_epochs,\n",
     "    validation_split=validation_split,\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's visualize the training progress of the model."
-   ],
    "metadata": {
     "colab_type": "text"
-   }
+   },
+   "source": [
+    "Let's visualize the training progress of the model."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "plt.plot(history.history[\"loss\"], label=\"train_loss\")\n",
     "plt.plot(history.history[\"val_loss\"], label=\"val_loss\")\n",
@@ -668,37 +676,36 @@
     "plt.legend()\n",
     "plt.grid()\n",
     "plt.show()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's display the final results of the training on CIFAR-100."
-   ],
    "metadata": {
     "colab_type": "text"
-   }
+   },
+   "source": [
+    "Let's display the final results of the training on CIFAR-100."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
    "source": [
     "loss, accuracy, top_5_accuracy = model.evaluate(x_test, y_test)\n",
     "print(f\"Test loss: {round(loss, 2)}\")\n",
     "print(f\"Test accuracy: {round(accuracy * 100, 2)}%\")\n",
     "print(f\"Test top 5 accuracy: {round(top_5_accuracy * 100, 2)}%\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "colab_type": "code"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
    "source": [
     "The Swin Transformer model we just trained has just 152K parameters, and it gets\n",
     "us to ~75% test top-5 accuracy within just 40 epochs without any signs of overfitting\n",
@@ -722,10 +729,7 @@
     "This example takes inspiration from the official\n",
     "[PyTorch](https://github.com/microsoft/Swin-Transformer) and\n",
     "[TensorFlow](https://github.com/VcampSoldiers/Swin-Transformer-Tensorflow) implementations."
-   ],
-   "metadata": {
-    "colab_type": "text"
-   }
+   ]
   }
  ],
  "metadata": {
@@ -755,5 +759,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/examples/vision/md/swin_transformers.md
+++ b/examples/vision/md/swin_transformers.md
@@ -170,7 +170,7 @@ class DropPath(layers.Layer):
     def call(self, x):
         input_shape = tf.shape(x)
         batch_size = input_shape[0]
-        rank = len(input_shape)
+        rank = input_shape.shape.as_list()[0]
         shape = (batch_size,) + (1,) * (rank - 1)
         random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)
         path_mask = tf.floor(random_tensor)

--- a/examples/vision/md/swin_transformers.md
+++ b/examples/vision/md/swin_transformers.md
@@ -170,7 +170,7 @@ class DropPath(layers.Layer):
     def call(self, x):
         input_shape = tf.shape(x)
         batch_size = input_shape[0]
-        rank = input_shape.shape.as_list()[0]
+        rank = x.shape.rank
         shape = (batch_size,) + (1,) * (rank - 1)
         random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)
         path_mask = tf.floor(random_tensor)

--- a/examples/vision/swin_transformers.py
+++ b/examples/vision/swin_transformers.py
@@ -132,7 +132,7 @@ class DropPath(layers.Layer):
     def call(self, x):
         input_shape = tf.shape(x)
         batch_size = input_shape[0]
-        rank = input_shape.shape.as_list()[0]
+        rank = x.shape.rank
         shape = (batch_size,) + (1,) * (rank - 1)
         random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)
         path_mask = tf.floor(random_tensor)

--- a/examples/vision/swin_transformers.py
+++ b/examples/vision/swin_transformers.py
@@ -132,7 +132,7 @@ class DropPath(layers.Layer):
     def call(self, x):
         input_shape = tf.shape(x)
         batch_size = input_shape[0]
-        rank = len(input_shape)
+        rank = input_shape.shape.as_list()[0]
         shape = (batch_size,) + (1,) * (rank - 1)
         random_tensor = (1 - self.drop_prob) + tf.random.uniform(shape, dtype=x.dtype)
         path_mask = tf.floor(random_tensor)


### PR DESCRIPTION
This is a really quick and small PR for the example I recently contributed, [Image classification with Swin Transformers](https://keras.io/examples/vision/swin_transformers). While my further experiments, I today noticed a really minor problem while saving the model using `model.save()`. We don't do this in the example which is why I might have missed it, but this change would be helpful if people want to take this example further and probably save the models they trained in this example.

Instead of using:

```py
rank = len(input_shape)
```

which creates problems on calling `model.save()` we now use the dynamic shape:

```py
rank = input_shape.shape.as_list()[0]
```

