### PR TITLE
Rename keras preprocessing page to dataset loading

### DIFF
--- a/redirects/api/preprocessing/image/index.html
+++ b/redirects/api/preprocessing/image/index.html
@@ -1,0 +1,2 @@
+
+<meta http-equiv="refresh" content="0; URL='https://keras.io/api/data_loading/image/'" />

--- a/redirects/api/preprocessing/index.html
+++ b/redirects/api/preprocessing/index.html
@@ -1,0 +1,2 @@
+
+<meta http-equiv="refresh" content="0; URL='https://keras.io/api/data_loading/'" />

--- a/redirects/api/preprocessing/text/index.html
+++ b/redirects/api/preprocessing/text/index.html
@@ -1,0 +1,2 @@
+
+<meta http-equiv="refresh" content="0; URL='https://keras.io/api/data_loading/text/'" />

--- a/redirects/api/preprocessing/timeseries/index.html
+++ b/redirects/api/preprocessing/timeseries/index.html
@@ -1,0 +1,2 @@
+
+<meta http-equiv="refresh" content="0; URL='https://keras.io/api/data_loading/timeseries/'" />

--- a/scripts/master.py
+++ b/scripts/master.py
@@ -53,43 +53,6 @@ MASTER = {
                 LAYERS_MASTER,
                 CALLBACKS_MASTER,
                 {
-                    'path': 'preprocessing/',
-                    'title': 'Data preprocessing',
-                    'toc': True,
-                    'children': [
-                        {
-                            'path': 'image',
-                            'title': 'Image data preprocessing',
-                            'generate': [
-                                'tensorflow.keras.preprocessing.image_dataset_from_directory',
-                                'tensorflow.keras.preprocessing.image.load_img',
-                                'tensorflow.keras.preprocessing.image.img_to_array',
-                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator',  # LEGACY
-                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow',  # LEGACY
-                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow_from_dataframe',  # LEGACY
-                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow_from_directory',  # LEGACY
-                            ],
-                        },
-                        {
-                            'path': 'timeseries',
-                            'title': 'Timeseries data preprocessing',
-                            'generate': [
-                                'tensorflow.keras.preprocessing.timeseries_dataset_from_array',
-                                'tensorflow.keras.preprocessing.sequence.pad_sequences',
-                                # 'tensorflow.keras.preprocessing.sequence.TimeseriesGenerator',  # LEGACY
-                            ]
-                        },
-                        {
-                            'path': 'text',
-                            'title': 'Text data preprocessing',
-                            'generate': [
-                                'tensorflow.keras.preprocessing.text_dataset_from_directory',
-                                # 'tensorflow.keras.preprocessing.text.Tokenizer',  # LEGACY
-                            ]
-                        },
-                    ]
-                },
-                {
                     'path': 'optimizers/',
                     'title': 'Optimizers',
                     'toc': True,
@@ -300,6 +263,43 @@ MASTER = {
                             ]
                         },
                     ],
+                },
+                {
+                    'path': 'data_loading/',
+                    'title': 'Data loading',
+                    'toc': True,
+                    'children': [
+                        {
+                            'path': 'image',
+                            'title': 'Image data loading',
+                            'generate': [
+                                'tensorflow.keras.utils.image_dataset_from_directory',
+                                'tensorflow.keras.utils.load_img',
+                                'tensorflow.keras.utils.img_to_array',
+                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator',  # LEGACY
+                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow',  # LEGACY
+                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow_from_dataframe',  # LEGACY
+                                # 'tensorflow.keras.preprocessing.image.ImageDataGenerator.flow_from_directory',  # LEGACY
+                            ],
+                        },
+                        {
+                            'path': 'timeseries',
+                            'title': 'Timeseries data loading',
+                            'generate': [
+                                'tensorflow.keras.utils.timeseries_dataset_from_array',
+                                # 'tensorflow.keras.preprocessing.sequence.pad_sequences',  # LEGACY
+                                # 'tensorflow.keras.preprocessing.sequence.TimeseriesGenerator',  # LEGACY
+                            ]
+                        },
+                        {
+                            'path': 'text',
+                            'title': 'Text data loading',
+                            'generate': [
+                                'tensorflow.keras.utils.text_dataset_from_directory',
+                                # 'tensorflow.keras.preprocessing.text.Tokenizer',  # LEGACY
+                            ]
+                        },
+                    ]
                 },
                 {
                     'path': 'datasets/',

--- a/templates/api/data_loading/index.md
+++ b/templates/api/data_loading/index.md
@@ -1,13 +1,18 @@
-# Dataset preprocessing
+# Data loading
 
-Keras dataset preprocessing utilities, located at `tf.keras.preprocessing`,
+Keras data loading utilities, located in `tf.keras.utils`,
 help you go from raw data on disk to a `tf.data.Dataset` object that can be
-used to train a model.
+used to efficiently train a model.
+
+These loading utilites can be combined with
+[preprocessing layers](https://keras.io/guides/preprocessing_layers/) to
+futher transform your input dataset before training.
 
 Here's a quick example: let's say you have 10 folders, each containing
 10,000 images from a different category, and you want to train a
-classifier that maps an image to its category. Your training data folder would look
-like this:
+classifier that maps an image to its category.
+
+Your training data folder would look like this:
 
 ```
 training_data/
@@ -20,34 +25,35 @@ training_data/
 etc.
 ```
 
-You may also have a validation data folder `validation_data/` structured in the same way.
+You may also have a validation data folder `validation_data/` structured in the
+same way.
 
 You could simply do:
 
 ```python
 from tensorflow import keras
-from tensorflow.keras.preprocessing import image_dataset_from_directory
 
-train_ds = image_dataset_from_directory(
+train_ds = keras.utils.image_dataset_from_directory(
     directory='training_data/',
     labels='inferred',
     label_mode='categorical',
     batch_size=32,
     image_size=(256, 256))
-validation_ds = image_dataset_from_directory(
+validation_ds = keras.utils.image_dataset_from_directory(
     directory='validation_data/',
     labels='inferred',
     label_mode='categorical',
     batch_size=32,
     image_size=(256, 256))
 
-model = keras.applications.Xception(weights=None, input_shape=(256, 256, 3), classes=10)
+model = keras.applications.Xception(
+    weights=None, input_shape=(256, 256, 3), classes=10)
 model.compile(optimizer='rmsprop', loss='categorical_crossentropy')
 model.fit(train_ds, epochs=10, validation_data=validation_ds)
 ```
 
 
-## Available dataset preprocessing utilities
+## Available dataset loading utilities
 
 {{toc}}
 


### PR DESCRIPTION
These utilities symbols were moved from keras.preprocessing to
keras.utils, and the ones that are still listed are for loading
not manipulating data.