### PR TITLE
update getting started for kt 1.1.0

### DIFF
--- a/guides/ipynb/keras_tuner/getting_started.ipynb
+++ b/guides/ipynb/keras_tuner/getting_started.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Authors:** Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin<br>\n",
     "**Date created:** 2019/05/31<br>\n",
-    "**Last modified:** 2021/06/07<br>\n",
+    "**Last modified:** 2021/10/27<br>\n",
     "**Description:** The basics of using KerasTuner to tune model hyperparameters."
    ]
   },
@@ -20,18 +20,8 @@
     "colab_type": "text"
    },
    "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install keras-tuner -q"
+    "## shell\n",
+    "pip install keras-tuner -q"
    ]
   },
   {
@@ -42,9 +32,338 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Here's how to perform hyperparameter tuning for a single-layer dense neural\n",
-    "network using random search.\n",
-    "First, we need to prepare the dataset -- let's use MNIST dataset as an example."
+    "KerasTuner is a general-purpose hyperparameter tuning library. It has strong\n",
+    "integration with Keras workflows, but it isn't limited to them: you could use\n",
+    "it to tune scikit-learn models, or anything else. In this tutorial, you will\n",
+    "see how to tune model architecture, training process, and data preprocessing\n",
+    "steps with KerasTuner. Let's start from a simple example.\n",
+    "\n",
+    "## Tune the model architecture\n",
+    "\n",
+    "The first thing we need to do is writing a function, which returns a compiled\n",
+    "Keras model. It takes an argument `hp` for defining the hyperparameters while\n",
+    "building the model.\n",
+    "\n",
+    "### Define the search space\n",
+    "\n",
+    "In the following code example, we define a Keras model with two `Dense` layers.\n",
+    "We want to tune the number of units in the first `Dense` layer. We just define\n",
+    "an integer hyperparameter with `hp.Int('units', min_value=32, max_value=512, step=32)`,\n",
+    "whose range is from 32 to 512 inclusive. When sampling from it, the minimum\n",
+    "step for walking through the interval is 32."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "\n",
+    "\n",
+    "def build_model(hp):\n",
+    "    model = keras.Sequential()\n",
+    "    model.add(layers.Flatten())\n",
+    "    model.add(\n",
+    "        layers.Dense(\n",
+    "            # Define the hyperparameter.\n",
+    "            units=hp.Int(\"units\", min_value=32, max_value=512, step=32),\n",
+    "            activation=\"relu\",\n",
+    "        )\n",
+    "    )\n",
+    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
+    "    model.compile(\n",
+    "        optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "You can quickly test if the model builds successfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import keras_tuner as kt\n",
+    "\n",
+    "build_model(kt.HyperParameters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "There are many other types of hyperparameters as well. We can define multiple\n",
+    "hyperparameters in the function. In the following code, we tune the whether to\n",
+    "use a `Dropout` layer with `hp.Boolean()`, tune which activation function to\n",
+    "use with `hp.Choice()`, tune the learning rate of the optimizer with\n",
+    "`hp.Float()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def build_model(hp):\n",
+    "    model = keras.Sequential()\n",
+    "    model.add(layers.Flatten())\n",
+    "    model.add(\n",
+    "        layers.Dense(\n",
+    "            # Tune number of units.\n",
+    "            units=hp.Int(\"units\", min_value=32, max_value=512, step=32),\n",
+    "            # Tune the activation function to use.\n",
+    "            activation=hp.Choice(\"activation\", [\"relu\", \"tanh\"]),\n",
+    "        )\n",
+    "    )\n",
+    "    # Tune whether to use dropout.\n",
+    "    if hp.Boolean(\"dropout\"):\n",
+    "        model.add(layers.Dropout(rate=0.25))\n",
+    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
+    "    # Define the optimizer learning rate as a hyperparameter.\n",
+    "    learning_rate = hp.Float(\"lr\", min_value=1e-4, max_value=1e-2, sampling=\"log\")\n",
+    "    model.compile(\n",
+    "        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "build_model(kt.HyperParameters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "As shown below, the hyperparameters are actual values. In fact, they are just\n",
+    "functions returning actual values. For example, `hp.Int()` returns an `int`\n",
+    "value. Therefore, you can put them into variables, for loops, or if\n",
+    "conditions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hp = kt.HyperParameters()\n",
+    "print(hp.Int(\"units\", min_value=32, max_value=512, step=32))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "You can also define the hyperparameters in advance and keep your Keras code in\n",
+    "a separate function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def call_existing_code(units, activation, dropout, lr):\n",
+    "    model = keras.Sequential()\n",
+    "    model.add(layers.Flatten())\n",
+    "    model.add(layers.Dense(units=units, activation=activation))\n",
+    "    if dropout:\n",
+    "        model.add(layers.Dropout(rate=0.25))\n",
+    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
+    "    model.compile(\n",
+    "        optimizer=keras.optimizers.Adam(learning_rate=lr),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "def build_model(hp):\n",
+    "    units = hp.Int(\"units\", min_value=32, max_value=512, step=32)\n",
+    "    activation = hp.Choice(\"activation\", [\"relu\", \"tanh\"])\n",
+    "    dropout = hp.Boolean(\"dropout\")\n",
+    "    lr = hp.Float(\"lr\", min_value=1e-4, max_value=1e-2, sampling=\"log\")\n",
+    "    # call existing model-building code with the hyperparameter values.\n",
+    "    model = call_existing_code(\n",
+    "        units=units, activation=activation, dropout=dropout, lr=lr\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "build_model(kt.HyperParameters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Each of the hyperparameters is uniquely identified by its name (the first\n",
+    "argument). To tune the number of units in different `Dense` layers separately\n",
+    "as different hyperparameters, we give them different names as `f\"units_{i}\"`.\n",
+    "\n",
+    "Notably, this is also an example of creating conditional hyperparameters.\n",
+    "There are many hyperparameters specifying the number of units in the `Dense`\n",
+    "layers. The number of such hyperparameters is decided by the number of layers,\n",
+    "which is also a hyperparameter. Therefore, the total number of hyperparameters\n",
+    "used may be different from trial to trial. Some hyperparameter is only used\n",
+    "when a certain condition is satisfied. For example, `units_3` is only used\n",
+    "when `num_layers` is larger than 3. With KerasTuner, you can easily define\n",
+    "such hyperparameters dynamically while creating the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def build_model(hp):\n",
+    "    model = keras.Sequential()\n",
+    "    model.add(layers.Flatten())\n",
+    "    # Tune the number of layers.\n",
+    "    for i in range(hp.Int(\"num_layers\", 1, 3)):\n",
+    "        model.add(\n",
+    "            layers.Dense(\n",
+    "                # Tune number of units separately.\n",
+    "                units=hp.Int(f\"units_{i}\", min_value=32, max_value=512, step=32),\n",
+    "                activation=hp.Choice(\"activation\", [\"relu\", \"tanh\"]),\n",
+    "            )\n",
+    "        )\n",
+    "    if hp.Boolean(\"dropout\"):\n",
+    "        model.add(layers.Dropout(rate=0.25))\n",
+    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
+    "    learning_rate = hp.Float(\"lr\", min_value=1e-4, max_value=1e-2, sampling=\"log\")\n",
+    "    model.compile(\n",
+    "        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),\n",
+    "        loss=\"categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "build_model(kt.HyperParameters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Start the search\n",
+    "\n",
+    "After defining the search space, we need to select a tuner class to run the\n",
+    "search. You may choose from `RandomSearch`, `BayesianOptimization` and\n",
+    "`Hyperband`, which correspond to different tuning algorithms. Here we use\n",
+    "`RandomSearch` as an example.\n",
+    "\n",
+    "To initialize the tuner, we need to specify several arguments in the initializer.\n",
+    "\n",
+    "* `hypermodel`. The model-building function, which is `build_model` in our case.\n",
+    "* `objective`. The name of the objective to optimize (whether to minimize or\n",
+    "maximize is automatically inferred for built-in metrics). We will introduce how\n",
+    "to use custom metrics later in this tutorial.\n",
+    "* `max_trials`. The total number of trials to run during the search.\n",
+    "* `executions_per_trial`. The number of models that should be built and fit for\n",
+    "each trial. Different trials have different hyperparameter values. The\n",
+    "executions within the same trial have the same hyperparameter values. The\n",
+    "purpose of having multiple executions per trial is to reduce results variance\n",
+    "and therefore be able to more accurately assess the performance of a model. If\n",
+    "you want to get results faster, you could set `executions_per_trial=1` (single\n",
+    "round of training for each model configuration).\n",
+    "* `overwrite`. Control whether to overwrite the previous results in the same\n",
+    "directory or resume the previous search instead. Here we set `overwrite=True`\n",
+    "to start a new search and ignore any previous results.\n",
+    "* `directory`. A path to a directory for storing the search results.\n",
+    "* `project_name`. The name of the sub-directory in the `directory`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=build_model,\n",
+    "    objective=\"val_accuracy\",\n",
+    "    max_trials=3,\n",
+    "    executions_per_trial=2,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"helloworld\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "You can print a summary of the search space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner.search_space_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Before starting the search, let's prepare the MNIST dataset."
    ]
   },
   {
@@ -81,123 +400,9 @@
     "colab_type": "text"
    },
    "source": [
-    "## Prepare a model-building function\n",
-    "\n",
-    "Then, we define a model-building function. It takes an argument `hp` from\n",
-    "which you can sample hyperparameters, such as\n",
-    "`hp.Int('units', min_value=32, max_value=512, step=32)`\n",
-    "(an integer from a certain range).\n",
-    "\n",
-    "This function returns a compiled model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from tensorflow.keras import layers\n",
-    "from keras_tuner import RandomSearch\n",
-    "\n",
-    "\n",
-    "def build_model(hp):\n",
-    "    model = keras.Sequential()\n",
-    "    model.add(layers.Flatten())\n",
-    "    model.add(\n",
-    "        layers.Dense(\n",
-    "            units=hp.Int(\"units\", min_value=32, max_value=512, step=32),\n",
-    "            activation=\"relu\",\n",
-    "        )\n",
-    "    )\n",
-    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
-    "    model.compile(\n",
-    "        optimizer=keras.optimizers.Adam(\n",
-    "            hp.Choice(\"learning_rate\", values=[1e-2, 1e-3, 1e-4])\n",
-    "        ),\n",
-    "        loss=\"categorical_crossentropy\",\n",
-    "        metrics=[\"accuracy\"],\n",
-    "    )\n",
-    "    return model\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Start the search\n",
-    "\n",
-    "Next, let's instantiate a tuner. You should specify the model-building function, the\n",
-    "name of the objective to optimize (whether to minimize or maximize is\n",
-    "automatically inferred for built-in metrics), the total number of trials\n",
-    "(`max_trials`) to test, and the number of models that should be built and fit\n",
-    "for each trial (`executions_per_trial`).\n",
-    "\n",
-    "We use the `overwrite` argument to control whether to overwrite the previous\n",
-    "results in the same directory or resume the previous search instead.  Here we\n",
-    "set `overwrite=True` to start a new search and ignore any previous results.\n",
-    "\n",
-    "Available tuners are `RandomSearch`, `BayesianOptimization` and `Hyperband`.\n",
-    "\n",
-    "**Note:** the purpose of having multiple executions per trial is to reduce\n",
-    "results variance and therefore be able to more accurately assess the\n",
-    "performance of a model. If you want to get results faster, you could set\n",
-    "`executions_per_trial=1` (single round of training for each model\n",
-    "configuration)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "tuner = RandomSearch(\n",
-    "    build_model,\n",
-    "    objective=\"val_accuracy\",\n",
-    "    max_trials=3,\n",
-    "    executions_per_trial=2,\n",
-    "    overwrite=True,\n",
-    "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "You can print a summary of the search space:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "tuner.search_space_summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
     "Then, start the search for the best hyperparameter configuration.\n",
-    "The call to `search` has the same signature as `model.fit()`."
+    "All the arguments passed to `search` is passed to `model.fit()` in each\n",
+    "execution. Remember to pass `validation_data` to evaluate the model."
    ]
   },
   {
@@ -217,21 +422,16 @@
     "colab_type": "text"
    },
    "source": [
-    "Here's what happens in `search`: models are built iteratively by calling the\n",
-    "model-building function, which populates the hyperparameter space (search\n",
-    "space) tracked by the `hp` object. The tuner progressively explores the space,\n",
-    "recording metrics for each configuration."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Query the results\n",
+    "During the `search`, the model-building function is called with different\n",
+    "hyperparameter values in different trial. In each trial, the tuner would\n",
+    "generate a new set of hyperparameter values to build the model. The model is\n",
+    "then fit and evaluated. The metrics are recorded. The tuner progressively\n",
+    "explores the space and finally finds a good set of hyperparameter values.\n",
     "\n",
-    "When search is over, you can retrieve the best model(s):"
+    "### Query the results\n",
+    "\n",
+    "When search is over, you can retrieve the best model(s). The model is saved at\n",
+    "its best performing epoch evaluated on the `validation_data`."
    ]
   },
   {
@@ -242,7 +442,13 @@
    },
    "outputs": [],
    "source": [
-    "models = tuner.get_best_models(num_models=2)"
+    "# Get the top 2 models.\n",
+    "models = tuner.get_best_models(num_models=2)\n",
+    "best_model = models[0]\n",
+    "# Build the model.\n",
+    "# Needed for `Sequential` without specified `input_shape`.\n",
+    "best_model.build(input_shape=(None, 28, 28))\n",
+    "best_model.summary()"
    ]
   },
   {
@@ -251,7 +457,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Or print a summary of the results:"
+    "You can also print a summary of the search results."
    ]
   },
   {
@@ -271,7 +477,35 @@
     "colab_type": "text"
    },
    "source": [
-    "You will also find detailed logs, checkpoints, etc, in the folder `my_dir/helloworld`, i.e. `directory/project_name`."
+    "You will find detailed logs, checkpoints, etc, in the folder\n",
+    "`my_dir/helloworld`, i.e. `directory/project_name`.\n",
+    "\n",
+    "You can also visualize the tuning results using TensorBoard and HParams plugin.\n",
+    "For more information, please following\n",
+    "[this link](https://keras.io/guides/keras_tuner/visualize_tuning/).\n",
+    "\n",
+    "### Retrain the model\n",
+    "\n",
+    "If you want to train the model with the entire dataset, you may retrieve the\n",
+    "best hyperparameters and retrain the model by yourself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# Get the top 2 hyperparameters.\n",
+    "best_hps = tuner.get_best_hyperparameters(5)\n",
+    "# Build the model with the best hp.\n",
+    "model = build_model(best_hps[0])\n",
+    "# Fit with the entire dataset.\n",
+    "x_all = np.concatenate((x_train, x_val))\n",
+    "y_all = np.concatenate((y_train, y_val))\n",
+    "model.fit(x=x_all, y=y_all, epochs=1)"
    ]
   },
   {
@@ -280,15 +514,28 @@
     "colab_type": "text"
    },
    "source": [
-    "## The search space may contain conditional hyperparameters\n",
+    "## Tune model training\n",
     "\n",
-    "Below, we have a `for` loop creating a tunable number of layers,\n",
-    "which themselves involve a tunable `units` parameter.\n",
+    "To tune the model building process, we need to subclass the `HyperModel` class,\n",
+    "which also makes it easy to share and reuse hypermodels.\n",
     "\n",
-    "This can be pushed to any level of parameter interdependency, including recursion.\n",
+    "We need to override `HyperModel.build()` and `HyperModel.fit()` to tune the\n",
+    "model building and training process respectively. A `HyperModel.build()`\n",
+    "method is the same as the model-building function, which creates a Keras model\n",
+    "using the hyperparameters and returns it.\n",
     "\n",
-    "Note that all parameter names should be unique (here, in the loop over `i`,\n",
-    "we name the inner parameters `'units_' + str(i)`)."
+    "In `HyperModel.fit()`, you can access the model returned by\n",
+    "`HyperModel.build()`,`hp` and all the arguments passed to `search()`. You need\n",
+    "to train the model and return the training history.\n",
+    "\n",
+    "In the following code, we will tune the `shuffle` argument in `model.fit()`.\n",
+    "\n",
+    "It is generally not needed to tune the number of epochs because a built-in\n",
+    "callback is passed to `model.fit()` to save the model at its best epoch\n",
+    "evaluated by the `validation_data`.\n",
+    "\n",
+    "> **Note**: The `**kwargs` should always be passed to `model.fit()` because it\n",
+    "contains the callbacks for model saving and tensorboard plugins."
    ]
   },
   {
@@ -300,54 +547,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "def build_model(hp):\n",
-    "    model = keras.Sequential()\n",
-    "    model.add(layers.Flatten())\n",
-    "    for i in range(hp.Int(\"num_layers\", 2, 20)):\n",
-    "        model.add(\n",
-    "            layers.Dense(\n",
-    "                units=hp.Int(\"units_\" + str(i), min_value=32, max_value=512, step=32),\n",
-    "                activation=\"relu\",\n",
-    "            )\n",
-    "        )\n",
-    "    model.add(layers.Dense(10, activation=\"softmax\"))\n",
-    "    model.compile(\n",
-    "        optimizer=keras.optimizers.Adam(hp.Choice(\"learning_rate\", [1e-2, 1e-3, 1e-4])),\n",
-    "        loss=\"categorical_crossentropy\",\n",
-    "        metrics=[\"accuracy\"],\n",
-    "    )\n",
-    "    return model\n",
-    ""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## You can use a HyperModel subclass instead of a model-building function\n",
-    "\n",
-    "This makes it easy to share and reuse hypermodels.\n",
-    "\n",
-    "A `HyperModel` subclass only needs to implement a `build(self, hp)` method."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from keras_tuner import HyperModel\n",
-    "\n",
-    "\n",
-    "class MyHyperModel(HyperModel):\n",
-    "    def __init__(self, classes):\n",
-    "        self.classes = classes\n",
-    "\n",
+    "class MyHyperModel(kt.HyperModel):\n",
     "    def build(self, hp):\n",
     "        model = keras.Sequential()\n",
     "        model.add(layers.Flatten())\n",
@@ -357,29 +557,654 @@
     "                activation=\"relu\",\n",
     "            )\n",
     "        )\n",
-    "        model.add(layers.Dense(self.classes, activation=\"softmax\"))\n",
+    "        model.add(layers.Dense(10, activation=\"softmax\"))\n",
     "        model.compile(\n",
-    "            optimizer=keras.optimizers.Adam(\n",
-    "                hp.Choice(\"learning_rate\", values=[1e-2, 1e-3, 1e-4])\n",
-    "            ),\n",
-    "            loss=\"categorical_crossentropy\",\n",
-    "            metrics=[\"accuracy\"],\n",
+    "            optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"],\n",
     "        )\n",
     "        return model\n",
     "\n",
