### PR TITLE
Changed reset_states to reset_state

### DIFF
--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -293,7 +293,7 @@ methods:
 - `update_state(self, y_true, y_pred, sample_weight=None)`, which uses the targets
 y_true and the model predictions y_pred to update the state variables.
 - `result(self)`, which uses the state variables to compute the final results.
-- `reset_states(self)`, which reinitializes the state of the metric.
+- `reset_state(self)`, which reinitializes the state of the metric.
 
 State update and results computation are kept separate (in `update_state()` and
 `result()`, respectively) because in some cases, the results computation might be very
@@ -321,7 +321,7 @@ class CategoricalTruePositives(keras.metrics.Metric):
     def result(self):
         return self.true_positives
 
-    def reset_states(self):
+    def reset_state(self):
         # The state of the metric will be reset at the start of each epoch.
         self.true_positives.assign(0.0)
 


### PR DESCRIPTION
Changed reset_states to reset_state to avoid warning "UserWarning: Metric CategoricalTruePositives implements a `reset_states()` method; rename it to `reset_state()` (without the final "s"). The name `reset_states()` has been deprecated to improve API consistency."