### PR TITLE
fixing issue in GCN example

### DIFF
--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -584,7 +584,7 @@ class GNNNodeClassifier(tf.keras.Model):
         # Postprocess node embedding.
         x = self.postprocess(x)
         # Fetch node embeddings for the input node_indices.
-        node_embeddings = tf.squeeze(tf.gather(x, input_node_indices))
+        node_embeddings = tf.gather(x, input_node_indices)
         # Compute logits
         return self.compute_logits(node_embeddings)
 


### PR DESCRIPTION
The small  issue prevented the code from running in Colab environment, because of inconsistencies in the dimension of the output layer.