+    "    def fit(self, hp, model, *args, **kwargs):\n",
+    "        return model.fit(\n",
+    "            *args,\n",
+    "            # Tune whether to shuffle the data in each epoch.\n",
+    "            shuffle=hp.Boolean(\"shuffle\"),\n",
+    "            **kwargs,\n",
+    "        )\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Again, we can do a quick check to see if the code works correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hp = kt.HyperParameters()\n",
+    "hypermodel = MyHyperModel()\n",
+    "model = hypermodel.build(hp)\n",
+    "hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Tune data preprocessing\n",
     "\n",
-    "hypermodel = MyHyperModel(classes=10)\n",
+    "To tune data preprocessing, we just add an additional step in\n",
+    "`HyperModel.fit()`, where we can access the dataset from the arguments. In the\n",
+    "following code, we tune whether to normalize the data before training the\n",
+    "model. This time we explicitly put `x` and `y` in the function signature\n",
+    "because we need to use them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
     "\n",
-    "tuner = RandomSearch(\n",
-    "    hypermodel,\n",
+    "class MyHyperModel(kt.HyperModel):\n",
+    "    def build(self, hp):\n",
+    "        model = keras.Sequential()\n",
+    "        model.add(layers.Flatten())\n",
+    "        model.add(\n",
+    "            layers.Dense(\n",
+    "                units=hp.Int(\"units\", min_value=32, max_value=512, step=32),\n",
+    "                activation=\"relu\",\n",
+    "            )\n",
+    "        )\n",
+    "        model.add(layers.Dense(10, activation=\"softmax\"))\n",
+    "        model.compile(\n",
+    "            optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"],\n",
+    "        )\n",
+    "        return model\n",
+    "\n",
+    "    def fit(self, hp, model, x, y, **kwargs):\n",
+    "        if hp.Boolean(\"normalize\"):\n",
+    "            x = layers.Normalization()(x)\n",
+    "        return model.fit(\n",
+    "            x,\n",
+    "            y,\n",
+    "            # Tune whether to shuffle the data in each epoch.\n",
+    "            shuffle=hp.Boolean(\"shuffle\"),\n",
+    "            **kwargs,\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "hp = kt.HyperParameters()\n",
+    "hypermodel = MyHyperModel()\n",
+    "model = hypermodel.build(hp)\n",
+    "hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If a hyperparameter is used both in `build()` and `fit()`, you can define it in\n",
+    "`build()` and use `hp.get(hp_name)` to retrieve it in `fit()`. We use the\n",
+    "image size as an example. It is both used as the input shape in `build()`, and\n",
+    "used by data prerprocessing step to crop the images in `fit()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class MyHyperModel(kt.HyperModel):\n",
+    "    def build(self, hp):\n",
+    "        image_size = hp.Int(\"image_size\", 10, 28)\n",
+    "        inputs = keras.Input(shape=(image_size, image_size))\n",
+    "        outputs = layers.Flatten()(inputs)\n",
+    "        outputs = layers.Dense(\n",
+    "            units=hp.Int(\"units\", min_value=32, max_value=512, step=32),\n",
+    "            activation=\"relu\",\n",
+    "        )(outputs)\n",
+    "        outputs = layers.Dense(10, activation=\"softmax\")(outputs)\n",
+    "        model = keras.Model(inputs, outputs)\n",
+    "        model.compile(\n",
+    "            optimizer=\"adam\", loss=\"categorical_crossentropy\", metrics=[\"accuracy\"],\n",
+    "        )\n",
+    "        return model\n",
+    "\n",
+    "    def fit(self, hp, model, x, y, validation_data=None, **kwargs):\n",
+    "        if hp.Boolean(\"normalize\"):\n",
+    "            x = layers.Normalization()(x)\n",
+    "        image_size = hp.get(\"image_size\")\n",
+    "        cropped_x = x[:, :image_size, :image_size, :]\n",
+    "        if validation_data:\n",
+    "            x_val, y_val = validation_data\n",
+    "            cropped_x_val = x_val[:, :image_size, :image_size, :]\n",
+    "            validation_data = (cropped_x_val, y_val)\n",
+    "        return model.fit(\n",
+    "            cropped_x,\n",
+    "            y,\n",
+    "            # Tune whether to shuffle the data in each epoch.\n",
+    "            shuffle=hp.Boolean(\"shuffle\"),\n",
+    "            validation_data=validation_data,\n",
+    "            **kwargs,\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    MyHyperModel(),\n",
     "    objective=\"val_accuracy\",\n",
     "    max_trials=3,\n",
     "    overwrite=True,\n",
     "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
+    "    project_name=\"tune_hypermodel\",\n",
     ")\n",
     "\n",
     "tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Retrain the model\n",
