### PR TITLE
Updated use of embed_dim and ff_dim arguments to match expected sshap…

### DIFF
--- a/examples/nlp/text_classification_with_switch_transformer.py
+++ b/examples/nlp/text_classification_with_switch_transformer.py
@@ -93,9 +93,9 @@ This is used as the Mixture of Experts in the Switch Transformer.
 """
 
 
-def create_feedforward_network(ff_dim, name=None):
+def create_feedforward_network(ff_dim, embed_dim, name=None):
     return keras.Sequential(
-        [layers.Dense(ff_dim, activation="relu"), layers.Dense(ff_dim)], name=name
+        [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim)], name=name
     )
 
 
@@ -178,12 +178,15 @@ class Router(layers.Layer):
         expert_gate *= expert_mask_flat
         # Combine expert outputs and scaling with router probability.
         # combine_tensor shape: [tokens_per_batch, num_experts, expert_capacity]
-        combined_tensor = tf.expand_dims(
-            expert_gate
-            * expert_mask_flat
-            * tf.squeeze(tf.one_hot(expert_index, depth=self.num_experts), 1),
-            -1,
-        ) * tf.squeeze(tf.one_hot(position_in_expert, depth=self.expert_capacity), 1)
+        combined_tensor = (
+            tf.expand_dims(
+                expert_gate
+                * expert_mask_flat
+                * tf.squeeze(tf.one_hot(expert_index, depth=self.num_experts), 1),
+                -1,
+            )
+            * tf.squeeze(tf.one_hot(position_in_expert, depth=self.expert_capacity), 1)
+        )
         # Create binary dispatch_tensor [tokens_per_batch, num_experts, expert_capacity]
         # that is 1 if the token gets routed to the corresponding expert.
         dispatch_tensor = tf.cast(combined_tensor, tf.dtypes.float32)
@@ -197,11 +200,13 @@ class Router(layers.Layer):
 
 
 class Switch(layers.Layer):
-    def __init__(self, num_experts, embed_dim, num_tokens_per_batch, capacity_factor=1):
+    def __init__(
+        self, num_experts, embed_dim, ff_dim, num_tokens_per_batch, capacity_factor=1
+    ):
         self.num_experts = num_experts
         self.embed_dim = embed_dim
         self.experts = [
-            create_feedforward_network(embed_dim) for _ in range(num_experts)
+            create_feedforward_network(ff_dim, embed_dim) for _ in range(num_experts)
         ]
 
         self.expert_capacity = num_tokens_per_batch // self.num_experts
@@ -278,8 +283,8 @@ of it to classify text.
 
 
 def create_classifier():
-    switch = Switch(num_experts, embed_dim, num_tokens_per_batch)
-    transformer_block = TransformerBlock(ff_dim, num_heads, switch)
+    switch = Switch(num_experts, embed_dim, ff_dim, num_tokens_per_batch)
+    transformer_block = TransformerBlock(embed_dim // num_heads, num_heads, switch)
 
     inputs = layers.Input(shape=(num_tokens_per_example,))
     embedding_layer = TokenAndPositionEmbedding(


### PR DESCRIPTION
This is a suggested change to how the `embed_dim` and `ff_dim` arguments are used within the switch transformer example (`examples/nlp/text_classification_with_switch_transformer.py`).  

 I believe this update better reflects the expected tensor shapes within the typical transformer block, and as described in the Switch Transformers paper.  (I wasn't able to get the parameter counts to match those quoted for the different variants in the paper until this change.)