+    "\n",
+    "Using `HyperModel` also allows you to retrain the best model by yourself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hypermodel = MyHyperModel()\n",
+    "best_hp = tuner.get_best_hyperparameters()[0]\n",
+    "model = hypermodel.build(best_hp)\n",
+    "hypermodel.fit(best_hp, model, x_all, y_all, epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Specify the tuning objective\n",
+    "\n",
+    "In all previous examples, we all just used validation accuracy\n",
+    "(`\"val_accuracy\"`) as the tuning objective to select the best model. Actually,\n",
+    "you can use any metric as the objective. The most commonly used metric is\n",
+    "`\"val_loss\"`, which is the validation loss.\n",
+    "\n",
+    "### Built-in metric as the objective\n",
+    "\n",
+    "There are many other built-in metrics in Keras you can use as the objective.\n",
+    "Here is [a list of the built-in metrics](https://keras.io/api/metrics/).\n",
+    "\n",
+    "To use a built-in metric as the objective, you need to follow these steps:\n",
+    "* Compile the model with the the built-in metric. For example, you want to use\n",
+    "`MeanAbsoluteError()`. You need to compile the model with\n",
+    "`metrics=[MeanAbsoluteError()]`. You may also use its name string instead:\n",
+    "`metrics=[\"mean_absolute_error\"]`. The name string of the metric is always\n",
+    "the snake case of the class name.\n",
+    "\n",
+    "* Identify the objective name string. The name string of the objective is\n",
+    "always in the format of `f\"val_{metric_name_string}\"`. For example, the\n",
+    "objective name string of mean squared error evaluated on the validation data\n",
+    "should be `\"val_mean_absolute_error\"`.\n",
+    "\n",
+    "* Wrap it into `kt.Objective`. We usually need to wrap the objective into a\n",
+    "`kt.Objective` object to specify the direction to optimize the objective. For\n",
+    "example, we want to minimize the mean squared error, we can use\n",
+    "`kt.Objective(\"val_mean_absolute_error\", \"min\")`. The direction should be\n",
+    "either `\"min\"` or `\"max\"`.\n",
+    "\n",
+    "* Pass the wrapped objective to the tuner.\n",
+    "\n",
+    "You can see the following barebone code example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def build_regressor(hp):\n",
+    "    model = keras.Sequential(\n",
+    "        [\n",
+    "            layers.Dense(units=hp.Int(\"units\", 32, 128, 32), activation=\"relu\"),\n",
+    "            layers.Dense(units=1),\n",
+    "        ]\n",
+    "    )\n",
+    "    model.compile(\n",
+    "        optimizer=\"adam\",\n",
+    "        loss=\"mean_squared_error\",\n",
+    "        # Objective is one of the metrics.\n",
+    "        metrics=[keras.metrics.MeanAbsoluteError()],\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=build_regressor,\n",
+    "    # The objective name and direction.\n",
+    "    # Name is the f\"val_{snake_case_metric_class_name}\".\n",
+    "    objective=kt.Objective(\"val_mean_absolute_error\", direction=\"min\"),\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"built_in_metrics\",\n",
+    ")\n",
+    "\n",
+    "tuner.search(\n",
+    "    x=np.random.rand(100, 10),\n",
+    "    y=np.random.rand(100, 1),\n",
+    "    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),\n",
+    ")\n",
+    "\n",
+    "tuner.results_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Custom metric as the objective\n",
+    "\n",
+    "You may implement your own metric and use it as the hyperparameter search\n",
+    "objective. Here, we use mean squared error (MSE) as an example. First, we\n",
+    "implement the MSE metric by subclassing `keras.metrics.Metric`. Remember to\n",
+    "give a name to your metric using the `name` argument of `super().__init__()`,\n",
+    "which will be used later. Note: MSE is actully a build-in metric, which can be\n",
+    "imported with `keras.metrics.MeanSquaredError`. This is just an example to show\n",
+    "how to use a custom metric as the hyperparameter search objective.\n",
+    "\n",
+    "For more information about implementing custom metrics, please see [this\n",
+    "tutorial](https://keras.io/api/metrics/#creating-custom-metrics). If you would\n",
+    "like a metric with a different function signature than `update_state(y_true,\n",
+    "y_pred, sample_weight)`, you can override the `train_step()` method of your\n",
+    "model following [this\n",
+    "tutorial](https://keras.io/guides/customizing_what_happens_in_fit/#going-lowerlevel)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "\n",
+    "class CustomMetric(keras.metrics.Metric):\n",
+    "    def __init__(self, **kwargs):\n",
+    "        # Specify the name of the metric as \"custom_metric\".\n",
+    "        super().__init__(name=\"custom_metric\", **kwargs)\n",
+    "        self.sum = self.add_weight(name=\"sum\", initializer=\"zeros\")\n",
+    "        self.count = self.add_weight(name=\"count\", dtype=tf.int32, initializer=\"zeros\")\n",
+    "\n",
+    "    def update_state(self, y_true, y_pred, sample_weight=None):\n",
+    "        values = tf.math.squared_difference(y_pred, y_true)\n",
+    "        count = tf.shape(y_true)[0]\n",
+    "        if sample_weight is not None:\n",
+    "            sample_weight = tf.cast(sample_weight, self.dtype)\n",
+    "            values *= sample_weight\n",
+    "            count *= sample_weight\n",
+    "        self.sum.assign_add(tf.reduce_sum(values))\n",
+    "        self.count.assign_add(count)\n",
+    "\n",
+    "    def result(self):\n",
+    "        return self.sum / tf.cast(self.count, tf.float32)\n",
+    "\n",
+    "    def reset_states(self):\n",
+    "        self.sum.assign(0)\n",
+    "        self.count.assign(0)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Run the search with the custom objective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def build_regressor(hp):\n",
+    "    model = keras.Sequential(\n",
+    "        [\n",
+    "            layers.Dense(units=hp.Int(\"units\", 32, 128, 32), activation=\"relu\"),\n",
+    "            layers.Dense(units=1),\n",
+    "        ]\n",
+    "    )\n",
+    "    model.compile(\n",
+    "        optimizer=\"adam\",\n",
+    "        loss=\"mean_squared_error\",\n",
+    "        # Put custom metric into the metrics.\n",
+    "        metrics=[CustomMetric()],\n",
+    "    )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=build_regressor,\n",
+    "    # Specify the name and direction of the objective.\n",
+    "    objective=kt.Objective(\"val_custom_metric\", direction=\"min\"),\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"custom_metrics\",\n",
+    ")\n",
+    "\n",
+    "tuner.search(\n",
+    "    x=np.random.rand(100, 10),\n",
+    "    y=np.random.rand(100, 1),\n",
+    "    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),\n",
+    ")\n",
+    "\n",
+    "tuner.results_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If your custom objective is hard to put into a custom metric, you can also\n",
+    "evaluate the model by yourself in `HyperModel.fit()` and return the objective\n",
+    "value. The objective value would be minimized by default. In this case, you\n",
+    "don't need to specify the `objective` when initializing the tuner. However, in\n",
+    "this case, the metric value will not be tracked in the Keras logs by only\n",
+    "KerasTuner logs. Therefore, these values would not be displayed by any\n",
+    "TensorBoard view using the Keras metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class HyperRegressor(kt.HyperModel):\n",
+    "    def build(self, hp):\n",
+    "        model = keras.Sequential(\n",
+    "            [\n",
+    "                layers.Dense(units=hp.Int(\"units\", 32, 128, 32), activation=\"relu\"),\n",
+    "                layers.Dense(units=1),\n",
+    "            ]\n",
+    "        )\n",
+    "        model.compile(\n",
+    "            optimizer=\"adam\", loss=\"mean_squared_error\",\n",
+    "        )\n",
+    "        return model\n",
+    "\n",
+    "    def fit(self, hp, model, x, y, validation_data, **kwargs):\n",
+    "        model.fit(x, y, **kwargs)\n",
+    "        x_val, y_val = validation_data\n",
+    "        y_pred = model.predict(x_val)\n",
+    "        # Return a single float to minimize.\n",
+    "        return np.mean(np.abs(y_pred - y_val))\n",
+    "\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=HyperRegressor(),\n",
+    "    # No objective to specify.\n",
+    "    # Objective is the return value of `HyperModel.fit()`.\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"custom_eval\",\n",
+    ")\n",
+    "tuner.search(\n",
+    "    x=np.random.rand(100, 10),\n",
+    "    y=np.random.rand(100, 1),\n",
+    "    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),\n",
+    ")\n",
+    "\n",
+    "tuner.results_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If you have multiple metrics to track in KerasTuner, but only use one of them\n",
+    "as the objective, you can return a dictionary, whose keys are the metric names\n",
+    "and the values are the metrics values, for example, return `{\"metric_a\": 1.0,\n",
+    "\"metric_b\", 2.0}`. Use one of the keys as the objective name, for example,\n",
+    "`kt.Objective(\"metric_a\", \"min\")`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class HyperRegressor(kt.HyperModel):\n",
+    "    def build(self, hp):\n",
+    "        model = keras.Sequential(\n",
+    "            [\n",
+    "                layers.Dense(units=hp.Int(\"units\", 32, 128, 32), activation=\"relu\"),\n",
+    "                layers.Dense(units=1),\n",
+    "            ]\n",
+    "        )\n",
+    "        model.compile(\n",
+    "            optimizer=\"adam\", loss=\"mean_squared_error\",\n",
+    "        )\n",
+    "        return model\n",
+    "\n",
+    "    def fit(self, hp, model, x, y, validation_data, **kwargs):\n",
+    "        model.fit(x, y, **kwargs)\n",
+    "        x_val, y_val = validation_data\n",
+    "        y_pred = model.predict(x_val)\n",
+    "        # Return a dictionary of metrics for KerasTuner to track.\n",
+    "        return {\n",
+    "            \"metric_a\": -np.mean(np.abs(y_pred - y_val)),\n",
+    "            \"metric_b\": np.mean(np.square(y_pred - y_val)),\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=HyperRegressor(),\n",
+    "    # Objective is one of the keys.\n",
+    "    # Maximize the negative MAE, equivalent to minimize MAE.\n",
+    "    objective=kt.Objective(\"metric_a\", \"max\"),\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"custom_eval_dict\",\n",
+    ")\n",
+    "tuner.search(\n",
+    "    x=np.random.rand(100, 10),\n",
+    "    y=np.random.rand(100, 1),\n",
+    "    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),\n",
+    ")\n",
+    "\n",
+    "tuner.results_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Tune end-to-end workflows\n",
+    "\n",
+    "In some cases, it is hard to align your code into build and fit functions. You\n",
+    "can also keep your end-to-end workflow in one place by overriding\n",
+    "`Tuner.run_trial()`, which gives you full control of a trial. You can see it\n",
+    "as a black-box optimizer for anything.\n",
+    "\n",
+    "### Tune any function\n",
+    "\n",
+    "For example, you can find a value of `x`, which minimizes `f(x)=x*x+1`. In the\n",
+    "following code, we just define `x` as a hyperparameter, and return `f(x)` as\n",
+    "the objective value. The `hypermodel` and `objective` argument for initializing\n",
+    "the tuner can be omitted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class MyTuner(kt.RandomSearch):\n",
+    "    def run_trial(self, trial, *args, **kwargs):\n",
+    "        # Get the hp from trial.\n",
+    "        hp = trial.hyperparameters\n",
+    "        # Define \"x\" as a hyperparameter.\n",
+    "        x = hp.Float(\"x\", min_value=-1.0, max_value=1.0)\n",
+    "        # Return the objective value to minimize.\n",
+    "        return x * x + 1\n",
+    "\n",
+    "\n",
+    "tuner = MyTuner(\n",
+    "    # No hypermodel or objective specified.\n",
+    "    max_trials=20,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"tune_anything\",\n",
+    ")\n",
+    "\n",
+    "# No need to pass anything to search()\n",
+    "# unless you use them in run_trial().\n",
+    "tuner.search()\n",
+    "print(tuner.get_best_hyperparameters()[0].get(\"x\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Keep Keras code separate\n",
+    "\n",
+    "You can keep all your Keras code unchanged and use KerasTuner to tune it. It\n",
+    "is useful if you cannot modify the Keras code for some reason.\n",
+    "\n",
+    "It also gives you more flexibility. You don't have to separate the model\n",
+    "building and training code apart. However, this workflow would not help you\n",
+    "save the model or connect with the TensorBoard plugins.\n",
+    "\n",
+    "To save the model, you can use `trial.trial_id`, which is a string to uniquely\n",
+    "identify a trial, to construct different paths to save the models from\n",
+    "different trials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "\n",
+    "def keras_code(units, optimizer, saving_path):\n",
+    "    # Build model\n",
+    "    model = keras.Sequential(\n",
+    "        [layers.Dense(units=units, activation=\"relu\"), layers.Dense(units=1),]\n",
+    "    )\n",
+    "    model.compile(\n",
+    "        optimizer=optimizer, loss=\"mean_squared_error\",\n",
+    "    )\n",
+    "\n",
+    "    # Prepare data\n",
+    "    x_train = np.random.rand(100, 10)\n",
+    "    y_train = np.random.rand(100, 1)\n",
+    "    x_val = np.random.rand(20, 10)\n",
+    "    y_val = np.random.rand(20, 1)\n",
+    "\n",
+    "    # Train & eval model\n",
+    "    model.fit(x_train, y_train)\n",
+    "\n",
+    "    # Save model\n",
+    "    model.save(saving_path)\n",
+    "\n",
+    "    # Return a single float as the objective value.\n",
+    "    # You may also return a dictionary\n",
+    "    # of {metric_name: metric_value}.\n",
+    "    y_pred = model.predict(x_val)\n",
+    "    return np.mean(np.abs(y_pred - y_val))\n",
+    "\n",
+    "\n",
+    "class MyTuner(kt.RandomSearch):\n",
+    "    def run_trial(self, trial, **kwargs):\n",
+    "        hp = trial.hyperparameters\n",
+    "        return keras_code(\n",
+    "            units=hp.Int(\"units\", 32, 128, 32),\n",
+    "            optimizer=hp.Choice(\"optimizer\", [\"adam\", \"adadelta\"]),\n",
+    "            saving_path=os.path.join(\"/tmp\", trial.trial_id),\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "tuner = MyTuner(\n",
+    "    max_trials=3, overwrite=True, directory=\"my_dir\", project_name=\"keep_code_separate\",\n",
+    ")\n",
+    "tuner.search()\n",
+    "# Retraining the model\n",
+    "best_hp = tuner.get_best_hyperparameters()[0]\n",
+    "keras_code(**best_hp.values, saving_path=\"/tmp/best_model\")"
    ]
   },
   {
@@ -392,7 +1217,8 @@
     "\n",
     "These are ready-to-use hypermodels for computer vision.\n",
     "\n",
-    "They come pre-compiled with `loss=\"categorical_crossentropy\"` and `metrics=[\"accuracy\"]`."
+    "They come pre-compiled with `loss=\"categorical_crossentropy\"` and\n",
+    "`metrics=[\"accuracy\"]`."
    ]
   },
   {
@@ -407,160 +1233,13 @@
     "\n",
     "hypermodel = HyperResNet(input_shape=(28, 28, 1), classes=10)\n",
     "\n",
-    "tuner = RandomSearch(\n",
+    "tuner = kt.RandomSearch(\n",
     "    hypermodel,\n",
     "    objective=\"val_accuracy\",\n",
-    "    max_trials=3,\n",
+    "    max_trials=2,\n",
     "    overwrite=True,\n",
     "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
-    ")\n",
-    "\n",
-    "tuner.search(\n",
-    "    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## You can easily restrict the search space to just a few parameters\n",
-    "\n",
-    "If you have an existing hypermodel, and you want to search over only a few parameters\n",
-    "(such as the learning rate), you can do so by passing a `hyperparameters` argument\n",
-    "to the tuner constructor, as well as `tune_new_entries=False` to specify that parameters\n",
-    "that you didn't list in `hyperparameters` should not be tuned. For these parameters, the default\n",
-    "value gets used."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "from keras_tuner import HyperParameters\n",
-    "from keras_tuner.applications import HyperXception\n",
-    "\n",
-    "hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)\n",
-    "\n",
-    "hp = HyperParameters()\n",
-    "\n",
-    "# This will override the `learning_rate` parameter with your\n",
-    "# own selection of choices\n",
-    "hp.Choice(\"learning_rate\", values=[1e-2, 1e-3, 1e-4])\n",
-    "\n",
-    "tuner = RandomSearch(\n",
-    "    hypermodel,\n",
-    "    hyperparameters=hp,\n",
-    "    # `tune_new_entries=False` prevents unlisted parameters from being tuned\n",
-    "    tune_new_entries=False,\n",
-    "    objective=\"val_accuracy\",\n",
-    "    max_trials=3,\n",
-    "    overwrite=True,\n",
-    "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
-    ")\n",
-    "\n",
-    "tuner.search(\n",
-    "    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## About parameter default values\n",
-    "\n",
-    "Whenever you register a hyperparameter inside a model-building function or the `build` method of a hypermodel,\n",
-    "you can specify a default value:\n",
-    "\n",
-    "```python\n",
-    "hp.Int(\"units\", min_value=32, max_value=512, step=32, default=128)\n",
-    "```\n",
-    "\n",
-    "If you don't, hyperparameters always have a default default (for `Int`, it is equal to `min_value`).\n",
-    "\n",
-    "## Fixing values in a hypermodel\n",
-    "\n",
-    "What if you want to do the reverse -- tune all available parameters in a hypermodel, **except** one (the learning rate)?\n",
-    "\n",
-    "Pass a `hyperparameters` argument with a `Fixed` entry (or any number of `Fixed` entries), and specify `tune_new_entries=True`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)\n",
-    "\n",
-    "hp = HyperParameters()\n",
-    "hp.Fixed(\"learning_rate\", value=1e-4)\n",
-    "\n",
-    "tuner = RandomSearch(\n",
-    "    hypermodel,\n",
-    "    hyperparameters=hp,\n",
-    "    tune_new_entries=True,\n",
-    "    objective=\"val_accuracy\",\n",
-    "    max_trials=3,\n",
-    "    overwrite=True,\n",
-    "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
-    ")\n",
-    "\n",
-    "tuner.search(\n",
-    "    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "## Overriding compilation arguments\n",
-    "\n",
-    "If you have a hypermodel for which you want to change the existing optimizer,\n",
-    "loss, or metrics, you can do so by passing these arguments\n",
-    "to the tuner constructor:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)\n",
-    "\n",
-    "tuner = RandomSearch(\n",
-    "    hypermodel,\n",
-    "    optimizer=keras.optimizers.Adam(1e-3),\n",
-    "    loss=\"mse\",\n",
-    "    metrics=[\n",
-    "        keras.metrics.Precision(name=\"precision\"),\n",
-    "        keras.metrics.Recall(name=\"recall\"),\n",
-    "    ],\n",
-    "    objective=\"val_loss\",\n",
-    "    max_trials=3,\n",
-    "    overwrite=True,\n",
-    "    directory=\"my_dir\",\n",
-    "    project_name=\"helloworld\",\n",
+    "    project_name=\"built_in_hypermodel\",\n",
     ")\n",
     "\n",
     "tuner.search(\n",

--- a/guides/ipynb/keras_tuner/tailor_the_search_space.ipynb
+++ b/guides/ipynb/keras_tuner/tailor_the_search_space.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Tailor the search space\n",
+    "\n",
+    "**Authors:** Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin<br>\n",
+    "**Date created:** 2019/05/31<br>\n",
+    "**Last modified:** 2021/10/27<br>\n",
+    "**Description:** Tune a subset of the hyperparameters without changing the hypermodel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## shell\n",
+    "pip install keras-tuner -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "In this guide, we will show how to tailor the search space without changing the\n",
+    "`HyperModel` code directly.  For example, you can only tune some of the\n",
+    "hyperparameters and keep the rest fixed, or you can override the compile\n",
+    "arguments, like `optimizer`, `loss`, and `metrics`.\n",
+    "\n",
+    "## The default value of a hyperparameter\n",
+    "\n",
+    "Before we tailor the search space, it is important to know that every\n",
+    "hyperparameter has a default value.  This default value is used as the\n",
+    "hyperparameter value when not tuning it during our tailoring the search space.\n",
+    "\n",
+    "Whenever you register a hyperparameter, you can use the `default` argument to\n",
+    "specify a default value:\n",
+    "\n",
+    "```python\n",
+    "hp.Int(\"units\", min_value=32, max_value=128, step=32, default=64)\n",
+    "```\n",
+    "\n",
+    "If you don't, hyperparameters always have a default default (for `Int`, it is\n",
+    "equal to `min_value`).\n",
+    "\n",
+    "In the following model-building function, we specified the default value for\n",
+    "the `units` hyperparameter as 64."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "import keras_tuner as kt\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def build_model(hp):\n",
+    "    model = keras.Sequential()\n",
+    "    model.add(layers.Flatten())\n",
+    "    model.add(\n",
+    "        layers.Dense(\n",
+    "            units=hp.Int(\"units\", min_value=32, max_value=128, step=32, default=64)\n",
+    "        )\n",
+    "    )\n",
+    "    if hp.Boolean(\"dropout\"):\n",
+    "        model.add(layers.Dropout(rate=0.25))\n",
+    "    model.add\n",
+    "    model.compile(\n",
+    "        optimizer=keras.optimizers.Adam(\n",
+    "            learning_rate=hp.Choice(\"learning_rate\", values=[1e-2, 1e-3, 1e-4])\n",
+    "        ),\n",
+    "        loss=\"sparse_categorical_crossentropy\",\n",
+    "        metrics=[\"accuracy\"],\n",
+    "    )\n",
+    "    return model\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We will reuse this search space in the rest of the tutorial by overriding the\n",
+    "hyperparameters without defining a new search space.\n",
+    "\n",
+    "## Search a few and fix the rest\n",
+    "\n",
+    "If you have an existing hypermodel, and you want to search over only a few\n",
+    "hyperparameters, and keep the rest fixed, you don't have to change the code in\n",
+    "the model-building function or the `HyperModel`.  You can pass a\n",
+    "`HyperParameters` to the `hyperparameters` argument to the tuner constructor\n",
+    "with all the hyperparameters you want to tune.  Specify\n",
+    "`tune_new_entries=False` to prevent it from tuning other hyperparameters, the\n",
+    "default value of which would be used.\n",
+    "\n",
+    "In the following example, we only tune the `learning_rate` hyperparameter, and\n",
+    "changed its type and value ranges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hp = kt.HyperParameters()\n",
+    "\n",
+    "# This will override the `learning_rate` parameter with your\n",
+    "# own selection of choices\n",
+    "hp.Float(\"learning_rate\", min_value=1e-4, max_value=1e-2, sampling=\"log\")\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel=build_model,\n",
+    "    hyperparameters=hp,\n",
+    "    # Prevents unlisted parameters from being tuned\n",
+    "    tune_new_entries=False,\n",
+    "    objective=\"val_accuracy\",\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"search_a_few\",\n",
+    ")\n",
+    "\n",
+    "# Generate random data\n",
+    "x_train = np.random.rand(100, 28, 28, 1)\n",
+    "y_train = np.random.randint(0, 10, (100, 1))\n",
+    "x_val = np.random.rand(20, 28, 28, 1)\n",
+    "y_val = np.random.randint(0, 10, (20, 1))\n",
+    "\n",
+    "# Run the search\n",
+    "tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If you summarize the search space, you will see only one hyperparameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner.search_space_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Fix a few and tune the rest\n",
+    "\n",
+    "In the example above we showed how to tune only a few hyperparameters and keep\n",
+    "the rest fixed.  You can also do the reverse: only fix a few hyperparameters\n",
+    "and tune all the rest.\n",
+    "\n",
+    "In the following example, we fixed the value of the `learning_rate`\n",
+    "hyperparameter.  Pass a `hyperparameters` argument with a `Fixed` entry (or any\n",
+    "number of `Fixed` entries).  Also remember to specify `tune_new_entries=True`,\n",
+    "which allows us to tune the rest of the hyperparameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hp = kt.HyperParameters()\n",
+    "hp.Fixed(\"learning_rate\", value=1e-4)\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    build_model,\n",
+    "    hyperparameters=hp,\n",
+    "    tune_new_entries=True,\n",
+    "    objective=\"val_accuracy\",\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"fix_a_few\",\n",
+    ")\n",
+    "\n",
+    "tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If you summarize the search space, you will see the `learning_rate` is marked\n",
+    "as fixed, and the rest of the hyperparameters are being tuned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner.search_space_summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Overriding compilation arguments\n",
+    "\n",
+    "If you have a hypermodel for which you want to change the existing optimizer,\n",
+    "loss, or metrics, you can do so by passing these arguments to the tuner\n",
+    "constructor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner = kt.RandomSearch(\n",
+    "    build_model,\n",
+    "    optimizer=keras.optimizers.Adam(1e-3),\n",
+    "    loss=\"mse\",\n",
+    "    metrics=[\"sparse_categorical_crossentropy\",],\n",
+    "    objective=\"val_loss\",\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"override_compile\",\n",
+    ")\n",
+    "\n",
+    "tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "If you get the best model, you can see the loss function has changed to MSE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "tuner.get_best_models()[0].loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Tailor the search space of pre-build HyperModels\n",
+    "\n",
+    "You can also use these techniques with the pre-build models in KerasTuner, like\n",
+    "`HyperResNet` or `HyperXception`.  However, to see what hyperparameters are in\n",
+    "these pre-build `HyperModel`s, you will have to read the source code.\n",
+    "\n",
+    "In the following example, we only tune the `learning_rate` of `HyperXception`\n",
+    "and fixed all the rest of the hyperparameters. Because the default loss of\n",
+    "`HyperXception` is `categorical_crossentropy`, which expect the labels to be\n",
+    "one-hot encoded, which doesn't match our raw integer label data, we need to\n",
+    "change it by overriding the `loss` in the compile args to\n",
+    "`sparse_categorical_crossentropy`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "hypermodel = kt.applications.HyperXception(input_shape=(28, 28, 1), classes=10)\n",
+    "\n",
+    "hp = kt.HyperParameters()\n",
+    "\n",
+    "# This will override the `learning_rate` parameter with your\n",
+    "# own selection of choices\n",
+    "hp.Choice(\"learning_rate\", values=[1e-2, 1e-3, 1e-4])\n",
+    "\n",
+    "tuner = kt.RandomSearch(\n",
+    "    hypermodel,\n",
+    "    hyperparameters=hp,\n",
+    "    # Prevents unlisted parameters from being tuned\n",
+    "    tune_new_entries=False,\n",
+    "    # Override the loss.\n",
+    "    loss=\"sparse_categorical_crossentropy\",\n",
+    "    metrics=[\"accuracy\"],\n",
+    "    objective=\"val_accuracy\",\n",
+    "    max_trials=3,\n",
+    "    overwrite=True,\n",
+    "    directory=\"my_dir\",\n",
+    "    project_name=\"helloworld\",\n",
+    ")\n",
+    "\n",
+    "# Run the search\n",
+    "tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))\n",
+    "tuner.search_space_summary()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "tailor_the_search_space",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/guides/keras_tuner/getting_started.py
+++ b/guides/keras_tuner/getting_started.py
@@ -7,8 +7,8 @@ Description: The basics of using KerasTuner to tune model hyperparameters.
 """
 
 """
-## Setup
-!pip install keras-tuner==1.1.0rc0 -q
+## shell
+pip install keras-tuner -q
 """
 
 

--- a/guides/keras_tuner/getting_started.py
+++ b/guides/keras_tuner/getting_started.py
@@ -15,10 +15,11 @@ pip install keras-tuner -q
 """
 ## Introduction
 
-KerasTuner is a hyperparameter tuning library for Keras models or anything you
-would like to tune. In this tutorial, you will see how to tune model
-architecture, training process, and data preprocessing steps with KerasTuner.
-Let's start from a simple example.
+KerasTuner is a general-purpose hyperparameter tuning library. It has strong
+integration with Keras workflows, but it isn't limited to them: you could use
+it to tune scikit-learn models, or anything else. In this tutorial, you will
+see how to tune model architecture, training process, and data preprocessing
+steps with KerasTuner. Let's start from a simple example.
 
 ## Tune the model architecture
 
@@ -149,9 +150,16 @@ build_model(kt.HyperParameters())
 Each of the hyperparameters is uniquely identified by its name (the first
 argument). To tune the number of units in different `Dense` layers separately
 as different hyperparameters, we give them different names as `f"units_{i}"`.
-Notably, this is also an example of conditional hyperparameters. The value of
-the hyperparameter specifying the number of `Dense` layers decides how many
-other hyperparameters follows it.
+
+Notably, this is also an example of creating conditional hyperparameters.
+There are many hyperparameters specifying the number of units in the `Dense`
+layers. The number of such hyperparameters is decided by the number of layers,
+which is also a hyperparameter. Therefore, the total number of hyperparameters
+used may be different from trial to trial. Some hyperparameter is only used
+when a certain condition is satisfied. For example, `units_3` is only used
+when `num_layers` is larger than 3. With KerasTuner, you can easily define
+such hyperparameters dynamically while creating the model.
+
 """
 
 
@@ -192,13 +200,10 @@ search. You may choose from `RandomSearch`, `BayesianOptimization` and
 To initialize the tuner, we need to specify several arguments in the initializer.
 
 * `hypermodel`. The model-building function, which is `build_model` in our case.
-
 * `objective`. The name of the objective to optimize (whether to minimize or
 maximize is automatically inferred for built-in metrics). We will introduce how
 to use custom metrics later in this tutorial.
-
 * `max_trials`. The total number of trials to run during the search.
-
 * `executions_per_trial`. The number of models that should be built and fit for
 each trial. Different trials have different hyperparameter values. The
 executions within the same trial have the same hyperparameter values. The
@@ -206,13 +211,10 @@ purpose of having multiple executions per trial is to reduce results variance
 and therefore be able to more accurately assess the performance of a model. If
 you want to get results faster, you could set `executions_per_trial=1` (single
 round of training for each model configuration).
-
 * `overwrite`. Control whether to overwrite the previous results in the same
 directory or resume the previous search instead. Here we set `overwrite=True`
 to start a new search and ignore any previous results.
-
 * `directory`. A path to a directory for storing the search results.
-
 * `project_name`. The name of the sub-directory in the `directory`.
 
 """
@@ -296,8 +298,8 @@ You will find detailed logs, checkpoints, etc, in the folder
 `my_dir/helloworld`, i.e. `directory/project_name`.
 
 You can also visualize the tuning results using TensorBoard and HParams plugin.
-For more information, please following [this
-link](https://keras.io/guides/keras_tuner/visualize_tuning/).
+For more information, please following
+[this link](https://keras.io/guides/keras_tuner/visualize_tuning/).
 
 ### Retrain the model
 
@@ -694,7 +696,7 @@ tuner.results_summary()
 
 """
 If you have multiple metrics to track in KerasTuner, but only use one of them
-as the objective. You can return a dictionary, whose keys are the metric names
+as the objective, you can return a dictionary, whose keys are the metric names
 and the values are the metrics values, for example, return `{"metric_a": 1.0,
 "metric_b", 2.0}`. Use one of the keys as the objective name, for example,
 `kt.Objective("metric_a", "min")`.

--- a/guides/keras_tuner/getting_started.py
+++ b/guides/keras_tuner/getting_started.py
@@ -2,24 +2,239 @@
 Title: Getting started with KerasTuner
 Authors: Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin
 Date created: 2019/05/31
-Last modified: 2021/06/07
+Last modified: 2021/10/27
 Description: The basics of using KerasTuner to tune model hyperparameters.
 """
 
 """
 ## Setup
+!pip install keras-tuner==1.1.0rc0 -q
 """
 
-"""shell
-pip install keras-tuner -q
-"""
 
 """
 ## Introduction
 
-Here's how to perform hyperparameter tuning for a single-layer dense neural
-network using random search.
-First, we need to prepare the dataset -- let's use MNIST dataset as an example.
+KerasTuner is a hyperparameter tuning library for Keras models or anything you
+would like to tune. In this tutorial, you will see how to tune model
+architecture, training process, and data preprocessing steps with KerasTuner.
+Let's start from a simple example.
+
+## Tune the model architecture
+
+The first thing we need to do is writing a function, which returns a compiled
+Keras model. It takes an argument `hp` for defining the hyperparameters while
+building the model.
+
+### Define the search space
+
+In the following code example, we define a Keras model with two `Dense` layers.
+We want to tune the number of units in the first `Dense` layer. We just define
+an integer hyperparameter with `hp.Int('units', min_value=32, max_value=512, step=32)`,
+whose range is from 32 to 512 inclusive. When sampling from it, the minimum
+step for walking through the interval is 32.
+"""
+
+from tensorflow import keras
+from tensorflow.keras import layers
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            # Define the hyperparameter.
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            activation="relu",
+        )
+    )
+    model.add(layers.Dense(10, activation="softmax"))
+    model.compile(
+        optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+    )
+    return model
+
+
+"""
+You can quickly test if the model builds successfully.
+"""
+
+import keras_tuner as kt
+
+build_model(kt.HyperParameters())
+
+"""
+There are many other types of hyperparameters as well. We can define multiple
+hyperparameters in the function. In the following code, we tune the whether to
+use a `Dropout` layer with `hp.Boolean()`, tune which activation function to
+use with `hp.Choice()`, tune the learning rate of the optimizer with
+`hp.Float()`.
+"""
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            # Tune number of units.
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            # Tune the activation function to use.
+            activation=hp.Choice("activation", ["relu", "tanh"]),
+        )
+    )
+    # Tune whether to use dropout.
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    # Define the optimizer learning rate as a hyperparameter.
+    learning_rate = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+
+"""
+As shown below, the hyperparameters are actual values. In fact, they are just
+functions returning actual values. For example, `hp.Int()` returns an `int`
+value. Therefore, you can put them into variables, for loops, or if
+conditions.
+"""
+
+hp = kt.HyperParameters()
+print(hp.Int("units", min_value=32, max_value=512, step=32))
+
+"""
+You can also define the hyperparameters in advance and keep your Keras code in
+a separate function.
+"""
+
+
+def call_existing_code(units, activation, dropout, lr):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(layers.Dense(units=units, activation=activation))
+    if dropout:
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=lr),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def build_model(hp):
+    units = hp.Int("units", min_value=32, max_value=512, step=32)
+    activation = hp.Choice("activation", ["relu", "tanh"])
+    dropout = hp.Boolean("dropout")
+    lr = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    # call existing model-building code with the hyperparameter values.
+    model = call_existing_code(
+        units=units, activation=activation, dropout=dropout, lr=lr
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+
+"""
+Each of the hyperparameters is uniquely identified by its name (the first
+argument). To tune the number of units in different `Dense` layers separately
+as different hyperparameters, we give them different names as `f"units_{i}"`.
+Notably, this is also an example of conditional hyperparameters. The value of
+the hyperparameter specifying the number of `Dense` layers decides how many
+other hyperparameters follows it.
+"""
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    # Tune the number of layers.
+    for i in range(hp.Int("num_layers", 1, 3)):
+        model.add(
+            layers.Dense(
+                # Tune number of units separately.
+                units=hp.Int(f"units_{i}", min_value=32, max_value=512, step=32),
+                activation=hp.Choice("activation", ["relu", "tanh"]),
+            )
+        )
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    learning_rate = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+
+"""
+### Start the search
+
+After defining the search space, we need to select a tuner class to run the
+search. You may choose from `RandomSearch`, `BayesianOptimization` and
+`Hyperband`, which correspond to different tuning algorithms. Here we use
+`RandomSearch` as an example.
+
+To initialize the tuner, we need to specify several arguments in the initializer.
+
+* `hypermodel`. The model-building function, which is `build_model` in our case.
+
+* `objective`. The name of the objective to optimize (whether to minimize or
+maximize is automatically inferred for built-in metrics). We will introduce how
+to use custom metrics later in this tutorial.
+
+* `max_trials`. The total number of trials to run during the search.
+
+* `executions_per_trial`. The number of models that should be built and fit for
+each trial. Different trials have different hyperparameter values. The
+executions within the same trial have the same hyperparameter values. The
+purpose of having multiple executions per trial is to reduce results variance
+and therefore be able to more accurately assess the performance of a model. If
+you want to get results faster, you could set `executions_per_trial=1` (single
+round of training for each model configuration).
+
+* `overwrite`. Control whether to overwrite the previous results in the same
+directory or resume the previous search instead. Here we set `overwrite=True`
+to start a new search and ignore any previous results.
+
+* `directory`. A path to a directory for storing the search results.
+
+* `project_name`. The name of the sub-directory in the `directory`.
+
+"""
+
+tuner = kt.RandomSearch(
+    hypermodel=build_model,
+    objective="val_accuracy",
+    max_trials=3,
+    executions_per_trial=2,
+    overwrite=True,
+    directory="my_dir",
+    project_name="helloworld",
+)
+
+"""
+You can print a summary of the search space:
+"""
+
+tuner.search_space_summary()
+
+"""
+Before starting the search, let's prepare the MNIST dataset.
 """
 
 from tensorflow import keras
@@ -42,157 +257,90 @@ y_val = keras.utils.to_categorical(y_val, num_classes)
 y_test = keras.utils.to_categorical(y_test, num_classes)
 
 """
-## Prepare a model-building function
-
-Then, we define a model-building function. It takes an argument `hp` from
-which you can sample hyperparameters, such as
-`hp.Int('units', min_value=32, max_value=512, step=32)`
-(an integer from a certain range).
-
-This function returns a compiled model.
-"""
-
-from tensorflow.keras import layers
-from keras_tuner import RandomSearch
-
-
-def build_model(hp):
-    model = keras.Sequential()
-    model.add(layers.Flatten())
-    model.add(
-        layers.Dense(
-            units=hp.Int("units", min_value=32, max_value=512, step=32),
-            activation="relu",
-        )
-    )
-    model.add(layers.Dense(10, activation="softmax"))
-    model.compile(
-        optimizer=keras.optimizers.Adam(
-            hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-        ),
-        loss="categorical_crossentropy",
-        metrics=["accuracy"],
-    )
-    return model
-
-
-"""
-## Start the search
-
-Next, let's instantiate a tuner. You should specify the model-building function, the
-name of the objective to optimize (whether to minimize or maximize is
-automatically inferred for built-in metrics), the total number of trials
-(`max_trials`) to test, and the number of models that should be built and fit
-for each trial (`executions_per_trial`).
-
-We use the `overwrite` argument to control whether to overwrite the previous
-results in the same directory or resume the previous search instead.  Here we
-set `overwrite=True` to start a new search and ignore any previous results.
-
-Available tuners are `RandomSearch`, `BayesianOptimization` and `Hyperband`.
-
-**Note:** the purpose of having multiple executions per trial is to reduce
-results variance and therefore be able to more accurately assess the
-performance of a model. If you want to get results faster, you could set
-`executions_per_trial=1` (single round of training for each model
-configuration).
-"""
-
-tuner = RandomSearch(
-    build_model,
-    objective="val_accuracy",
-    max_trials=3,
-    executions_per_trial=2,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-"""
-You can print a summary of the search space:
-"""
-
-tuner.search_space_summary()
-
-"""
 Then, start the search for the best hyperparameter configuration.
-The call to `search` has the same signature as `model.fit()`.
+All the arguments passed to `search` is passed to `model.fit()` in each
+execution. Remember to pass `validation_data` to evaluate the model.
 """
 
 tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))
 
 """
-Here's what happens in `search`: models are built iteratively by calling the
-model-building function, which populates the hyperparameter space (search
-space) tracked by the `hp` object. The tuner progressively explores the space,
-recording metrics for each configuration.
+During the `search`, the model-building function is called with different
+hyperparameter values in different trial. In each trial, the tuner would
+generate a new set of hyperparameter values to build the model. The model is
+then fit and evaluated. The metrics are recorded. The tuner progressively
+explores the space and finally finds a good set of hyperparameter values.
+
+### Query the results
+
+When search is over, you can retrieve the best model(s). The model is saved at
+its best performing epoch evaluated on the `validation_data`.
 """
 
-"""
-## Query the results
-
-When search is over, you can retrieve the best model(s):
-"""
-
+# Get the top 2 models.
 models = tuner.get_best_models(num_models=2)
+best_model = models[0]
+# Build the model.
+# Needed for `Sequential` without specified `input_shape`.
+best_model.build(input_shape=(None, 28, 28))
+best_model.summary()
 
 """
-Or print a summary of the results:
+You can also print a summary of the search results.
 """
 
 tuner.results_summary()
 
 """
-You will also find detailed logs, checkpoints, etc, in the folder `my_dir/helloworld`, i.e. `directory/project_name`.
+You will find detailed logs, checkpoints, etc, in the folder
+`my_dir/helloworld`, i.e. `directory/project_name`.
+
+You can also visualize the tuning results using TensorBoard and HParams plugin.
+For more information, please following [this
+link](https://keras.io/guides/keras_tuner/visualize_tuning/).
+
+### Retrain the model
+
+If you want to train the model with the entire dataset, you may retrieve the
+best hyperparameters and retrain the model by yourself.
 """
 
-"""
-## The search space may contain conditional hyperparameters
-
-Below, we have a `for` loop creating a tunable number of layers,
-which themselves involve a tunable `units` parameter.
-
-This can be pushed to any level of parameter interdependency, including recursion.
-
-Note that all parameter names should be unique (here, in the loop over `i`,
-we name the inner parameters `'units_' + str(i)`).
-"""
-
-
-def build_model(hp):
-    model = keras.Sequential()
-    model.add(layers.Flatten())
-    for i in range(hp.Int("num_layers", 2, 20)):
-        model.add(
-            layers.Dense(
-                units=hp.Int("units_" + str(i), min_value=32, max_value=512, step=32),
-                activation="relu",
-            )
-        )
-    model.add(layers.Dense(10, activation="softmax"))
-    model.compile(
-        optimizer=keras.optimizers.Adam(hp.Choice("learning_rate", [1e-2, 1e-3, 1e-4])),
-        loss="categorical_crossentropy",
-        metrics=["accuracy"],
-    )
-    return model
-
+# Get the top 2 hyperparameters.
+best_hps = tuner.get_best_hyperparameters(5)
+# Build the model with the best hp.
+model = build_model(best_hps[0])
+# Fit with the entire dataset.
+x_all = np.concatenate((x_train, x_val))
+y_all = np.concatenate((y_train, y_val))
+model.fit(x=x_all, y=y_all, epochs=1)
 
 """
-## You can use a HyperModel subclass instead of a model-building function
+## Tune model training
 
-This makes it easy to share and reuse hypermodels.
+To tune the model building process, we need to subclass the `HyperModel` class,
+which also makes it easy to share and reuse hypermodels.
 
-A `HyperModel` subclass only needs to implement a `build(self, hp)` method.
+We need to override `HyperModel.build()` and `HyperModel.fit()` to tune the
+model building and training process respectively. A `HyperModel.build()`
+method is the same as the model-building function, which creates a Keras model
+using the hyperparameters and returns it.
+
+In `HyperModel.fit()`, you can access the model returned by
+`HyperModel.build()`,`hp` and all the arguments passed to `search()`. You need
+to train the model and return the training history.
+
+In the following code, we will tune the `shuffle` argument in `model.fit()`.
+
+It is generally not needed to tune the number of epochs because a built-in
+callback is passed to `model.fit()` to save the model at its best epoch
+evaluated by the `validation_data`.
+
+> **Note**: The `**kwargs` should always be passed to `model.fit()` because it
+contains the callbacks for model saving and tensorboard plugins.
 """
 
-from keras_tuner import HyperModel
 
-
-class MyHyperModel(HyperModel):
-    def __init__(self, classes):
-        self.classes = classes
-
+class MyHyperModel(kt.HyperModel):
     def build(self, hp):
         model = keras.Sequential()
         model.add(layers.Flatten())
@@ -202,57 +350,239 @@ class MyHyperModel(HyperModel):
                 activation="relu",
             )
         )
-        model.add(layers.Dense(self.classes, activation="softmax"))
+        model.add(layers.Dense(10, activation="softmax"))
         model.compile(
-            optimizer=keras.optimizers.Adam(
-                hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-            ),
-            loss="categorical_crossentropy",
-            metrics=["accuracy"],
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
         )
         return model
 
+    def fit(self, hp, model, *args, **kwargs):
+        return model.fit(
+            *args,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            **kwargs,
+        )
 
-hypermodel = MyHyperModel(classes=10)
 
-tuner = RandomSearch(
-    hypermodel,
+"""
+Again, we can do a quick check to see if the code works correctly.
+"""
+
+hp = kt.HyperParameters()
+hypermodel = MyHyperModel()
+model = hypermodel.build(hp)
+hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))
+
+"""
+## Tune data preprocessing
+
+To tune data preprocessing, we just add an additional step in
+`HyperModel.fit()`, where we can access the dataset from the arguments. In the
+following code, we tune whether to normalize the data before training the
+model. This time we explicitly put `x` and `y` in the function signature
+because we need to use them.
+
+"""
+
+
+class MyHyperModel(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential()
+        model.add(layers.Flatten())
+        model.add(
+            layers.Dense(
+                units=hp.Int("units", min_value=32, max_value=512, step=32),
+                activation="relu",
+            )
+        )
+        model.add(layers.Dense(10, activation="softmax"))
+        model.compile(
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+        )
+        return model
+
+    def fit(self, hp, model, x, y, **kwargs):
+        if hp.Boolean("normalize"):
+            x = layers.Normalization()(x)
+        return model.fit(
+            x,
+            y,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            **kwargs,
+        )
+
+
+hp = kt.HyperParameters()
+hypermodel = MyHyperModel()
+model = hypermodel.build(hp)
+hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))
+
+"""
+If a hyperparameter is used both in `build()` and `fit()`, you can define it in
+`build()` and use `hp.get(hp_name)` to retrieve it in `fit()`. We use the
+image size as an example. It is both used as the input shape in `build()`, and
+used by data prerprocessing step to crop the images in `fit()`.
+"""
+
+
+class MyHyperModel(kt.HyperModel):
+    def build(self, hp):
+        image_size = hp.Int("image_size", 10, 28)
+        inputs = keras.Input(shape=(image_size, image_size))
+        outputs = layers.Flatten()(inputs)
+        outputs = layers.Dense(
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            activation="relu",
+        )(outputs)
+        outputs = layers.Dense(10, activation="softmax")(outputs)
+        model = keras.Model(inputs, outputs)
+        model.compile(
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data=None, **kwargs):
+        if hp.Boolean("normalize"):
+            x = layers.Normalization()(x)
+        image_size = hp.get("image_size")
+        cropped_x = x[:, :image_size, :image_size, :]
+        if validation_data:
+            x_val, y_val = validation_data
+            cropped_x_val = x_val[:, :image_size, :image_size, :]
+            validation_data = (cropped_x_val, y_val)
+        return model.fit(
+            cropped_x,
+            y,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            validation_data=validation_data,
+            **kwargs,
+        )
+
+
+tuner = kt.RandomSearch(
+    MyHyperModel(),
     objective="val_accuracy",
     max_trials=3,
     overwrite=True,
     directory="my_dir",
-    project_name="helloworld",
+    project_name="tune_hypermodel",
 )
 
 tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))
 
 """
-## Use a custom metric as the tuning objective
+### Retrain the model
 
-You may implement your own metric and use it as the hyperparameter search objective.
+Using `HyperModel` also allows you to retrain the best model by yourself.
+"""
 
-Here, we use mean squared error (MSE) as an example.
+hypermodel = MyHyperModel()
+best_hp = tuner.get_best_hyperparameters()[0]
+model = hypermodel.build(best_hp)
+hypermodel.fit(best_hp, model, x_all, y_all, epochs=1)
 
-First, we implement the MSE metric by extending the `keras.metrics.Metric`
-class. Remember to give a name to your metric using the `name` argument of
-`super().__init__()`, which will be used later.
+"""
+## Specify the tuning objective
 
-Note: MSE is actully a build-in metric, which can be imported with
-`keras.metrics.MeanSquaredError`. This is just an example to show how to use a custom metric
-as the hyperparameter search objective.
-For more information about implementing custom metrics, please
-see [this tutorial](https://keras.io/api/metrics/#creating-custom-metrics). If
-you would like a metric with a different function signature than
-`update_state(y_true, y_pred, sample_weight)`, you can override the
-`train_step()` method of your model following
-[this tutorial](https://keras.io/guides/customizing_what_happens_in_fit/#going-lowerlevel).
+In all previous examples, we all just used validation accuracy
+(`"val_accuracy"`) as the tuning objective to select the best model. Actually,
+you can use any metric as the objective. The most commonly used metric is
+`"val_loss"`, which is the validation loss.
+
+### Built-in metric as the objective
+
+There are many other built-in metrics in Keras you can use as the objective.
+Here is [a list of the built-in metrics](https://keras.io/api/metrics/).
+
+To use a built-in metric as the objective, you need to follow these steps:
+* Compile the model with the the built-in metric. For example, you want to use
+`MeanAbsoluteError()`. You need to compile the model with
+`metrics=[MeanAbsoluteError()]`. You may also use its name string instead:
+`metrics=["mean_absolute_error"]`. The name string of the metric is always
+the snake case of the class name.
+
+* Identify the objective name string. The name string of the objective is
+always in the format of `f"val_{metric_name_string}"`. For example, the
+objective name string of mean squared error evaluated on the validation data
+should be `"val_mean_absolute_error"`.
+
+* Wrap it into `kt.Objective`. We usually need to wrap the objective into a
+`kt.Objective` object to specify the direction to optimize the objective. For
+example, we want to minimize the mean squared error, we can use
+`kt.Objective("val_mean_absolute_error", "min")`. The direction should be
+either `"min"` or `"max"`.
+
+* Pass the wrapped objective to the tuner.
+
+You can see the following barebone code example.
+"""
+
+
+def build_regressor(hp):
+    model = keras.Sequential(
+        [
+            layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+            layers.Dense(units=1),
+        ]
+    )
+    model.compile(
+        optimizer="adam",
+        loss="mean_squared_error",
+        # Objective is one of the metrics.
+        metrics=[keras.metrics.MeanAbsoluteError()],
+    )
+    return model
+
+
+tuner = kt.RandomSearch(
+    hypermodel=build_regressor,
+    # The objective name and direction.
+    # Name is the f"val_{snake_case_metric_class_name}".
+    objective=kt.Objective("val_mean_absolute_error", direction="min"),
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="built_in_metrics",
+)
+
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+
+"""
+### Custom metric as the objective
+
+You may implement your own metric and use it as the hyperparameter search
+objective. Here, we use mean squared error (MSE) as an example. First, we
+implement the MSE metric by subclassing `keras.metrics.Metric`. Remember to
+give a name to your metric using the `name` argument of `super().__init__()`,
+which will be used later. Note: MSE is actully a build-in metric, which can be
+imported with `keras.metrics.MeanSquaredError`. This is just an example to show
+how to use a custom metric as the hyperparameter search objective.
+
+For more information about implementing custom metrics, please see [this
+tutorial](https://keras.io/api/metrics/#creating-custom-metrics). If you would
+like a metric with a different function signature than `update_state(y_true,
+y_pred, sample_weight)`, you can override the `train_step()` method of your
+model following [this
+tutorial](https://keras.io/guides/customizing_what_happens_in_fit/#going-lowerlevel).
+
 """
 
 import tensorflow as tf
 
-class MeanSquaredError(keras.metrics.Metric):
+
+class CustomMetric(keras.metrics.Metric):
     def __init__(self, **kwargs):
-        super().__init__(name="mean_squared_error", **kwargs)
+        # Specify the name of the metric as "custom_metric".
+        super().__init__(name="custom_metric", **kwargs)
         self.sum = self.add_weight(name="sum", initializer="zeros")
         self.count = self.add_weight(name="count", dtype=tf.int32, initializer="zeros")
 
@@ -261,13 +591,13 @@ class MeanSquaredError(keras.metrics.Metric):
         count = tf.shape(y_true)[0]
         if sample_weight is not None:
             sample_weight = tf.cast(sample_weight, self.dtype)
-            values = tf.multiply(values, sample_weight)
-            count = tf.multiply(count, sample_weight)
+            values *= sample_weight
+            count *= sample_weight
         self.sum.assign_add(tf.reduce_sum(values))
         self.count.assign_add(count)
 
     def result(self):
-        return tf.math.divide(self.sum, tf.cast(self.count, tf.float32))
+        return self.sum / tf.cast(self.count, tf.float32)
 
     def reset_states(self):
         self.sum.assign(0)
@@ -275,174 +605,269 @@ class MeanSquaredError(keras.metrics.Metric):
 
 
 """
-Second, we pass a `MeanSquaredError` instance to `model.compile()` in `build_model()`.
+Run the search with the custom objective.
 """
 
 
-def build_model(hp):
+def build_regressor(hp):
     model = keras.Sequential(
         [
-            layers.Dense(10, activation="relu"),
-            layers.Dense(hp.Int("units", 5, 50), activation="relu"),
-            layers.Dense(1, activation="sigmoid"),
+            layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+            layers.Dense(units=1),
         ]
     )
-    model.compile(loss="mae", metrics=[MeanSquaredError()])  # Use mse as a metric
+    model.compile(
+        optimizer="adam",
+        loss="mean_squared_error",
+        # Put custom metric into the metrics.
+        metrics=[CustomMetric()],
+    )
     return model
 
 
-"""
-Finally, we use `Objective(name='val_mean_squared_error', direction='min')`
-as the `objective` of the `Tuner`. The `name` should be in the form of
-`'val_' + metric_name`, referring the metric on the validation data. We
-specified the metric name as `'mean_squared_error'` in the initializer.
-Therefore, the name for the objective is `'val_mean_squared_error'`.  The
-`direction` should be either `'min'` (the lower the better) or `'max'` (the
-higher the better).
-
-"""
-
-from keras_tuner import Objective
-
-tuner = RandomSearch(
-    build_model,
-    objective=Objective("val_mean_squared_error", direction="min"),
+tuner = kt.RandomSearch(
+    hypermodel=build_regressor,
+    # Specify the name and direction of the objective.
+    objective=kt.Objective("val_custom_metric", direction="min"),
     max_trials=3,
     overwrite=True,
+    directory="my_dir",
+    project_name="custom_metrics",
 )
 
-# Run the search as a quick test.
 tuner.search(
     x=np.random.rand(100, 10),
     y=np.random.rand(100, 1),
-    epochs=2,
-    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1))
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
 )
 
+tuner.results_summary()
+
 """
-## Pre-made tunable applications: HyperResNet and HyperXception
+If your custom objective is hard to put into a custom metric, you can also
+evaluate the model by yourself in `HyperModel.fit()` and return the objective
+value. The objective value would be minimized by default. In this case, you
+don't need to specify the `objective` when initializing the tuner. However, in
+this case, the metric value will not be tracked in the Keras logs by only
+KerasTuner logs. Therefore, these values would not be displayed by any
+TensorBoard view using the Keras metrics.
+"""
+
+
+class HyperRegressor(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential(
+            [
+                layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+                layers.Dense(units=1),
+            ]
+        )
+        model.compile(
+            optimizer="adam", loss="mean_squared_error",
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data, **kwargs):
+        model.fit(x, y, **kwargs)
+        x_val, y_val = validation_data
+        y_pred = model.predict(x_val)
+        # Return a single float to minimize.
+        return np.mean(np.abs(y_pred - y_val))
+
+
+tuner = kt.RandomSearch(
+    hypermodel=HyperRegressor(),
+    # No objective to specify.
+    # Objective is the return value of `HyperModel.fit()`.
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="custom_eval",
+)
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+
+"""
+If you have multiple metrics to track in KerasTuner, but only use one of them
+as the objective. You can return a dictionary, whose keys are the metric names
+and the values are the metrics values, for example, return `{"metric_a": 1.0,
+"metric_b", 2.0}`. Use one of the keys as the objective name, for example,
+`kt.Objective("metric_a", "min")`.
+"""
+
+
+class HyperRegressor(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential(
+            [
+                layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+                layers.Dense(units=1),
+            ]
+        )
+        model.compile(
+            optimizer="adam", loss="mean_squared_error",
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data, **kwargs):
+        model.fit(x, y, **kwargs)
+        x_val, y_val = validation_data
+        y_pred = model.predict(x_val)
+        # Return a dictionary of metrics for KerasTuner to track.
+        return {
+            "metric_a": -np.mean(np.abs(y_pred - y_val)),
+            "metric_b": np.mean(np.square(y_pred - y_val)),
+        }
+
+
+tuner = kt.RandomSearch(
+    hypermodel=HyperRegressor(),
+    # Objective is one of the keys.
+    # Maximize the negative MAE, equivalent to minimize MAE.
+    objective=kt.Objective("metric_a", "max"),
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="custom_eval_dict",
+)
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+
+"""
+## Tune end-to-end workflows
+
+In some cases, it is hard to align your code into build and fit functions. You
+can also keep your end-to-end workflow in one place by overriding
+`Tuner.run_trial()`, which gives you full control of a trial. You can see it
+as a black-box optimizer for anything.
+
+### Tune any function
+
+For example, you can find a value of `x`, which minimizes `f(x)=x*x+1`. In the
+following code, we just define `x` as a hyperparameter, and return `f(x)` as
+the objective value. The `hypermodel` and `objective` argument for initializing
+the tuner can be omitted.
+"""
+
+
+class MyTuner(kt.RandomSearch):
+    def run_trial(self, trial, *args, **kwargs):
+        # Get the hp from trial.
+        hp = trial.hyperparameters
+        # Define "x" as a hyperparameter.
+        x = hp.Float("x", min_value=-1.0, max_value=1.0)
+        # Return the objective value to minimize.
+        return x * x + 1
+
+
+tuner = MyTuner(
+    # No hypermodel or objective specified.
+    max_trials=20,
+    overwrite=True,
+    directory="my_dir",
+    project_name="tune_anything",
+)
+
+# No need to pass anything to search()
+# unless you use them in run_trial().
+tuner.search()
+print(tuner.get_best_hyperparameters()[0].get("x"))
+
+"""
+### Keep Keras code separate
+
+You can keep all your Keras code unchanged and use KerasTuner to tune it. It
+is useful if you cannot modify the Keras code for some reason.
+
+It also gives you more flexibility. You don't have to separate the model
+building and training code apart. However, this workflow would not help you
+save the model or connect with the TensorBoard plugins.
+
+To save the model, you can use `trial.trial_id`, which is a string to uniquely
+identify a trial, to construct different paths to save the models from
+different trials.
+"""
+
+import os
+
+
+def keras_code(units, optimizer, saving_path):
+    # Build model
+    model = keras.Sequential(
+        [layers.Dense(units=units, activation="relu"), layers.Dense(units=1),]
+    )
+    model.compile(
+        optimizer=optimizer, loss="mean_squared_error",
+    )
+
+    # Prepare data
+    x_train = np.random.rand(100, 10)
+    y_train = np.random.rand(100, 1)
+    x_val = np.random.rand(20, 10)
+    y_val = np.random.rand(20, 1)
+
+    # Train & eval model
+    model.fit(x_train, y_train)
+
+    # Save model
+    model.save(saving_path)
+
+    # Return a single float as the objective value.
+    # You may also return a dictionary
+    # of {metric_name: metric_value}.
+    y_pred = model.predict(x_val)
+    return np.mean(np.abs(y_pred - y_val))
+
+
+class MyTuner(kt.RandomSearch):
+    def run_trial(self, trial, **kwargs):
+        hp = trial.hyperparameters
+        return keras_code(
+            units=hp.Int("units", 32, 128, 32),
+            optimizer=hp.Choice("optimizer", ["adam", "adadelta"]),
+            saving_path=os.path.join("/tmp", trial.trial_id),
+        )
+
+
+tuner = MyTuner(
+    max_trials=3, overwrite=True, directory="my_dir", project_name="keep_code_separate",
+)
+tuner.search()
+# Retraining the model
+best_hp = tuner.get_best_hyperparameters()[0]
+keras_code(**best_hp.values, saving_path="/tmp/best_model")
+
+"""
+## KerasTuner includes pre-made tunable applications: HyperResNet and HyperXception
 
 These are ready-to-use hypermodels for computer vision.
 
-They come pre-compiled with `loss="categorical_crossentropy"` and `metrics=["accuracy"]`.
+They come pre-compiled with `loss="categorical_crossentropy"` and
+`metrics=["accuracy"]`.
+
 """
 
 from keras_tuner.applications import HyperResNet
 
 hypermodel = HyperResNet(input_shape=(28, 28, 1), classes=10)
 
-tuner = RandomSearch(
+tuner = kt.RandomSearch(
     hypermodel,
     objective="val_accuracy",
-    max_trials=3,
+    max_trials=2,
     overwrite=True,
     directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-
-"""
-## You can easily restrict the search space to just a few parameters
-
-If you have an existing hypermodel, and you want to search over only a few parameters
-(such as the learning rate), you can do so by passing a `hyperparameters` argument
-to the tuner constructor, as well as `tune_new_entries=False` to specify that parameters
-that you didn't list in `hyperparameters` should not be tuned. For these parameters, the default
-value gets used.
-"""
-
-from keras_tuner import HyperParameters
-from keras_tuner.applications import HyperXception
-
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-hp = HyperParameters()
-
-# This will override the `learning_rate` parameter with your
-# own selection of choices
-hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-
-tuner = RandomSearch(
-    hypermodel,
-    hyperparameters=hp,
-    # `tune_new_entries=False` prevents unlisted parameters from being tuned
-    tune_new_entries=False,
-    objective="val_accuracy",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-
-"""
-## About parameter default values
-
-Whenever you register a hyperparameter inside a model-building function or the `build` method of a hypermodel,
-you can specify a default value:
-
-```python
-hp.Int("units", min_value=32, max_value=512, step=32, default=128)
-```
-
-If you don't, hyperparameters always have a default default (for `Int`, it is equal to `min_value`).
-
-## Fixing values in a hypermodel
-
-What if you want to do the reverse -- tune all available parameters in a hypermodel, **except** one (the learning rate)?
-
-Pass a `hyperparameters` argument with a `Fixed` entry (or any number of `Fixed` entries), and specify `tune_new_entries=True`.
-"""
-
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-hp = HyperParameters()
-hp.Fixed("learning_rate", value=1e-4)
-
-tuner = RandomSearch(
-    hypermodel,
-    hyperparameters=hp,
-    tune_new_entries=True,
-    objective="val_accuracy",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-
-"""
-## Overriding compilation arguments
-
-If you have a hypermodel for which you want to change the existing optimizer,
-loss, or metrics, you can do so by passing these arguments
-to the tuner constructor:
-"""
-
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-tuner = RandomSearch(
-    hypermodel,
-    optimizer=keras.optimizers.Adam(1e-3),
-    loss="mse",
-    metrics=[
-        keras.metrics.Precision(name="precision"),
-        keras.metrics.Recall(name="recall"),
-    ],
-    objective="val_loss",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
+    project_name="built_in_hypermodel",
 )
 
 tuner.search(

--- a/guides/keras_tuner/tailor_the_search_space.py
+++ b/guides/keras_tuner/tailor_the_search_space.py
@@ -1,0 +1,222 @@
+"""
+Title: Tailor the search space
+Authors: Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin
+Date created: 2019/05/31
+Last modified: 2021/10/27
+Description: Tune a subset of the hyperparameters without changing the hypermodel.
+"""
+
+"""
+## shell
+pip install keras-tuner -q
+"""
+
+"""
+In this guide, we will show how to tailor the search space without changing the
+`HyperModel` code directly.  For example, you can only tune some of the
+hyperparameters and keep the rest fixed, or you can override the compile
+arguments, like `optimizer`, `loss`, and `metrics`.
+
+## The default value of a hyperparameter
+
+Before we tailor the search space, it is important to know that every
+hyperparameter has a default value.  This default value is used as the
+hyperparameter value when not tuning it during our tailoring the search space.
+
+Whenever you register a hyperparameter, you can use the `default` argument to
+specify a default value:
+
+```python
+hp.Int("units", min_value=32, max_value=128, step=32, default=64)
+```
+
+If you don't, hyperparameters always have a default default (for `Int`, it is
+equal to `min_value`).
+
+In the following model-building function, we specified the default value for
+the `units` hyperparameter as 64.
+"""
+
+from tensorflow import keras
+from tensorflow.keras import layers
+import keras_tuner as kt
+import numpy as np
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            units=hp.Int("units", min_value=32, max_value=128, step=32, default=64)
+        )
+    )
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add
+    model.compile(
+        optimizer=keras.optimizers.Adam(
+            learning_rate=hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
+        ),
+        loss="sparse_categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+"""
+We will reuse this search space in the rest of the tutorial by overriding the
+hyperparameters without defining a new search space.
+
+## Search a few and fix the rest
+
+If you have an existing hypermodel, and you want to search over only a few
+hyperparameters, and keep the rest fixed, you don't have to change the code in
+the model-building function or the `HyperModel`.  You can pass a
+`HyperParameters` to the `hyperparameters` argument to the tuner constructor
+with all the hyperparameters you want to tune.  Specify
+`tune_new_entries=False` to prevent it from tuning other hyperparameters, the
+default value of which would be used.
+
+In the following example, we only tune the `learning_rate` hyperparameter, and
+changed its type and value ranges.
+"""
+
+hp = kt.HyperParameters()
+
+# This will override the `learning_rate` parameter with your
+# own selection of choices
+hp.Float("learning_rate", min_value=1e-4, max_value=1e-2, sampling="log")
+
+tuner = kt.RandomSearch(
+    hypermodel=build_model,
+    hyperparameters=hp,
+    # Prevents unlisted parameters from being tuned
+    tune_new_entries=False,
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="search_a_few",
+)
+
+# Generate random data
+x_train = np.random.rand(100, 28, 28, 1)
+y_train = np.random.randint(0, 10, (100, 1))
+x_val = np.random.rand(20, 28, 28, 1)
+y_val = np.random.randint(0, 10, (20, 1))
+
+# Run the search
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+
+"""
+If you summarize the search space, you will see only one hyperparameter.
+"""
+
+tuner.search_space_summary()
+
+"""
+## Fix a few and tune the rest
+
+In the example above we showed how to tune only a few hyperparameters and keep
+the rest fixed.  You can also do the reverse: only fix a few hyperparameters
+and tune all the rest.
+
+In the following example, we fixed the value of the `learning_rate`
+hyperparameter.  Pass a `hyperparameters` argument with a `Fixed` entry (or any
+number of `Fixed` entries).  Also remember to specify `tune_new_entries=True`,
+which allows us to tune the rest of the hyperparameters.
+"""
+
+hp = kt.HyperParameters()
+hp.Fixed("learning_rate", value=1e-4)
+
+tuner = kt.RandomSearch(
+    build_model,
+    hyperparameters=hp,
+    tune_new_entries=True,
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="fix_a_few",
+)
+
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+
+"""
+If you summarize the search space, you will see the `learning_rate` is marked
+as fixed, and the rest of the hyperparameters are being tuned.
+"""
+
+tuner.search_space_summary()
+
+"""
+## Overriding compilation arguments
+
+If you have a hypermodel for which you want to change the existing optimizer,
+loss, or metrics, you can do so by passing these arguments to the tuner
+constructor:
+"""
+
+tuner = kt.RandomSearch(
+    build_model,
+    optimizer=keras.optimizers.Adam(1e-3),
+    loss="mse",
+    metrics=["sparse_categorical_crossentropy",],
+    objective="val_loss",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="override_compile",
+)
+
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+
+"""
+If you get the best model, you can see the loss function has changed to MSE.
+"""
+
+tuner.get_best_models()[0].loss
+
+"""
+## Tailor the search space of pre-build HyperModels
+
+You can also use these techniques with the pre-build models in KerasTuner, like
+`HyperResNet` or `HyperXception`.  However, to see what hyperparameters are in
+these pre-build `HyperModel`s, you will have to read the source code.
+
+In the following example, we only tune the `learning_rate` of `HyperXception`
+and fixed all the rest of the hyperparameters. Because the default loss of
+`HyperXception` is `categorical_crossentropy`, which expect the labels to be
+one-hot encoded, which doesn't match our raw integer label data, we need to
+change it by overriding the `loss` in the compile args to
+`sparse_categorical_crossentropy`.
+"""
+
+hypermodel = kt.applications.HyperXception(input_shape=(28, 28, 1), classes=10)
+
+hp = kt.HyperParameters()
+
+# This will override the `learning_rate` parameter with your
+# own selection of choices
+hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
+
+tuner = kt.RandomSearch(
+    hypermodel,
+    hyperparameters=hp,
+    # Prevents unlisted parameters from being tuned
+    tune_new_entries=False,
+    # Override the loss.
+    loss="sparse_categorical_crossentropy",
+    metrics=["accuracy"],
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="helloworld",
+)
+
+# Run the search
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+tuner.search_space_summary()

--- a/guides/md/keras_tuner/getting_started.md
+++ b/guides/md/keras_tuner/getting_started.md
@@ -2,28 +2,314 @@
 
 **Authors:** Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin<br>
 **Date created:** 2019/05/31<br>
-**Last modified:** 2021/06/07<br>
+**Last modified:** 2021/10/27<br>
 **Description:** The basics of using KerasTuner to tune model hyperparameters.
 
 
 <img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/guides/ipynb/keras_tuner/getting_started.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/guides/keras_tuner/getting_started.py)
 
 
-
----
-## Setup
-
-
-```python
-!pip install keras-tuner -q
-```
-
 ---
 ## Introduction
 
-Here's how to perform hyperparameter tuning for a single-layer dense neural
-network using random search.
-First, we need to prepare the dataset -- let's use MNIST dataset as an example.
+KerasTuner is a general-purpose hyperparameter tuning library. It has strong
+integration with Keras workflows, but it isn't limited to them: you could use
+it to tune scikit-learn models, or anything else. In this tutorial, you will
+see how to tune model architecture, training process, and data preprocessing
+steps with KerasTuner. Let's start from a simple example.
+
+---
+## Tune the model architecture
+
+The first thing we need to do is writing a function, which returns a compiled
+Keras model. It takes an argument `hp` for defining the hyperparameters while
+building the model.
+
+### Define the search space
+
+In the following code example, we define a Keras model with two `Dense` layers.
+We want to tune the number of units in the first `Dense` layer. We just define
+an integer hyperparameter with `hp.Int('units', min_value=32, max_value=512, step=32)`,
+whose range is from 32 to 512 inclusive. When sampling from it, the minimum
+step for walking through the interval is 32.
+
+
+```python
+from tensorflow import keras
+from tensorflow.keras import layers
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            # Define the hyperparameter.
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            activation="relu",
+        )
+    )
+    model.add(layers.Dense(10, activation="softmax"))
+    model.compile(
+        optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+    )
+    return model
+
+```
+
+<div class="k-default-codeblock">
+```
+2021-11-05 20:25:47.680336: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
+2021-11-05 20:25:47.680383: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
+
+```
+</div>
+You can quickly test if the model builds successfully.
+
+
+```python
+import keras_tuner as kt
+
+build_model(kt.HyperParameters())
+```
+
+<div class="k-default-codeblock">
+```
+2021-11-05 20:25:49.112763: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
+2021-11-05 20:25:49.112805: W tensorflow/stream_executor/cuda/cuda_driver.cc:269] failed call to cuInit: UNKNOWN ERROR (303)
+2021-11-05 20:25:49.112835: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (a5a615fb2377): /proc/driver/nvidia/version does not exist
+2021-11-05 20:25:49.113040: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
+To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
+
+<keras.engine.sequential.Sequential at 0x7e1e8fe4bc90>
+
+```
+</div>
+There are many other types of hyperparameters as well. We can define multiple
+hyperparameters in the function. In the following code, we tune the whether to
+use a `Dropout` layer with `hp.Boolean()`, tune which activation function to
+use with `hp.Choice()`, tune the learning rate of the optimizer with
+`hp.Float()`.
+
+
+```python
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            # Tune number of units.
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            # Tune the activation function to use.
+            activation=hp.Choice("activation", ["relu", "tanh"]),
+        )
+    )
+    # Tune whether to use dropout.
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    # Define the optimizer learning rate as a hyperparameter.
+    learning_rate = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+```
+
+
+
+
+<div class="k-default-codeblock">
+```
+<keras.engine.sequential.Sequential at 0x7e1f4afe6a90>
+
+```
+</div>
+As shown below, the hyperparameters are actual values. In fact, they are just
+functions returning actual values. For example, `hp.Int()` returns an `int`
+value. Therefore, you can put them into variables, for loops, or if
+conditions.
+
+
+```python
+hp = kt.HyperParameters()
+print(hp.Int("units", min_value=32, max_value=512, step=32))
+```
+
+<div class="k-default-codeblock">
+```
+32
+
+```
+</div>
+You can also define the hyperparameters in advance and keep your Keras code in
+a separate function.
+
+
+```python
+
+def call_existing_code(units, activation, dropout, lr):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(layers.Dense(units=units, activation=activation))
+    if dropout:
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=lr),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def build_model(hp):
+    units = hp.Int("units", min_value=32, max_value=512, step=32)
+    activation = hp.Choice("activation", ["relu", "tanh"])
+    dropout = hp.Boolean("dropout")
+    lr = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    # call existing model-building code with the hyperparameter values.
+    model = call_existing_code(
+        units=units, activation=activation, dropout=dropout, lr=lr
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+```
+
+
+
+
+<div class="k-default-codeblock">
+```
+<keras.engine.sequential.Sequential at 0x7e1e884d1e10>
+
+```
+</div>
+Each of the hyperparameters is uniquely identified by its name (the first
+argument). To tune the number of units in different `Dense` layers separately
+as different hyperparameters, we give them different names as `f"units_{i}"`.
+
+Notably, this is also an example of creating conditional hyperparameters.
+There are many hyperparameters specifying the number of units in the `Dense`
+layers. The number of such hyperparameters is decided by the number of layers,
+which is also a hyperparameter. Therefore, the total number of hyperparameters
+used may be different from trial to trial. Some hyperparameter is only used
+when a certain condition is satisfied. For example, `units_3` is only used
+when `num_layers` is larger than 3. With KerasTuner, you can easily define
+such hyperparameters dynamically while creating the model.
+
+
+```python
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    # Tune the number of layers.
+    for i in range(hp.Int("num_layers", 1, 3)):
+        model.add(
+            layers.Dense(
+                # Tune number of units separately.
+                units=hp.Int(f"units_{i}", min_value=32, max_value=512, step=32),
+                activation=hp.Choice("activation", ["relu", "tanh"]),
+            )
+        )
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add(layers.Dense(10, activation="softmax"))
+    learning_rate = hp.Float("lr", min_value=1e-4, max_value=1e-2, sampling="log")
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+build_model(kt.HyperParameters())
+```
+
+
+
+
+<div class="k-default-codeblock">
+```
+<keras.engine.sequential.Sequential at 0x7e1e884ba710>
+
+```
+</div>
+### Start the search
+
+After defining the search space, we need to select a tuner class to run the
+search. You may choose from `RandomSearch`, `BayesianOptimization` and
+`Hyperband`, which correspond to different tuning algorithms. Here we use
+`RandomSearch` as an example.
+
+To initialize the tuner, we need to specify several arguments in the initializer.
+
+* `hypermodel`. The model-building function, which is `build_model` in our case.
+* `objective`. The name of the objective to optimize (whether to minimize or
+maximize is automatically inferred for built-in metrics). We will introduce how
+to use custom metrics later in this tutorial.
+* `max_trials`. The total number of trials to run during the search.
+* `executions_per_trial`. The number of models that should be built and fit for
+each trial. Different trials have different hyperparameter values. The
+executions within the same trial have the same hyperparameter values. The
+purpose of having multiple executions per trial is to reduce results variance
+and therefore be able to more accurately assess the performance of a model. If
+you want to get results faster, you could set `executions_per_trial=1` (single
+round of training for each model configuration).
+* `overwrite`. Control whether to overwrite the previous results in the same
+directory or resume the previous search instead. Here we set `overwrite=True`
+to start a new search and ignore any previous results.
+* `directory`. A path to a directory for storing the search results.
+* `project_name`. The name of the sub-directory in the `directory`.
+
+
+```python
+tuner = kt.RandomSearch(
+    hypermodel=build_model,
+    objective="val_accuracy",
+    max_trials=3,
+    executions_per_trial=2,
+    overwrite=True,
+    directory="my_dir",
+    project_name="helloworld",
+)
+```
+
+You can print a summary of the search space:
+
+
+```python
+tuner.search_space_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Search space summary
+Default search space size: 5
+num_layers (Int)
+{'default': None, 'conditions': [], 'min_value': 1, 'max_value': 3, 'step': 1, 'sampling': None}
+units_0 (Int)
+{'default': None, 'conditions': [], 'min_value': 32, 'max_value': 512, 'step': 32, 'sampling': None}
+activation (Choice)
+{'default': 'relu', 'conditions': [], 'values': ['relu', 'tanh'], 'ordered': False}
+dropout (Boolean)
+{'default': False, 'conditions': []}
+lr (Float)
+{'default': 0.0001, 'conditions': [], 'min_value': 0.0001, 'max_value': 0.01, 'step': None, 'sampling': 'log'}
+
+```
+</div>
+Before starting the search, let's prepare the MNIST dataset.
 
 
 ```python
@@ -47,104 +333,9 @@ y_val = keras.utils.to_categorical(y_val, num_classes)
 y_test = keras.utils.to_categorical(y_test, num_classes)
 ```
 
-<div class="k-default-codeblock">
-```
-Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz
-11493376/11490434 [==============================] - 0s 0us/step
-
-```
-</div>
----
-## Prepare a model-building function
-
-Then, we define a model-building function. It takes an argument `hp` from
-which you can sample hyperparameters, such as
-`hp.Int('units', min_value=32, max_value=512, step=32)`
-(an integer from a certain range).
-
-This function returns a compiled model.
-
-
-```python
-from tensorflow.keras import layers
-from keras_tuner import RandomSearch
-
-
-def build_model(hp):
-    model = keras.Sequential()
-    model.add(layers.Flatten())
-    model.add(
-        layers.Dense(
-            units=hp.Int("units", min_value=32, max_value=512, step=32),
-            activation="relu",
-        )
-    )
-    model.add(layers.Dense(10, activation="softmax"))
-    model.compile(
-        optimizer=keras.optimizers.Adam(
-            hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-        ),
-        loss="categorical_crossentropy",
-        metrics=["accuracy"],
-    )
-    return model
-
-```
-
----
-## Start the search
-
-Next, let's instantiate a tuner. You should specify the model-building function, the
-name of the objective to optimize (whether to minimize or maximize is
-automatically inferred for built-in metrics), the total number of trials
-(`max_trials`) to test, and the number of models that should be built and fit
-for each trial (`executions_per_trial`).
-
-We use the `overwrite` argument to control whether to overwrite the previous
-results in the same directory or resume the previous search instead.  Here we
-set `overwrite=True` to start a new search and ignore any previous results.
-
-Available tuners are `RandomSearch`, `BayesianOptimization` and `Hyperband`.
-
-**Note:** the purpose of having multiple executions per trial is to reduce
-results variance and therefore be able to more accurately assess the
-performance of a model. If you want to get results faster, you could set
-`executions_per_trial=1` (single round of training for each model
-configuration).
-
-
-```python
-tuner = RandomSearch(
-    build_model,
-    objective="val_accuracy",
-    max_trials=3,
-    executions_per_trial=2,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-```
-
-You can print a summary of the search space:
-
-
-```python
-tuner.search_space_summary()
-```
-
-<div class="k-default-codeblock">
-```
-Search space summary
-Default search space size: 2
-units (Int)
-{'default': None, 'conditions': [], 'min_value': 32, 'max_value': 512, 'step': 32, 'sampling': None}
-learning_rate (Choice)
-{'default': 0.01, 'conditions': [], 'values': [0.01, 0.001, 0.0001], 'ordered': True}
-
-```
-</div>
 Then, start the search for the best hyperparameter configuration.
-The call to `search` has the same signature as `model.fit()`.
+All the arguments passed to `search` is passed to `model.fit()` in each
+execution. Remember to pass `validation_data` to evaluate the model.
 
 
 ```python
@@ -153,35 +344,61 @@ tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))
 
 <div class="k-default-codeblock">
 ```
-Trial 3 Complete [00h 00m 18s]
-val_accuracy: 0.9421000182628632
+Trial 3 Complete [00h 00m 14s]
+val_accuracy: 0.9490000009536743
 ```
 </div>
     
 <div class="k-default-codeblock">
 ```
-Best val_accuracy So Far: 0.9730499982833862
-Total elapsed time: 00h 00m 48s
+Best val_accuracy So Far: 0.9490000009536743
+Total elapsed time: 00h 01m 06s
 INFO:tensorflow:Oracle triggered exit
 
 ```
 </div>
-Here's what happens in `search`: models are built iteratively by calling the
-model-building function, which populates the hyperparameter space (search
-space) tracked by the `hp` object. The tuner progressively explores the space,
-recording metrics for each configuration.
+During the `search`, the model-building function is called with different
+hyperparameter values in different trial. In each trial, the tuner would
+generate a new set of hyperparameter values to build the model. The model is
+then fit and evaluated. The metrics are recorded. The tuner progressively
+explores the space and finally finds a good set of hyperparameter values.
 
----
-## Query the results
+### Query the results
 
-When search is over, you can retrieve the best model(s):
+When search is over, you can retrieve the best model(s). The model is saved at
+its best performing epoch evaluated on the `validation_data`.
 
 
 ```python
+# Get the top 2 models.
 models = tuner.get_best_models(num_models=2)
+best_model = models[0]
+# Build the model.
+# Needed for `Sequential` without specified `input_shape`.
+best_model.build(input_shape=(None, 28, 28))
+best_model.summary()
 ```
 
-Or print a summary of the results:
+<div class="k-default-codeblock">
+```
+Model: "sequential"
+_________________________________________________________________
+Layer (type)                 Output Shape              Param #   
+=================================================================
+flatten (Flatten)            (None, 784)               0         
+_________________________________________________________________
+dense (Dense)                (None, 256)               200960    
+_________________________________________________________________
+dense_1 (Dense)              (None, 10)                2570      
+=================================================================
+Total params: 203,530
+Trainable params: 203,530
+Non-trainable params: 0
+_________________________________________________________________
+
+```
+</div>
+You can also print a summary of the search results.
 
 
 ```python
@@ -196,74 +413,97 @@ Showing 10 best trials
 Objective(name='val_accuracy', direction='max')
 Trial summary
 Hyperparameters:
-units: 480
-learning_rate: 0.001
-Score: 0.9730499982833862
+num_layers: 1
+units_0: 256
+activation: tanh
+dropout: False
+lr: 0.006927528298367841
+units_1: 384
+units_2: 288
+Score: 0.9490000009536743
 Trial summary
 Hyperparameters:
-units: 160
-learning_rate: 0.001
-Score: 0.9692499935626984
+num_layers: 2
+units_0: 512
+activation: tanh
+dropout: False
+lr: 0.003389964511372384
+units_1: 448
+units_2: 256
+Score: 0.948500007390976
 Trial summary
 Hyperparameters:
-units: 320
-learning_rate: 0.0001
-Score: 0.9421000182628632
+num_layers: 3
+units_0: 288
+activation: tanh
+dropout: True
+lr: 0.004590811887281893
+units_1: 32
+units_2: 32
+Score: 0.9471000134944916
 
 ```
 </div>
-You will also find detailed logs, checkpoints, etc, in the folder `my_dir/helloworld`, i.e. `directory/project_name`.
+You will find detailed logs, checkpoints, etc, in the folder
+`my_dir/helloworld`, i.e. `directory/project_name`.
 
----
-## The search space may contain conditional hyperparameters
+You can also visualize the tuning results using TensorBoard and HParams plugin.
+For more information, please following
+[this link](https://keras.io/guides/keras_tuner/visualize_tuning/).
 
-Below, we have a `for` loop creating a tunable number of layers,
-which themselves involve a tunable `units` parameter.
+### Retrain the model
 
-This can be pushed to any level of parameter interdependency, including recursion.
-
-Note that all parameter names should be unique (here, in the loop over `i`,
-we name the inner parameters `'units_' + str(i)`).
+If you want to train the model with the entire dataset, you may retrieve the
+best hyperparameters and retrain the model by yourself.
 
 
 ```python
-
-def build_model(hp):
-    model = keras.Sequential()
-    model.add(layers.Flatten())
-    for i in range(hp.Int("num_layers", 2, 20)):
-        model.add(
-            layers.Dense(
-                units=hp.Int("units_" + str(i), min_value=32, max_value=512, step=32),
-                activation="relu",
-            )
-        )
-    model.add(layers.Dense(10, activation="softmax"))
-    model.compile(
-        optimizer=keras.optimizers.Adam(hp.Choice("learning_rate", [1e-2, 1e-3, 1e-4])),
-        loss="categorical_crossentropy",
-        metrics=["accuracy"],
-    )
-    return model
-
+# Get the top 2 hyperparameters.
+best_hps = tuner.get_best_hyperparameters(5)
+# Build the model with the best hp.
+model = build_model(best_hps[0])
+# Fit with the entire dataset.
+x_all = np.concatenate((x_train, x_val))
+y_all = np.concatenate((y_train, y_val))
+model.fit(x=x_all, y=y_all, epochs=1)
 ```
 
+<div class="k-default-codeblock">
+```
+1875/1875 [==============================] - 4s 2ms/step - loss: 0.2619 - accuracy: 0.9225
+
+<keras.callbacks.History at 0x7e1e882f9390>
+
+```
+</div>
 ---
-## You can use a HyperModel subclass instead of a model-building function
+## Tune model training
 
-This makes it easy to share and reuse hypermodels.
+To tune the model building process, we need to subclass the `HyperModel` class,
+which also makes it easy to share and reuse hypermodels.
 
-A `HyperModel` subclass only needs to implement a `build(self, hp)` method.
+We need to override `HyperModel.build()` and `HyperModel.fit()` to tune the
+model building and training process respectively. A `HyperModel.build()`
+method is the same as the model-building function, which creates a Keras model
+using the hyperparameters and returns it.
+
+In `HyperModel.fit()`, you can access the model returned by
+`HyperModel.build()`,`hp` and all the arguments passed to `search()`. You need
+to train the model and return the training history.
+
+In the following code, we will tune the `shuffle` argument in `model.fit()`.
+
+It is generally not needed to tune the number of epochs because a built-in
+callback is passed to `model.fit()` to save the model at its best epoch
+evaluated by the `validation_data`.
+
+> **Note**: The `**kwargs` should always be passed to `model.fit()` because it
+contains the callbacks for model saving and tensorboard plugins.
 
 
 ```python
-from keras_tuner import HyperModel
 
-
-class MyHyperModel(HyperModel):
-    def __init__(self, classes):
-        self.classes = classes
-
+class MyHyperModel(kt.HyperModel):
     def build(self, hp):
         model = keras.Sequential()
         model.add(layers.Flatten())
@@ -273,26 +513,144 @@ class MyHyperModel(HyperModel):
                 activation="relu",
             )
         )
-        model.add(layers.Dense(self.classes, activation="softmax"))
+        model.add(layers.Dense(10, activation="softmax"))
         model.compile(
-            optimizer=keras.optimizers.Adam(
-                hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-            ),
-            loss="categorical_crossentropy",
-            metrics=["accuracy"],
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
         )
         return model
 
+    def fit(self, hp, model, *args, **kwargs):
+        return model.fit(
+            *args,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            **kwargs,
+        )
 
-hypermodel = MyHyperModel(classes=10)
+```
 
-tuner = RandomSearch(
-    hypermodel,
+Again, we can do a quick check to see if the code works correctly.
+
+
+```python
+hp = kt.HyperParameters()
+hypermodel = MyHyperModel()
+model = hypermodel.build(hp)
+hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))
+```
+
+<div class="k-default-codeblock">
+```
+4/4 [==============================] - 0s 2ms/step - loss: 12.6636 - accuracy: 0.0900
+
+<keras.callbacks.History at 0x7e1e783effd0>
+
+```
+</div>
+---
+## Tune data preprocessing
+
+To tune data preprocessing, we just add an additional step in
+`HyperModel.fit()`, where we can access the dataset from the arguments. In the
+following code, we tune whether to normalize the data before training the
+model. This time we explicitly put `x` and `y` in the function signature
+because we need to use them.
+
+
+```python
+
+class MyHyperModel(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential()
+        model.add(layers.Flatten())
+        model.add(
+            layers.Dense(
+                units=hp.Int("units", min_value=32, max_value=512, step=32),
+                activation="relu",
+            )
+        )
+        model.add(layers.Dense(10, activation="softmax"))
+        model.compile(
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+        )
+        return model
+
+    def fit(self, hp, model, x, y, **kwargs):
+        if hp.Boolean("normalize"):
+            x = layers.Normalization()(x)
+        return model.fit(
+            x,
+            y,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            **kwargs,
+        )
+
+
+hp = kt.HyperParameters()
+hypermodel = MyHyperModel()
+model = hypermodel.build(hp)
+hypermodel.fit(hp, model, np.random.rand(100, 28, 28), np.random.rand(100, 10))
+```
+
+<div class="k-default-codeblock">
+```
+4/4 [==============================] - 0s 3ms/step - loss: 12.3855 - accuracy: 0.0800
+
+<keras.callbacks.History at 0x7e1e501f2290>
+
+```
+</div>
+If a hyperparameter is used both in `build()` and `fit()`, you can define it in
+`build()` and use `hp.get(hp_name)` to retrieve it in `fit()`. We use the
+image size as an example. It is both used as the input shape in `build()`, and
+used by data prerprocessing step to crop the images in `fit()`.
+
+
+```python
+
+class MyHyperModel(kt.HyperModel):
+    def build(self, hp):
+        image_size = hp.Int("image_size", 10, 28)
+        inputs = keras.Input(shape=(image_size, image_size))
+        outputs = layers.Flatten()(inputs)
+        outputs = layers.Dense(
+            units=hp.Int("units", min_value=32, max_value=512, step=32),
+            activation="relu",
+        )(outputs)
+        outputs = layers.Dense(10, activation="softmax")(outputs)
+        model = keras.Model(inputs, outputs)
+        model.compile(
+            optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"],
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data=None, **kwargs):
+        if hp.Boolean("normalize"):
+            x = layers.Normalization()(x)
+        image_size = hp.get("image_size")
+        cropped_x = x[:, :image_size, :image_size, :]
+        if validation_data:
+            x_val, y_val = validation_data
+            cropped_x_val = x_val[:, :image_size, :image_size, :]
+            validation_data = (cropped_x_val, y_val)
+        return model.fit(
+            cropped_x,
+            y,
+            # Tune whether to shuffle the data in each epoch.
+            shuffle=hp.Boolean("shuffle"),
+            validation_data=validation_data,
+            **kwargs,
+        )
+
+
+tuner = kt.RandomSearch(
+    MyHyperModel(),
     objective="val_accuracy",
     max_trials=3,
     overwrite=True,
     directory="my_dir",
-    project_name="helloworld",
+    project_name="tune_hypermodel",
 )
 
 tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))
@@ -300,16 +658,562 @@ tuner.search(x_train, y_train, epochs=2, validation_data=(x_val, y_val))
 
 <div class="k-default-codeblock">
 ```
-Trial 3 Complete [00h 00m 10s]
-val_accuracy: 0.9571999907493591
+Trial 3 Complete [00h 00m 05s]
+val_accuracy: 0.645799994468689
 ```
 </div>
     
 <div class="k-default-codeblock">
 ```
-Best val_accuracy So Far: 0.9573000073432922
-Total elapsed time: 00h 00m 28s
+Best val_accuracy So Far: 0.9753000140190125
+Total elapsed time: 00h 00m 18s
 INFO:tensorflow:Oracle triggered exit
+
+```
+</div>
+### Retrain the model
+
+Using `HyperModel` also allows you to retrain the best model by yourself.
+
+
+```python
+hypermodel = MyHyperModel()
+best_hp = tuner.get_best_hyperparameters()[0]
+model = hypermodel.build(best_hp)
+hypermodel.fit(best_hp, model, x_all, y_all, epochs=1)
+```
+
+<div class="k-default-codeblock">
+```
+1875/1875 [==============================] - 4s 2ms/step - loss: 0.2108 - accuracy: 0.9383
+
+<keras.callbacks.History at 0x7e1e50176910>
+
+```
+</div>
+---
+## Specify the tuning objective
+
+In all previous examples, we all just used validation accuracy
+(`"val_accuracy"`) as the tuning objective to select the best model. Actually,
+you can use any metric as the objective. The most commonly used metric is
+`"val_loss"`, which is the validation loss.
+
+### Built-in metric as the objective
+
+There are many other built-in metrics in Keras you can use as the objective.
+Here is [a list of the built-in metrics](https://keras.io/api/metrics/).
+
+To use a built-in metric as the objective, you need to follow these steps:
+* Compile the model with the the built-in metric. For example, you want to use
+`MeanAbsoluteError()`. You need to compile the model with
+`metrics=[MeanAbsoluteError()]`. You may also use its name string instead:
+`metrics=["mean_absolute_error"]`. The name string of the metric is always
+the snake case of the class name.
+
+* Identify the objective name string. The name string of the objective is
+always in the format of `f"val_{metric_name_string}"`. For example, the
+objective name string of mean squared error evaluated on the validation data
+should be `"val_mean_absolute_error"`.
+
+* Wrap it into `kt.Objective`. We usually need to wrap the objective into a
+`kt.Objective` object to specify the direction to optimize the objective. For
+example, we want to minimize the mean squared error, we can use
+`kt.Objective("val_mean_absolute_error", "min")`. The direction should be
+either `"min"` or `"max"`.
+
+* Pass the wrapped objective to the tuner.
+
+You can see the following barebone code example.
+
+
+```python
+
+def build_regressor(hp):
+    model = keras.Sequential(
+        [
+            layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+            layers.Dense(units=1),
+        ]
+    )
+    model.compile(
+        optimizer="adam",
+        loss="mean_squared_error",
+        # Objective is one of the metrics.
+        metrics=[keras.metrics.MeanAbsoluteError()],
+    )
+    return model
+
+
+tuner = kt.RandomSearch(
+    hypermodel=build_regressor,
+    # The objective name and direction.
+    # Name is the f"val_{snake_case_metric_class_name}".
+    objective=kt.Objective("val_mean_absolute_error", direction="min"),
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="built_in_metrics",
+)
+
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+val_mean_absolute_error: 0.9329107403755188
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_mean_absolute_error So Far: 0.36633360385894775
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+Results summary
+Results in my_dir/built_in_metrics
+Showing 10 best trials
+Objective(name='val_mean_absolute_error', direction='min')
+Trial summary
+Hyperparameters:
+units: 64
+Score: 0.36633360385894775
+Trial summary
+Hyperparameters:
+units: 96
+Score: 0.6075559854507446
+Trial summary
+Hyperparameters:
+units: 32
+Score: 0.9329107403755188
+
+```
+</div>
+### Custom metric as the objective
+
+You may implement your own metric and use it as the hyperparameter search
+objective. Here, we use mean squared error (MSE) as an example. First, we
+implement the MSE metric by subclassing `keras.metrics.Metric`. Remember to
+give a name to your metric using the `name` argument of `super().__init__()`,
+which will be used later. Note: MSE is actully a build-in metric, which can be
+imported with `keras.metrics.MeanSquaredError`. This is just an example to show
+how to use a custom metric as the hyperparameter search objective.
+
+For more information about implementing custom metrics, please see [this
+tutorial](https://keras.io/api/metrics/#creating-custom-metrics). If you would
+like a metric with a different function signature than `update_state(y_true,
+y_pred, sample_weight)`, you can override the `train_step()` method of your
+model following [this
+tutorial](https://keras.io/guides/customizing_what_happens_in_fit/#going-lowerlevel).
+
+
+```python
+import tensorflow as tf
+
+
+class CustomMetric(keras.metrics.Metric):
+    def __init__(self, **kwargs):
+        # Specify the name of the metric as "custom_metric".
+        super().__init__(name="custom_metric", **kwargs)
+        self.sum = self.add_weight(name="sum", initializer="zeros")
+        self.count = self.add_weight(name="count", dtype=tf.int32, initializer="zeros")
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        values = tf.math.squared_difference(y_pred, y_true)
+        count = tf.shape(y_true)[0]
+        if sample_weight is not None:
+            sample_weight = tf.cast(sample_weight, self.dtype)
+            values *= sample_weight
+            count *= sample_weight
+        self.sum.assign_add(tf.reduce_sum(values))
+        self.count.assign_add(count)
+
+    def result(self):
+        return self.sum / tf.cast(self.count, tf.float32)
+
+    def reset_states(self):
+        self.sum.assign(0)
+        self.count.assign(0)
+
+```
+
+Run the search with the custom objective.
+
+
+```python
+
+def build_regressor(hp):
+    model = keras.Sequential(
+        [
+            layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+            layers.Dense(units=1),
+        ]
+    )
+    model.compile(
+        optimizer="adam",
+        loss="mean_squared_error",
+        # Put custom metric into the metrics.
+        metrics=[CustomMetric()],
+    )
+    return model
+
+
+tuner = kt.RandomSearch(
+    hypermodel=build_regressor,
+    # Specify the name and direction of the objective.
+    objective=kt.Objective("val_custom_metric", direction="min"),
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="custom_metrics",
+)
+
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+val_custom_metric: 0.30915313959121704
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_custom_metric So Far: 0.12008240073919296
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+Results summary
+Results in my_dir/custom_metrics
+Showing 10 best trials
+Objective(name='val_custom_metric', direction='min')
+Trial summary
+Hyperparameters:
+units: 64
+Score: 0.12008240073919296
+Trial summary
+Hyperparameters:
+units: 128
+Score: 0.30915313959121704
+Trial summary
+Hyperparameters:
+units: 32
+Score: 0.3939990699291229
+
+```
+</div>
+If your custom objective is hard to put into a custom metric, you can also
+evaluate the model by yourself in `HyperModel.fit()` and return the objective
+value. The objective value would be minimized by default. In this case, you
+don't need to specify the `objective` when initializing the tuner. However, in
+this case, the metric value will not be tracked in the Keras logs by only
+KerasTuner logs. Therefore, these values would not be displayed by any
+TensorBoard view using the Keras metrics.
+
+
+```python
+
+class HyperRegressor(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential(
+            [
+                layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+                layers.Dense(units=1),
+            ]
+        )
+        model.compile(
+            optimizer="adam", loss="mean_squared_error",
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data, **kwargs):
+        model.fit(x, y, **kwargs)
+        x_val, y_val = validation_data
+        y_pred = model.predict(x_val)
+        # Return a single float to minimize.
+        return np.mean(np.abs(y_pred - y_val))
+
+
+tuner = kt.RandomSearch(
+    hypermodel=HyperRegressor(),
+    # No objective to specify.
+    # Objective is the return value of `HyperModel.fit()`.
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="custom_eval",
+)
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+default_objective: 0.2412411448544125
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best default_objective So Far: 0.23100022641910956
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+Results summary
+Results in my_dir/custom_eval
+Showing 10 best trials
+Objective(name='default_objective', direction='min')
+Trial summary
+Hyperparameters:
+units: 96
+Score: 0.23100022641910956
+Trial summary
+Hyperparameters:
+units: 64
+Score: 0.2412411448544125
+Trial summary
+Hyperparameters:
+units: 128
+Score: 0.2530983137665876
+
+```
+</div>
+If you have multiple metrics to track in KerasTuner, but only use one of them
+as the objective, you can return a dictionary, whose keys are the metric names
+and the values are the metrics values, for example, return `{"metric_a": 1.0,
+"metric_b", 2.0}`. Use one of the keys as the objective name, for example,
+`kt.Objective("metric_a", "min")`.
+
+
+```python
+
+class HyperRegressor(kt.HyperModel):
+    def build(self, hp):
+        model = keras.Sequential(
+            [
+                layers.Dense(units=hp.Int("units", 32, 128, 32), activation="relu"),
+                layers.Dense(units=1),
+            ]
+        )
+        model.compile(
+            optimizer="adam", loss="mean_squared_error",
+        )
+        return model
+
+    def fit(self, hp, model, x, y, validation_data, **kwargs):
+        model.fit(x, y, **kwargs)
+        x_val, y_val = validation_data
+        y_pred = model.predict(x_val)
+        # Return a dictionary of metrics for KerasTuner to track.
+        return {
+            "metric_a": -np.mean(np.abs(y_pred - y_val)),
+            "metric_b": np.mean(np.square(y_pred - y_val)),
+        }
+
+
+tuner = kt.RandomSearch(
+    hypermodel=HyperRegressor(),
+    # Objective is one of the keys.
+    # Maximize the negative MAE, equivalent to minimize MAE.
+    objective=kt.Objective("metric_a", "max"),
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="custom_eval_dict",
+)
+tuner.search(
+    x=np.random.rand(100, 10),
+    y=np.random.rand(100, 1),
+    validation_data=(np.random.rand(20, 10), np.random.rand(20, 1)),
+)
+
+tuner.results_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Trial 2 Complete [00h 00m 00s]
+metric_a: -0.6945157521387751
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best metric_a So Far: -0.2497985563585922
+Total elapsed time: 00h 00m 00s
+INFO:tensorflow:Oracle triggered exit
+Results summary
+Results in my_dir/custom_eval_dict
+Showing 10 best trials
+Objective(name='metric_a', direction='max')
+Trial summary
+Hyperparameters:
+units: 96
+Score: -0.2497985563585922
+Trial summary
+Hyperparameters:
+units: 64
+Score: -0.6945157521387751
+
+```
+</div>
+---
+## Tune end-to-end workflows
+
+In some cases, it is hard to align your code into build and fit functions. You
+can also keep your end-to-end workflow in one place by overriding
+`Tuner.run_trial()`, which gives you full control of a trial. You can see it
+as a black-box optimizer for anything.
+
+### Tune any function
+
+For example, you can find a value of `x`, which minimizes `f(x)=x*x+1`. In the
+following code, we just define `x` as a hyperparameter, and return `f(x)` as
+the objective value. The `hypermodel` and `objective` argument for initializing
+the tuner can be omitted.
+
+
+```python
+
+class MyTuner(kt.RandomSearch):
+    def run_trial(self, trial, *args, **kwargs):
+        # Get the hp from trial.
+        hp = trial.hyperparameters
+        # Define "x" as a hyperparameter.
+        x = hp.Float("x", min_value=-1.0, max_value=1.0)
+        # Return the objective value to minimize.
+        return x * x + 1
+
+
+tuner = MyTuner(
+    # No hypermodel or objective specified.
+    max_trials=20,
+    overwrite=True,
+    directory="my_dir",
+    project_name="tune_anything",
+)
+
+# No need to pass anything to search()
+# unless you use them in run_trial().
+tuner.search()
+print(tuner.get_best_hyperparameters()[0].get("x"))
+```
+
+<div class="k-default-codeblock">
+```
+Trial 20 Complete [00h 00m 00s]
+default_objective: 1.4344639272139101
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best default_objective So Far: 1.0000144839776872
+Total elapsed time: 00h 00m 00s
+INFO:tensorflow:Oracle triggered exit
+0.0038057821386991986
+
+```
+</div>
+### Keep Keras code separate
+
+You can keep all your Keras code unchanged and use KerasTuner to tune it. It
+is useful if you cannot modify the Keras code for some reason.
+
+It also gives you more flexibility. You don't have to separate the model
+building and training code apart. However, this workflow would not help you
+save the model or connect with the TensorBoard plugins.
+
+To save the model, you can use `trial.trial_id`, which is a string to uniquely
+identify a trial, to construct different paths to save the models from
+different trials.
+
+
+```python
+import os
+
+
+def keras_code(units, optimizer, saving_path):
+    # Build model
+    model = keras.Sequential(
+        [layers.Dense(units=units, activation="relu"), layers.Dense(units=1),]
+    )
+    model.compile(
+        optimizer=optimizer, loss="mean_squared_error",
+    )
+
+    # Prepare data
+    x_train = np.random.rand(100, 10)
+    y_train = np.random.rand(100, 1)
+    x_val = np.random.rand(20, 10)
+    y_val = np.random.rand(20, 1)
+
+    # Train & eval model
+    model.fit(x_train, y_train)
+
+    # Save model
+    model.save(saving_path)
+
+    # Return a single float as the objective value.
+    # You may also return a dictionary
+    # of {metric_name: metric_value}.
+    y_pred = model.predict(x_val)
+    return np.mean(np.abs(y_pred - y_val))
+
+
+class MyTuner(kt.RandomSearch):
+    def run_trial(self, trial, **kwargs):
+        hp = trial.hyperparameters
+        return keras_code(
+            units=hp.Int("units", 32, 128, 32),
+            optimizer=hp.Choice("optimizer", ["adam", "adadelta"]),
+            saving_path=os.path.join("/tmp", trial.trial_id),
+        )
+
+
+tuner = MyTuner(
+    max_trials=3, overwrite=True, directory="my_dir", project_name="keep_code_separate",
+)
+tuner.search()
+# Retraining the model
+best_hp = tuner.get_best_hyperparameters()[0]
+keras_code(**best_hp.values, saving_path="/tmp/best_model")
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+default_objective: 0.5837161480697646
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best default_objective So Far: 0.38188325636156456
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+4/4 [==============================] - 0s 1ms/step - loss: 0.3970
+INFO:tensorflow:Assets written to: /tmp/best_model/assets
+
+0.5514325799865272
 
 ```
 </div>
@@ -318,7 +1222,8 @@ INFO:tensorflow:Oracle triggered exit
 
 These are ready-to-use hypermodels for computer vision.
 
-They come pre-compiled with `loss="categorical_crossentropy"` and `metrics=["accuracy"]`.
+They come pre-compiled with `loss="categorical_crossentropy"` and
+`metrics=["accuracy"]`.
 
 
 ```python
@@ -326,13 +1231,13 @@ from keras_tuner.applications import HyperResNet
 
 hypermodel = HyperResNet(input_shape=(28, 28, 1), classes=10)
 
-tuner = RandomSearch(
+tuner = kt.RandomSearch(
     hypermodel,
     objective="val_accuracy",
-    max_trials=3,
+    max_trials=2,
     overwrite=True,
     directory="my_dir",
-    project_name="helloworld",
+    project_name="built_in_hypermodel",
 )
 
 tuner.search(
@@ -342,61 +1247,7 @@ tuner.search(
 
 <div class="k-default-codeblock">
 ```
-Trial 3 Complete [00h 00m 34s]
-val_accuracy: 0.10000000149011612
-```
-</div>
-    
-<div class="k-default-codeblock">
-```
-Best val_accuracy So Far: 0.10000000149011612
-Total elapsed time: 00h 01m 45s
-INFO:tensorflow:Oracle triggered exit
-
-```
-</div>
----
-## You can easily restrict the search space to just a few parameters
-
-If you have an existing hypermodel, and you want to search over only a few parameters
-(such as the learning rate), you can do so by passing a `hyperparameters` argument
-to the tuner constructor, as well as `tune_new_entries=False` to specify that parameters
-that you didn't list in `hyperparameters` should not be tuned. For these parameters, the default
-value gets used.
-
-
-```python
-from keras_tuner import HyperParameters
-from keras_tuner.applications import HyperXception
-
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-hp = HyperParameters()
-
-# This will override the `learning_rate` parameter with your
-# own selection of choices
-hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
-
-tuner = RandomSearch(
-    hypermodel,
-    hyperparameters=hp,
-    # `tune_new_entries=False` prevents unlisted parameters from being tuned
-    tune_new_entries=False,
-    objective="val_accuracy",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-```
-
-<div class="k-default-codeblock">
-```
-Trial 3 Complete [00h 00m 02s]
+Trial 2 Complete [00h 00m 47s]
 val_accuracy: 0.10999999940395355
 ```
 </div>
@@ -404,110 +1255,7 @@ val_accuracy: 0.10999999940395355
 <div class="k-default-codeblock">
 ```
 Best val_accuracy So Far: 0.10999999940395355
-Total elapsed time: 00h 00m 08s
-INFO:tensorflow:Oracle triggered exit
-
-```
-</div>
----
-## About parameter default values
-
-Whenever you register a hyperparameter inside a model-building function or the `build` method of a hypermodel,
-you can specify a default value:
-
-```python
-hp.Int("units", min_value=32, max_value=512, step=32, default=128)
-```
-
-If you don't, hyperparameters always have a default default (for `Int`, it is equal to `min_value`).
-
----
-## Fixing values in a hypermodel
-
-What if you want to do the reverse -- tune all available parameters in a hypermodel, **except** one (the learning rate)?
-
-Pass a `hyperparameters` argument with a `Fixed` entry (or any number of `Fixed` entries), and specify `tune_new_entries=True`.
-
-
-```python
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-hp = HyperParameters()
-hp.Fixed("learning_rate", value=1e-4)
-
-tuner = RandomSearch(
-    hypermodel,
-    hyperparameters=hp,
-    tune_new_entries=True,
-    objective="val_accuracy",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-```
-
-<div class="k-default-codeblock">
-```
-Trial 3 Complete [00h 00m 07s]
-val_accuracy: 0.10000000149011612
-```
-</div>
-    
-<div class="k-default-codeblock">
-```
-Best val_accuracy So Far: 0.11999999731779099
-Total elapsed time: 00h 00m 17s
-INFO:tensorflow:Oracle triggered exit
-
-```
-</div>
----
-## Overriding compilation arguments
-
-If you have a hypermodel for which you want to change the existing optimizer,
-loss, or metrics, you can do so by passing these arguments
-to the tuner constructor:
-
-
-```python
-hypermodel = HyperXception(input_shape=(28, 28, 1), classes=10)
-
-tuner = RandomSearch(
-    hypermodel,
-    optimizer=keras.optimizers.Adam(1e-3),
-    loss="mse",
-    metrics=[
-        keras.metrics.Precision(name="precision"),
-        keras.metrics.Recall(name="recall"),
-    ],
-    objective="val_loss",
-    max_trials=3,
-    overwrite=True,
-    directory="my_dir",
-    project_name="helloworld",
-)
-
-tuner.search(
-    x_train[:100], y_train[:100], epochs=1, validation_data=(x_val[:100], y_val[:100])
-)
-```
-
-<div class="k-default-codeblock">
-```
-Trial 3 Complete [00h 00m 07s]
-val_loss: 0.09853753447532654
-```
-</div>
-    
-<div class="k-default-codeblock">
-```
-Best val_loss So Far: 0.08992436528205872
-Total elapsed time: 00h 00m 23s
+Total elapsed time: 00h 01m 09s
 INFO:tensorflow:Oracle triggered exit
 
 ```

--- a/guides/md/keras_tuner/tailor_the_search_space.md
+++ b/guides/md/keras_tuner/tailor_the_search_space.md
@@ -1,0 +1,342 @@
+# Tailor the search space
+
+**Authors:** Luca Invernizzi, James Long, Francois Chollet, Tom O'Malley, Haifeng Jin<br>
+**Date created:** 2019/05/31<br>
+**Last modified:** 2021/10/27<br>
+**Description:** Tune a subset of the hyperparameters without changing the hypermodel.
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/guides/ipynb/keras_tuner/tailor_the_search_space.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/guides/keras_tuner/tailor_the_search_space.py)
+
+
+
+In this guide, we will show how to tailor the search space without changing the
+`HyperModel` code directly.  For example, you can only tune some of the
+hyperparameters and keep the rest fixed, or you can override the compile
+arguments, like `optimizer`, `loss`, and `metrics`.
+
+---
+## The default value of a hyperparameter
+
+Before we tailor the search space, it is important to know that every
+hyperparameter has a default value.  This default value is used as the
+hyperparameter value when not tuning it during our tailoring the search space.
+
+Whenever you register a hyperparameter, you can use the `default` argument to
+specify a default value:
+
+```python
+hp.Int("units", min_value=32, max_value=128, step=32, default=64)
+```
+
+If you don't, hyperparameters always have a default default (for `Int`, it is
+equal to `min_value`).
+
+In the following model-building function, we specified the default value for
+the `units` hyperparameter as 64.
+
+
+```python
+from tensorflow import keras
+from tensorflow.keras import layers
+import keras_tuner as kt
+import numpy as np
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten())
+    model.add(
+        layers.Dense(
+            units=hp.Int("units", min_value=32, max_value=128, step=32, default=64)
+        )
+    )
+    if hp.Boolean("dropout"):
+        model.add(layers.Dropout(rate=0.25))
+    model.add
+    model.compile(
+        optimizer=keras.optimizers.Adam(
+            learning_rate=hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
+        ),
+        loss="sparse_categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+```
+
+<div class="k-default-codeblock">
+```
+2021-11-05 20:32:48.167811: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
+2021-11-05 20:32:48.167859: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
+
+```
+</div>
+We will reuse this search space in the rest of the tutorial by overriding the
+hyperparameters without defining a new search space.
+
+---
+## Search a few and fix the rest
+
+If you have an existing hypermodel, and you want to search over only a few
+hyperparameters, and keep the rest fixed, you don't have to change the code in
+the model-building function or the `HyperModel`.  You can pass a
+`HyperParameters` to the `hyperparameters` argument to the tuner constructor
+with all the hyperparameters you want to tune.  Specify
+`tune_new_entries=False` to prevent it from tuning other hyperparameters, the
+default value of which would be used.
+
+In the following example, we only tune the `learning_rate` hyperparameter, and
+changed its type and value ranges.
+
+
+```python
+hp = kt.HyperParameters()
+
+# This will override the `learning_rate` parameter with your
+# own selection of choices
+hp.Float("learning_rate", min_value=1e-4, max_value=1e-2, sampling="log")
+
+tuner = kt.RandomSearch(
+    hypermodel=build_model,
+    hyperparameters=hp,
+    # Prevents unlisted parameters from being tuned
+    tune_new_entries=False,
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="search_a_few",
+)
+
+# Generate random data
+x_train = np.random.rand(100, 28, 28, 1)
+y_train = np.random.randint(0, 10, (100, 1))
+x_val = np.random.rand(20, 28, 28, 1)
+y_val = np.random.randint(0, 10, (20, 1))
+
+# Run the search
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+val_accuracy: 0.0
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_accuracy So Far: 0.15000000596046448
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+
+```
+</div>
+If you summarize the search space, you will see only one hyperparameter.
+
+
+```python
+tuner.search_space_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Search space summary
+Default search space size: 1
+learning_rate (Float)
+{'default': 0.0001, 'conditions': [], 'min_value': 0.0001, 'max_value': 0.01, 'step': None, 'sampling': 'log'}
+
+```
+</div>
+---
+## Fix a few and tune the rest
+
+In the example above we showed how to tune only a few hyperparameters and keep
+the rest fixed.  You can also do the reverse: only fix a few hyperparameters
+and tune all the rest.
+
+In the following example, we fixed the value of the `learning_rate`
+hyperparameter.  Pass a `hyperparameters` argument with a `Fixed` entry (or any
+number of `Fixed` entries).  Also remember to specify `tune_new_entries=True`,
+which allows us to tune the rest of the hyperparameters.
+
+
+```python
+hp = kt.HyperParameters()
+hp.Fixed("learning_rate", value=1e-4)
+
+tuner = kt.RandomSearch(
+    build_model,
+    hyperparameters=hp,
+    tune_new_entries=True,
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="fix_a_few",
+)
+
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+val_accuracy: 0.0
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_accuracy So Far: 0.15000000596046448
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+
+```
+</div>
+If you summarize the search space, you will see the `learning_rate` is marked
+as fixed, and the rest of the hyperparameters are being tuned.
+
+
+```python
+tuner.search_space_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Search space summary
+Default search space size: 3
+learning_rate (Fixed)
+{'conditions': [], 'value': 0.0001}
+units (Int)
+{'default': 64, 'conditions': [], 'min_value': 32, 'max_value': 128, 'step': 32, 'sampling': None}
+dropout (Boolean)
+{'default': False, 'conditions': []}
+
+```
+</div>
+---
+## Overriding compilation arguments
+
+If you have a hypermodel for which you want to change the existing optimizer,
+loss, or metrics, you can do so by passing these arguments to the tuner
+constructor:
+
+
+```python
+tuner = kt.RandomSearch(
+    build_model,
+    optimizer=keras.optimizers.Adam(1e-3),
+    loss="mse",
+    metrics=["sparse_categorical_crossentropy",],
+    objective="val_loss",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="override_compile",
+)
+
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 00s]
+val_loss: 16.08868408203125
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_loss So Far: 14.065686225891113
+Total elapsed time: 00h 00m 01s
+INFO:tensorflow:Oracle triggered exit
+
+```
+</div>
+If you get the best model, you can see the loss function has changed to MSE.
+
+
+```python
+tuner.get_best_models()[0].loss
+```
+
+<div class="k-default-codeblock">
+```
+WARNING:tensorflow:Unresolved object in checkpoint: (root).layer_with_weights-0.kernel
+WARNING:tensorflow:Unresolved object in checkpoint: (root).layer_with_weights-0.bias
+WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.kernel
+WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.bias
+WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.kernel
+WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.bias
+WARNING:tensorflow:A checkpoint was restored (e.g. tf.train.Checkpoint.restore or tf.keras.Model.load_weights) but not all checkpointed values were used. See above for specific issues. Use expect_partial() on the load status object, e.g. tf.train.Checkpoint.restore(...).expect_partial(), to silence these warnings, or use assert_consumed() to make the check explicit. See https://www.tensorflow.org/guide/checkpoint#loading_mechanics for details.
+
+'mse'
+
+```
+</div>
+---
+## Tailor the search space of pre-build HyperModels
+
+You can also use these techniques with the pre-build models in KerasTuner, like
+`HyperResNet` or `HyperXception`.  However, to see what hyperparameters are in
+these pre-build `HyperModel`s, you will have to read the source code.
+
+In the following example, we only tune the `learning_rate` of `HyperXception`
+and fixed all the rest of the hyperparameters. Because the default loss of
+`HyperXception` is `categorical_crossentropy`, which expect the labels to be
+one-hot encoded, which doesn't match our raw integer label data, we need to
+change it by overriding the `loss` in the compile args to
+`sparse_categorical_crossentropy`.
+
+
+```python
+hypermodel = kt.applications.HyperXception(input_shape=(28, 28, 1), classes=10)
+
+hp = kt.HyperParameters()
+
+# This will override the `learning_rate` parameter with your
+# own selection of choices
+hp.Choice("learning_rate", values=[1e-2, 1e-3, 1e-4])
+
+tuner = kt.RandomSearch(
+    hypermodel,
+    hyperparameters=hp,
+    # Prevents unlisted parameters from being tuned
+    tune_new_entries=False,
+    # Override the loss.
+    loss="sparse_categorical_crossentropy",
+    metrics=["accuracy"],
+    objective="val_accuracy",
+    max_trials=3,
+    overwrite=True,
+    directory="my_dir",
+    project_name="helloworld",
+)
+
+# Run the search
+tuner.search(x_train, y_train, epochs=1, validation_data=(x_val, y_val))
+tuner.search_space_summary()
+```
+
+<div class="k-default-codeblock">
+```
+Trial 3 Complete [00h 00m 02s]
+val_accuracy: 0.05000000074505806
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+Best val_accuracy So Far: 0.20000000298023224
+Total elapsed time: 00h 00m 08s
+INFO:tensorflow:Oracle triggered exit
+Search space summary
+Default search space size: 1
+learning_rate (Choice)
+{'default': 0.01, 'conditions': [], 'values': [0.01, 0.001, 0.0001], 'ordered': True}
+
+```
+</div>

--- a/scripts/guides_master.py
+++ b/scripts/guides_master.py
@@ -19,6 +19,10 @@ KT_GUIDES_MASTER = {
             'path': 'visualize_tuning',
             'title': 'Visualize the hyperparameter tuning process',
         },
+        {
+            'path': 'tailor_the_search_space',
+            'title': 'Tailor the search space',
+        },
     ]
 }
 


### PR DESCRIPTION
New KerasTuner tutorial for 1.1.0 release.
Separate out part of the old tutorial to a new guide: tailor the search space.

Related RFC: [link](https://github.com/keras-team/governance/blob/b8a6ddd7d714fd73569b35b0f79963d012cfabd6/rfcs/20210920-tune-end-to-end-ml-workflows-in-keras-tuner.md)

This PR should not be merged until the new KT 1.1.0 release.