### PR TITLE
Add: Token Learner for Vision Transformer

### DIFF
--- a/examples/vision/ipynb/token_learner.ipynb
+++ b/examples/vision/ipynb/token_learner.ipynb
@@ -1,0 +1,744 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Learning to tokenize in Vision Transformers\n",
+    "\n",
+    "**Authors:** [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Sayak Paul](https://twitter.com/RisingSayak) (equal contribution)<br>\n",
+    "**Date created:** 2021/12/10<br>\n",
+    "**Last modified:** 2021/12/15<br>\n",
+    "**Description:** Adaptively generating a smaller number of tokens for Vision Transformers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Vision Transformers ([Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)) and many\n",
+    "other Transformer-based architectures ([Liu et al.](https://arxiv.org/abs/2103.14030),\n",
+    "[Yuan et al.](https://arxiv.org/abs/2101.11986), etc.) have shown strong results in\n",
+    "image recognition. The following provides a brief overview of the components involved in the\n",
+    "Vision Transformer architecture for image classification:\n",
+    "\n",
+    "* Extract small patches from input images.\n",
+    "* Linearly project those patches.\n",
+    "* Add positional embeddings to these linear projections.\n",
+    "* Run these projections through a series of Transformer ([Vaswani et al.](https://arxiv.org/abs/1706.03762))\n",
+    "blocks.\n",
+    "* Finally, take the representation from the final Transformer block and add a\n",
+    "classification head.\n",
+    "\n",
+    "If we take 224x224 images and extract 16x16 patches, we get a total of 196 patches (also\n",
+    "called tokens) for each image. The number of patches increases as we increase the\n",
+    "resolution, leading to higher memory footprint. Could we use a reduced\n",
+    "number of patches without having to compromise performance?\n",
+    "Ryoo et al. investigate this question in\n",
+    "[TokenLearner: Adaptive Space-Time Tokenization for Videos](https://openreview.net/forum?id=z-l1kpDXs88).\n",
+    "They introduce a novel module called **TokenLearner** that can help reduce the number\n",
+    "of patches used by a Vision Transformer (ViT) in an adaptive manner. With TokenLearner\n",
+    "incorporated in the standard ViT architecture, they are able to reduce the amount of\n",
+    "compute (measured in FLOPS) used by the model.\n",
+    "\n",
+    "In this example, we implement the TokenLearner module and demonstrate its\n",
+    "performance with a mini ViT and the CIFAR-10 dataset. We make use of the following\n",
+    "references:\n",
+    "\n",
+    "* [Official TokenLearner code](https://github.com/google-research/scenic/blob/main/scenic/projects/token_learner/model.py)\n",
+    "* [Image Classification with ViTs on keras.io](https://keras.io/examples/vision/image_classification_with_vision_transformer/)\n",
+    "* [TokenLearner slides from NeurIPS 2021](https://nips.cc/media/neurips-2021/Slides/26578.pdf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We need to install TensorFlow Addons to run this example. To install it, execute the\n",
+    "following:\n",
+    "\n",
+    "```shell\n",
+    "pip install tensorflow-addons\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "from tensorflow import keras\n",
+    "from tensorflow.keras import layers\n",
+    "import tensorflow_addons as tfa\n",
+    "\n",
+    "from datetime import datetime\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Hyperparameters\n",
+    "\n",
+    "Please feel free to change the hyperparameters and check your results. The best way to\n",
+    "develop intuition about the architecture is to experiment with it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# DATA\n",
+    "BATCH_SIZE = 256\n",
+    "AUTO = tf.data.AUTOTUNE\n",
+    "INPUT_SHAPE = (32, 32, 3)\n",
+    "NUM_CLASSES = 10\n",
+    "\n",
+    "# OPTIMIZER\n",
+    "LEARNING_RATE = 1e-3\n",
+    "WEIGHT_DECAY = 1e-4\n",
+    "\n",
+    "# TRAINING\n",
+    "EPOCHS = 20\n",
+    "\n",
+    "# AUGMENTATION\n",
+    "IMAGE_SIZE = 48  # We will resize input images to this size.\n",
+    "PATCH_SIZE = 6  # Size of the patches to be extracted from the input images.\n",
+    "NUM_PATCHES = (IMAGE_SIZE // PATCH_SIZE) ** 2\n",
+    "\n",
+    "# ViT ARCHITECTURE\n",
+    "LAYER_NORM_EPS = 1e-6\n",
+    "PROJECTION_DIM = 128\n",
+    "NUM_HEADS = 4\n",
+    "NUM_LAYERS = 4\n",
+    "MLP_UNITS = [\n",
+    "    PROJECTION_DIM * 2,\n",
+    "    PROJECTION_DIM,\n",
+    "]\n",
+    "\n",
+    "# TOKENLEARNER\n",
+    "NUM_TOKENS = 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Load and prepare the CIFAR-10 dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the CIFAR-10 dataset.\n",
+    "(x_train, y_train), (x_test, y_test) = keras.datasets.cifar10.load_data()\n",
+    "(x_train, y_train), (x_val, y_val) = (\n",
+    "    (x_train[:40000], y_train[:40000]),\n",
+    "    (x_train[40000:], y_train[40000:]),\n",
+    ")\n",
+    "print(f\"Training samples: {len(x_train)}\")\n",
+    "print(f\"Validation samples: {len(x_val)}\")\n",
+    "print(f\"Testing samples: {len(x_test)}\")\n",
+    "\n",
+    "# Convert to tf.data.Dataset objects.\n",
+    "train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))\n",
+    "train_ds = train_ds.shuffle(BATCH_SIZE * 100).batch(BATCH_SIZE).prefetch(AUTO)\n",
+    "\n",
+    "val_ds = tf.data.Dataset.from_tensor_slices((x_val, y_val))\n",
+    "val_ds = val_ds.batch(BATCH_SIZE).prefetch(AUTO)\n",
+    "\n",
+    "test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test))\n",
+    "test_ds = test_ds.batch(BATCH_SIZE).prefetch(AUTO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Data augmentation\n",
+    "\n",
+    "The augmentation pipeline consists of:\n",
+    "\n",
+    "- Rescaling\n",
+    "- Resizing\n",
+    "- Random cropping (fixed-sized or random sized)\n",
+    "- Random horizontal flipping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "data_augmentation = keras.Sequential(\n",
+    "    [\n",
+    "        layers.Rescaling(1 / 255.0),\n",
+    "        layers.Resizing(INPUT_SHAPE[0] + 20, INPUT_SHAPE[0] + 20),\n",
+    "        layers.RandomCrop(IMAGE_SIZE, IMAGE_SIZE),\n",
+    "        layers.RandomFlip(\"horizontal\"),\n",
+    "    ],\n",
+    "    name=\"data_augmentation\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Note that image data augmentation layers do not apply data transformations at inference time.\n",
+    "This means that when these layers are called with `training=False` they behave differently. Refer\n",
+    "[to the documentation](https://keras.io/api/layers/preprocessing_layers/image_augmentation/) for more\n",
+    "details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Positional embedding module\n",
+    "\n",
+    "A [Transformer](https://arxiv.org/abs/1706.03762) architecture consists of **multi-head\n",
+    "self attention** layers and **fully-connected feed forward** networks (MLP) as the main\n",
+    "components. Both these components are _permutation invariant_: they're not aware of\n",
+    "feature order.\n",
+    "\n",
+    "To overcome this problem we inject tokens with positional information. The\n",
+    "`position_embedding` function adds this positional information to the linearly projected\n",
+    "tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def position_embedding(\n",
+    "    projected_patches, num_patches=NUM_PATCHES, projection_dim=PROJECTION_DIM\n",
+    "):\n",
+    "    # Build the positions.\n",
+    "    positions = tf.range(start=0, limit=num_patches, delta=1)\n",
+    "\n",
+    "    # Encode the positions with an Embedding layer.\n",
+    "    encoded_positions = layers.Embedding(\n",
+    "        input_dim=num_patches, output_dim=projection_dim\n",
+    "    )(positions)\n",
+    "\n",
+    "    # Add encoded positions to the projected patches.\n",
+    "    return projected_patches + encoded_positions\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## MLP block for Transformer\n",
+    "\n",
+    "This serves as the Fully Connected Feed Forward block for our Transformer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def mlp(x, dropout_rate, hidden_units):\n",
+    "    # Iterate over the hidden units and\n",
+    "    # add Dense => Dropout.\n",
+    "    for units in hidden_units:\n",
+    "        x = layers.Dense(units, activation=tf.nn.gelu)(x)\n",
+    "        x = layers.Dropout(dropout_rate)(x)\n",
+    "    return x\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## TokenLearner module\n",
+    "\n",
+    "The following figure presents a pictorial overview of the module\n",
+    "([source](https://ai.googleblog.com/2021/12/improving-vision-transformer-efficiency.html)).\n",
+    "\n",
+    "![TokenLearner module GIF](https://blogger.googleusercontent.com/img/a/AVvXsEiylT3_nmd9-tzTnz3g3Vb4eTn-L5sOwtGJOad6t2we7FsjXSpbLDpuPrlInAhtE5hGCA_PfYTJtrIOKfLYLYGcYXVh1Ksfh_C1ZC-C8gw6GKtvrQesKoMrEA_LU_Gd5srl5-3iZDgJc1iyCELoXtfuIXKJ2ADDHOBaUjhU8lXTVdr2E7bCVaFgVHHkmA=w640-h208)\n",
+    "\n",
+    "The TokenLearner module takes as input an image-shaped tensor. It then passes it through\n",
+    "multiple single-channel convolutional layers extracting different spatial attention maps\n",
+    "focusing on different parts of the input. These attention maps are then element-wise\n",
+    "multiplied to the input and result is aggregated with pooling. This pooled output can be\n",
+    "trated as a summary of the input and has much lesser number of patches (8, for example)\n",
+    "than the original one (196, for example).\n",
+    "\n",
+    "Using multiple convolution layers helps with expressivity. Imposing a form of spatial\n",
+    "attention helps retain relevant information from the inputs. Both of these components are\n",
+    "crucial to make TokenLearner work, especially when we are significantly reducing the number of patches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def token_learner(inputs, number_of_tokens=NUM_TOKENS):\n",
+    "    # Layer normalize the inputs.\n",
+    "    x = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(inputs)  # (B, H, W, C)\n",
+    "\n",
+    "    # Applying Conv2D => Reshape => Permute\n",
+    "    # The reshape and permute is done to help with the next steps of\n",
+    "    # multiplication and Global Average Pooling.\n",
+    "    attention_maps = keras.Sequential(\n",
+    "        [\n",
+    "            # 3 layers of conv with gelu activation as suggested\n",
+    "            # in the paper.\n",
+    "            layers.Conv2D(\n",
+    "                filters=number_of_tokens,\n",
+    "                kernel_size=(3, 3),\n",
+    "                activation=tf.nn.gelu,\n",
+    "                padding=\"same\",\n",
+    "                use_bias=False,\n",
+    "            ),\n",
+    "            layers.Conv2D(\n",
+    "                filters=number_of_tokens,\n",
+    "                kernel_size=(3, 3),\n",
+    "                activation=tf.nn.gelu,\n",
+    "                padding=\"same\",\n",
+    "                use_bias=False,\n",
+    "            ),\n",
+    "            layers.Conv2D(\n",
+    "                filters=number_of_tokens,\n",
+    "                kernel_size=(3, 3),\n",
+    "                activation=tf.nn.gelu,\n",
+    "                padding=\"same\",\n",
+    "                use_bias=False,\n",
+    "            ),\n",
+    "            # This conv layer will generate the attention maps\n",
+    "            layers.Conv2D(\n",
+    "                filters=number_of_tokens,\n",
+    "                kernel_size=(3, 3),\n",
+    "                activation=\"sigmoid\",  # Note sigmoid for [0, 1] output\n",
+    "                padding=\"same\",\n",
+    "                use_bias=False,\n",
+    "            ),\n",
+    "            # Reshape and Permute\n",
+    "            layers.Reshape((-1, number_of_tokens)),  # (B, H*W, num_of_tokens)\n",
+    "            layers.Permute((2, 1)),\n",
+    "        ]\n",
+    "    )(\n",
+    "        x\n",
+    "    )  # (B, num_of_tokens, H*W)\n",
+    "\n",
+    "    # Reshape the input to align it with the output of the conv block.\n",
+    "    num_filters = inputs.shape[-1]\n",
+    "    inputs = layers.Reshape((1, -1, num_filters))(inputs)  # inputs == (B, 1, H*W, C)\n",
+    "\n",
+    "    # Element-Wise multiplication of the attention maps and the inputs\n",
+    "    attended_inputs = (\n",
+    "        attention_maps[..., tf.newaxis] * inputs\n",
+    "    )  # (B, num_tokens, H*W, C)\n",
+    "\n",
+    "    # Global average pooling the element wise multiplication result.\n",
+    "    outputs = tf.reduce_mean(attended_inputs, axis=2)  # (B, num_tokens, C)\n",
+    "    return outputs\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Transformer block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def transformer(encoded_patches):\n",
+    "    # Layer normalization 1.\n",
+    "    x1 = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(encoded_patches)\n",
+    "\n",
+    "    # Multi Head Self Attention layer 1.\n",
+    "    attention_output = layers.MultiHeadAttention(\n",
+    "        num_heads=NUM_HEADS, key_dim=PROJECTION_DIM, dropout=0.1\n",
+    "    )(x1, x1)\n",
+    "\n",
+    "    # Skip connection 1.\n",
+    "    x2 = layers.Add()([attention_output, encoded_patches])\n",
+    "\n",
+    "    # Layer normalization 2.\n",
+    "    x3 = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(x2)\n",
+    "\n",
+    "    # MLP layer 1.\n",
+    "    x4 = mlp(x3, hidden_units=MLP_UNITS, dropout_rate=0.1)\n",
+    "\n",
+    "    # Skip connection 2.\n",
+    "    encoded_patches = layers.Add()([x4, x2])\n",
+    "    return encoded_patches\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## ViT model with the TokenLearner module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def create_vit_classifier(use_token_learner=True, token_learner_units=NUM_TOKENS):\n",
+    "    inputs = layers.Input(shape=INPUT_SHAPE)  # (B, H, W, C)\n",
+    "\n",
+    "    # Augment data.\n",
+    "    augmented = data_augmentation(inputs)\n",
+    "\n",
+    "    # Create patches and project the pathces.\n",
+    "    projected_patches = layers.Conv2D(\n",
+    "        filters=PROJECTION_DIM,\n",
+    "        kernel_size=(PATCH_SIZE, PATCH_SIZE),\n",
+    "        strides=(PATCH_SIZE, PATCH_SIZE),\n",
+    "        padding=\"VALID\",\n",
+    "    )(augmented)\n",
+    "    _, h, w, c = projected_patches.shape\n",
+    "    projected_patches = layers.Reshape((h * w, c))(\n",
+    "        projected_patches\n",
+    "    )  # (B, number_patches, projection_dim)\n",
+    "\n",
+    "    # Add positional embeddings to the projected patches.\n",
+    "    encoded_patches = position_embedding(\n",
+    "        projected_patches\n",
+    "    )  # (B, number_patches, projection_dim)\n",
+    "    encoded_patches = layers.Dropout(0.1)(encoded_patches)\n",
+    "\n",
+    "    # Iterate over the number of layers and stack up blocks of\n",
+    "    # Transformer.\n",
+    "    for i in range(NUM_LAYERS):\n",
+    "        # Add a Transformer block.\n",
+    "        encoded_patches = transformer(encoded_patches)\n",
+    "\n",
+    "        # Add TokenLearner layer in the middle of the\n",
+    "        # architecture. The paper suggests that anywhere\n",
+    "        # between 1/2 or 3/4 will work well.\n",
+    "        if use_token_learner and i == NUM_LAYERS // 2:\n",
+    "            _, hh, c = encoded_patches.shape\n",
+    "            h = int(math.sqrt(hh))\n",
+    "            encoded_patches = layers.Reshape((h, h, c))(\n",
+    "                encoded_patches\n",
+    "            )  # (B, h, h, projection_dim)\n",
+    "            encoded_patches = token_learner(\n",
+    "                encoded_patches, token_learner_units\n",
+    "            )  # (B, num_tokens, c)\n",
+    "\n",
+    "    # Layer normalization and Global average pooling.\n",
+    "    representation = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(encoded_patches)\n",
+    "    representation = layers.GlobalAvgPool1D()(representation)\n",
+    "\n",
+    "    # Classify outputs.\n",
+    "    outputs = layers.Dense(NUM_CLASSES, activation=\"softmax\")(representation)\n",
+    "\n",
+    "    # Create the Keras model.\n",
+    "    model = keras.Model(inputs=inputs, outputs=outputs)\n",
+    "    return model\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "As shown in the [TokenLearner paper](https://openreview.net/forum?id=z-l1kpDXs88), it is\n",
+    "almost always advantageous to include the TokenLearner module in the middle of the\n",
+    "network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Training utility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def run_experiment(model):\n",
+    "    # Initialize the AdamW optimizer.\n",
+    "    optimizer = tfa.optimizers.AdamW(\n",
+    "        learning_rate=LEARNING_RATE, weight_decay=WEIGHT_DECAY\n",
+    "    )\n",
+    "\n",
+    "    # Compile the model with the optimizer, loss function\n",
+    "    # and the metrics.\n",
+    "    model.compile(\n",
+    "        optimizer=optimizer,\n",
+    "        loss=\"sparse_categorical_crossentropy\",\n",
+    "        metrics=[\n",
+    "            keras.metrics.SparseCategoricalAccuracy(name=\"accuracy\"),\n",
+    "            keras.metrics.SparseTopKCategoricalAccuracy(5, name=\"top-5-accuracy\"),\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    # Define callbacks\n",
+    "    checkpoint_filepath = \"/tmp/checkpoint\"\n",
+    "    checkpoint_callback = keras.callbacks.ModelCheckpoint(\n",
+    "        checkpoint_filepath,\n",
+    "        monitor=\"val_accuracy\",\n",
+    "        save_best_only=True,\n",
+    "        save_weights_only=True,\n",
+    "    )\n",
+    "\n",
+    "    # Train the model.\n",
+    "    _ = model.fit(\n",
+    "        train_ds,\n",
+    "        epochs=EPOCHS,\n",
+    "        validation_data=val_ds,\n",
+    "        callbacks=[checkpoint_callback],\n",
+    "    )\n",
+    "\n",
+    "    model.load_weights(checkpoint_filepath)\n",
+    "    _, accuracy, top_5_accuracy = model.evaluate(test_ds)\n",
+    "    print(f\"Test accuracy: {round(accuracy * 100, 2)}%\")\n",
+    "    print(f\"Test top 5 accuracy: {round(top_5_accuracy * 100, 2)}%\")\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Train and evaluate a ViT with TokenLearner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "vit_token_learner = create_vit_classifier()\n",
+    "run_experiment(vit_token_learner)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Results\n",
+    "\n",
+    "We experimented with and without the TokenLearner inside the mini ViT we implemented\n",
+    "(with the same hyperparameters presented in this example). Here are our results:\n",
+    "\n",
+    "| **TokenLearner** | **# tokens in<br> TokenLearner** | **Top-1 Acc<br>(Averaged across 5 runs)** | **GFLOPs** | **TensorBoard** |\n",
+    "|:---:|:---:|:---:|:---:|:---:|\n",
+    "| N | - | 56.112% | 0.0184 | [Link](https://tensorboard.dev/experiment/vkCwM49dQZ2RiK0ZT4mj7w/) |\n",
+    "| Y | 8 | **56.55%** | **0.0153** | [Link](https://tensorboard.dev/experiment/vkCwM49dQZ2RiK0ZT4mj7w/) |\n",
+    "| N | - | 56.37% | 0.0184 | [Link](https://tensorboard.dev/experiment/hdyJ4wznQROwqZTgbtmztQ/) |\n",
+    "| Y | 4 | **56.4980%** | **0.0147** | [Link](https://tensorboard.dev/experiment/hdyJ4wznQROwqZTgbtmztQ/) |\n",
+    "| N | - (# Transformer layers: 8) | 55.36% | 0.0359 | [Link](https://tensorboard.dev/experiment/sepBK5zNSaOtdCeEG6SV9w/) |\n",
+    "\n",
+    "TokenLearner is able to consistently outperform our mini ViT without the module. It is\n",
+    "also interesting to notice that it was also able to outperform a deeper version of our\n",
+    "mini ViT (with 8 layers). The authors also report similar observations in the paper and\n",
+    "they attribute this to the adaptiveness of TokenLearner.\n",
+    "\n",
+    "One should also note that the FLOPs count **decreases** considerably with the addition of\n",
+    "the TokenLearner module. With less FLOPs count the TokenLearner module is able to\n",
+    "deliver better results. This aligns very well with the authors' findings.\n",
+    "\n",
+    "Additionally, the authors [introduced](https://github.com/google-research/scenic/blob/main/scenic/projects/token_learner/model.py#L104)\n",
+    "a newer version of the TokenLearner for smaller training data regimes. Quoting the authors:\n",
+    "\n",
+    "> Instead of using 4 conv. layers with small channels to implement spatial attention,\n",
+    "  this version uses 2 grouped conv. layers with more channels. It also uses softmax\n",
+    "  instead of sigmoid. We confirmed that this version works better when having limited\n",
+    "  training data, such as training with ImageNet1K from scratch.\n",
+    "\n",
+    "We experimented with this module and in the following table we summarize the results:\n",
+    "\n",
+    "| **# Groups** | **# Tokens** | **Top-1 Acc** | **GFLOPs** | **TensorBoard** |\n",
+    "|:---:|:---:|:---:|:---:|:---:|\n",
+    "| 4 | 4 | 54.638% | 0.0149 | [Link](https://tensorboard.dev/experiment/KmfkGqAGQjikEw85phySmw/) |\n",
+    "| 8 | 8 | 54.898% | 0.0146 | [Link](https://tensorboard.dev/experiment/0PpgYOq9RFWV9njX6NJQ2w/) |\n",
+    "| 4 | 8 | 55.196% | 0.0149 | [Link](https://tensorboard.dev/experiment/WUkrHbZASdu3zrfmY4ETZg/) |\n",
+    "\n",
+    "Please note that we used the same hyperparameters presented in this example. Our\n",
+    "implementation is available\n",
+    "[in this notebook](https://github.com/ariG23498/TokenLearner/blob/master/TokenLearner-V1.1.ipynb).\n",
+    "We acknowledge that the results with this new TokenLearner module are slightly off\n",
+    "than expected and this might mitigate with hyperparameter tuning.\n",
+    "\n",
+    "*Note*: To compute the FLOPs of our models we used\n",
+    "[this utility](https://github.com/AdityaKane2001/regnety/blob/main/regnety/utils/model_utils.py#L27)\n",
+    "from [this repository](https://github.com/AdityaKane2001/regnety)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Number of parameters\n",
+    "\n",
+    "You may have noticed that adding the TokenLearner module increases the number of\n",
+    "parameters of the base network. But that does not mean it is less efficient as shown by\n",
+    "[Dehghani et al.](https://arxiv.org/abs/2110.12894). Similar findings were reported\n",
+    "by [Bello et al.](https://arxiv.org/abs/2103.07579) as well. The TokenLearner module\n",
+    "helps reducing the FLOPS in the overall network thereby helping to reduce the memory\n",
+    "footprint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Final notes\n",
+    "\n",
+    "* TokenFuser: The authors of the paper also propose another module named TokenFuser. This\n",
+    "module helps in remapping the representation of the TokenLearner output back to its\n",
+    "original spatial resolution. To reuse the TokenLearner in the ViT architecture, the\n",
+    "TokenFuser is a must. We first learn the tokens from the TokenLearner, build a\n",
+    "representation of the tokens from a Transformer layer and then remap the representation\n",
+    "into the original spatial resolution, so that it can again be consumed by a TokenLearner.\n",
+    "Note here that you can only use the TokenLearner module once in entire ViT model if not\n",
+    "paired with the TokenFuser.\n",
+    "* Use of these modules for video: The authors also suggest that TokenFuser goes really\n",
+    "well with Vision Transformers for Videos ([Arnab et al.](https://arxiv.org/abs/2103.15691)).\n",
+    "\n",
+    "We are grateful to [JarvisLabs](https://jarvislabs.ai/) and\n",
+    "[Google Developers Experts](https://developers.google.com/programs/experts/)\n",
+    "program for helping with GPU credits. Also, we are thankful to Michael Ryoo (first\n",
+    "author of TokenLearner) for fruitful discussions."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "token_learner",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -438,8 +438,8 @@ run_experiment(vit_token_learner)
 """
 ## Results
 
-We experimented with and without the TokenLearner inside the mini ViT we implemented.
-Here are our results:
+We experimented with and without the TokenLearner inside the mini ViT we implemented
+(with the same hyperparameters presented in this example). Here are our results:
 
 | **TokenLearner** | **# tokens in<br> TokenLearner** | **Top-1 Acc<br>(Averaged across 5
 runs)** | **TensorBoard** |
@@ -453,10 +453,32 @@ runs)** | **TensorBoard** |
 | N | - (# Transformer layers: 8) | 55.36% |
 [Link](https://tensorboard.dev/experiment/sepBK5zNSaOtdCeEG6SV9w/) |
 
-TokenLearner is able to consistently outperform our mini ViT without it. It is also
-interesting to notice that it was also able to outperform a deeper version of our mini
-ViT (with 8 layers). The authors also report similar observations in the paper and they
-attribute this to the adaptiveness of TokenLearner. 
+TokenLearner is able to consistently outperform our mini ViT without the module. It is
+also interesting to notice that it was also able to outperform a deeper version of our
+mini ViT (with 8 layers). The authors also report similar observations in the paper and
+they attribute this to the adaptiveness of TokenLearner.
+
+Additionally, the authors [introduced](https://github.com/google-research/scenic/blob/main/scenic/projects/token_learner/model.py#L104)
+a newer version of the TokenLearner for smaller training data regimes. Quoting the authors:
+
+> Instead of using 4 conv. layers with small channels to implement spatial attention,
+  this version uses 2 grouped conv. layers with more channels. It also uses softmax
+  instead of sigmoid. We confirmed that this version works better when having limited
+  training data, such as training with ImageNet1K from scratch.
+
+We experimented with this module and in the following table we summarize the results:
+
+| **# Groups** | **# Tokens** | **Top-1 Acc** | **TensorBoard** |
+|:---:|:---:|:---:|:---:|
+| 4 | 4 | 54.638% | [Link](https://tensorboard.dev/experiment/KmfkGqAGQjikEw85phySmw/) |
+| 8 | 8 | 54.898% | [Link](https://tensorboard.dev/experiment/0PpgYOq9RFWV9njX6NJQ2w/) |
+| 4 | 8 | 55.196% | [Link](https://tensorboard.dev/experiment/WUkrHbZASdu3zrfmY4ETZg/) |  
+
+Please note that we used the same hyperparameters presented in this example. Our
+implementation is available
+[in this notebook](https://github.com/ariG23498/TokenLearner/blob/master/TokenLearner-V1.1.ipynb).
+We acknowledge that the results with this new TokenLearner module is slightly off
+than expected and this might mitigate with hyperparameter tuning.
 """
 
 """
@@ -486,5 +508,6 @@ well with Vision Transformers for Videos ([Arnab et al.](https://arxiv.org/abs/2
 
 We are grateful to [JarvisLabs](https://jarvislabs.ai/) and 
 [Google Developers Experts](https://developers.google.com/programs/experts/)
-program for helping with GPU credits.
+program for helping with GPU credits. Also, we are thankful to Michael Ryoo (first
+author of TokenLearner) for fruitful discussions.
 """

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -11,27 +11,27 @@ Description: Adaptively generating a smaller number of tokens for Vision Transfo
 Vision Transformers ([Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)) and many
 other Transformer-based architectures ([Liu et al.](https://arxiv.org/abs/2103.14030),
 [Yuan et al.](https://arxiv.org/abs/2101.11986), etc.) have shown strong results in
-image recognition. Following provides a brief overview of the components involved in the
-Vision Transformer for image classification:
+image recognition. The following provides a brief overview of the components involved in the
+Vision Transformer architecture for image classification:
 
 * Extract small patches from input images.
 * Linearly project those patches.
 * Add positional embeddings to these linear projections.
-* These projections then go through a series of Transformer ([Vaswani et al.](https://arxiv.org/abs/1706.03762))
+* Run these projections through a series of Transformer ([Vaswani et al.](https://arxiv.org/abs/1706.03762))
 blocks.
 * Finally, take the representation from the final Transformer block and add a
 classification head.
 
-If we take 224x224 images and extract 16x16 patches we get a total of 196 patches (also
+If we take 224x224 images and extract 16x16 patches, we get a total of 196 patches (also
 called tokens) for each image. The number of patches increases as we increase the
-resolution introducing an overhead on the memory footprint. But, can we use a reduced
-number of patches without having to compromise performance? Ryoo et al. investigate this
-question in
+resolution, leading to higher memory footprint. Could we use a reduced
+number of patches without having to compromise performance?
+Ryoo et al. investigate this question in
 [TokenLearner: Adaptive Space-Time Tokenization for Videos](https://openreview.net/forum?id=z-l1kpDXs88).
 They introduce a novel module called **TokenLearner** that can help reduce the number
-of patches within a Vision Transformer (ViT) in an adaptible manner. With TokenLearner
+of patches used by a Vision Transformer (ViT) in an adaptive manner. With TokenLearner
 incorporated in the standard ViT architecture, they are able to reduce the amount of
-compute (measured in FLOPS).
+compute (measured in FLOPS) used by the model.
 
 In this example, we implement the TokenLearner module and demonstrate its
 performance with a mini ViT and the CIFAR-10 dataset. We make use of the following
@@ -73,7 +73,7 @@ import math
 ## Hyperparameters
 
 Please feel free to change the hyperparameters and check your results. The best way to
-get an intuition about the architecture is to experiment with it.
+develop intuition about the architecture is to experiment with it.
 """
 
 # DATA
@@ -153,9 +153,9 @@ data_augmentation = keras.Sequential(
 )
 
 """
-Note that these layers have their inference behaviour pre-defined. This means when
-these layers are called with `training=False` they behave differently. Refer
-[here](https://keras.io/api/layers/preprocessing_layers/image_augmentation/) for more
+Note that image data augmentation layers do not apply data transformations at inference time.
+This means that when these layers are called with `training=False` they behave differently. Refer
+[to the documentation](https://keras.io/api/layers/preprocessing_layers/image_augmentation/) for more
 details.
 """
 
@@ -164,7 +164,8 @@ details.
 
 A [Transformer](https://arxiv.org/abs/1706.03762) architecture consists of **multi-head
 self attention** layers and **fully-connected feed forward** networks (MLP) as the main
-components. Both these components are _permutation invariant_.
+components. Both these components are _permutation invariant_: they're not aware of
+feature order.
 
 To overcome this problem we inject tokens with positional information. The
 `position_embedding` function adds this positional information to the linearly projected
@@ -220,8 +221,7 @@ than the original one (196, for example).
 
 Using multiple convolution layers helps with expressivity. Imposing a form of spatial
 attention helps retain relevant information from the inputs. Both of these components are
-crucial to make TokenLearner work especially when we are reducing the number of patches
-significantly. 
+crucial to make TokenLearner work, especially when we are significantly reducing the number of patches.
 """
 
 
@@ -289,7 +289,6 @@ def token_learner(inputs, number_of_tokens=NUM_TOKENS):
 
 """
 ## Transformer block
-
 """
 
 
@@ -378,8 +377,8 @@ def create_vit_classifier(use_token_learner=True, token_learner_units=NUM_TOKENS
 
 """
 As shown in the [TokenLearner paper](https://openreview.net/forum?id=z-l1kpDXs88), it is
-almost always more advantageous to include the TokenLearner module from the middle of the
-network. 
+almost always advantageous to include the TokenLearner module in the middle of the
+network.
 """
 
 """
@@ -453,9 +452,9 @@ also interesting to notice that it was also able to outperform a deeper version 
 mini ViT (with 8 layers). The authors also report similar observations in the paper and
 they attribute this to the adaptiveness of TokenLearner. 
 
-One should also note that the FLOPs count **decrease** considerably with addition of
-the TokenLearner module. With less FLOPs count the TokenLearner module is able to 
-provide better results. This aligns very well with the authors' findings.
+One should also note that the FLOPs count **decreases** considerably with the addition of
+the TokenLearner module. With less FLOPs count the TokenLearner module is able to
+deliver better results. This aligns very well with the authors' findings.
 
 Additionally, the authors [introduced](https://github.com/google-research/scenic/blob/main/scenic/projects/token_learner/model.py#L104)
 a newer version of the TokenLearner for smaller training data regimes. Quoting the authors:

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -1,18 +1,16 @@
 """
 Title: Learning to tokenize in Vision Transformers
-Author: [Aritra Roy Gosthipaty^](https://twitter.com/ariG23498), [Sayak Paul^](https://twitter.com/risingSayak)
+Author: [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Sayak Paul](https://twitter.com/RisingSayak) (equal contribution)
 Date created: 2021/12/10
 Last modified: 2021/12/10
 Description: Adaptively generating a smaller number of tokens for Vision Transformers.
-
-^ Equal Contribution.
 """
 """
 ## Introduction
 
 Vision Transformers ([Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)) and many
 other Transformer-based architectures ([Liu et al.](https://arxiv.org/abs/2103.14030),
-[Yuan et al.](https://arxiv.org/abs/2101.11986), etc.) have shown tremendous results in
+[Yuan et al.](https://arxiv.org/abs/2101.11986), etc.) have shown strong results in
 image recognition. Following provides a brief overview of the components involved in the
 Vision Transformer for image classification:
 
@@ -35,7 +33,7 @@ of patches within a Vision Transformer (ViT) in an adaptible manner. With TokenL
 incorporated in the standard ViT architecture, they are able to reduce the amount of
 compute (measured in FLOPS).
 
-In this example, we will implement the TokenLearner module and demonstrate its
+In this example, we implement the TokenLearner module and demonstrate its
 performance with a mini ViT and the CIFAR-10 dataset. We make use of the following
 references:
 
@@ -47,7 +45,7 @@ references:
 """
 ## Setup
 
-We will need to install TensorFlow Addons to run this example. To install it, execute the
+We need to install TensorFlow Addons to run this example. To install it, execute the
 following:
 
 ```shell
@@ -155,7 +153,8 @@ data_augmentation = keras.Sequential(
 )
 
 """
-Note that these layers have their inference behaviour pre-defined. Refer
+Note that these layers have their inference behaviour pre-defined. This means when
+these layers are called with `training=False` they behave differently. Refer
 [here](https://keras.io/api/layers/preprocessing_layers/image_augmentation/) for more
 details.
 """
@@ -480,7 +479,7 @@ implementation is available
 We acknowledge that the results with this new TokenLearner module are slightly off
 than expected and this might mitigate with hyperparameter tuning.
 
-*Note*: To compute the FLOPs of our models we use
+*Note*: To compute the FLOPs of our models we used
 [this utility](https://github.com/AdityaKane2001/regnety/blob/main/regnety/utils/model_utils.py#L27)
 from [this repository](https://github.com/AdityaKane2001/regnety).
 """

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -477,7 +477,7 @@ We experimented with this module and in the following table we summarize the res
 Please note that we used the same hyperparameters presented in this example. Our
 implementation is available
 [in this notebook](https://github.com/ariG23498/TokenLearner/blob/master/TokenLearner-V1.1.ipynb).
-We acknowledge that the results with this new TokenLearner module is slightly off
+We acknowledge that the results with this new TokenLearner module are slightly off
 than expected and this might mitigate with hyperparameter tuning.
 """
 

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -1,6 +1,6 @@
 """
 Title: Learning to tokenize in Vision Transformers
-Author: [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Sayak Paul](https://twitter.com/RisingSayak) (equal contribution)
+Authors: [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Sayak Paul](https://twitter.com/RisingSayak) (equal contribution)
 Date created: 2021/12/10
 Last modified: 2021/12/10
 Description: Adaptively generating a smaller number of tokens for Vision Transformers.

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -463,9 +463,11 @@ attribute this to the adaptiveness of TokenLearner.
 ## Number of parameters
 
 You may have noticed that adding the TokenLearner module increases the number of
-parameters of the base network. But that does not mean it is less efficient 
-([Dehghani et al.](https://arxiv.org/abs/2110.12894)). The TokenLearner module helps
-reducing the FLOPS in the overall network thereby helping to reduce the memory footprint. 
+parameters of the base network. But that does not mean it is less efficient as shown by
+[Dehghani et al.](https://arxiv.org/abs/2110.12894). Similar findings were reported
+by [Bello et al.](https://arxiv.org/abs/2103.07579) as well. The TokenLearner module
+helps reducing the FLOPS in the overall network thereby helping to reduce the memory
+footprint. 
 """
 
 """

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -1,0 +1,489 @@
+"""
+Title: Learning to tokenize in Vision Transformers
+Author: [Aritra Roy Gosthipaty^](https://twitter.com/ariG23498), [Sayak Paul^](https://twitter.com/risingSayak)
+Date created: 2021/12/10
+Last modified: 2021/12/10
+Description: Adaptively generating a smaller number of tokens for Vision Transformers.
+
+^ Equal Contribution.
+"""
+"""
+## Introduction
+
+Vision Transformers ([Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)) and many
+other Transformer-based architectures ([Liu et al.](https://arxiv.org/abs/2103.14030),
+[Yuan et al.](https://arxiv.org/abs/2101.11986), etc.) have shown tremendous results in
+image recognition. Following provides a brief overview of the components involved in the
+Vision Transformer for image classification:
+
+* Extract small patches from input images.
+* Linearly project those patches.
+* Add positional embeddings to these linear projections.
+* These projections then go through a series of Transformer ([Vaswani et al.](https://arxiv.org/abs/1706.03762))
+blocks.
+* Finally, take the representation from the final Transformer block and add a
+classification head.
+
+If we take 224x224 images and extract 16x16 patches we get a total of 196 patches (also
+called tokens) for each image. The number of patches increases as we increase the
+resolution introducing an overhead on the memory footprint. But, can we use a reduced
+number of patches without having to compromise performance? Ryoo et al. investigate this
+question in
+[TokenLearner: Adaptive Space-Time Tokenization for Videos](https://openreview.net/forum?id=z-l1kpDXs88).
+They introduce a novel module called **TokenLearner** that can help reduce the number
+of patches within a Vision Transformer (ViT) in an adaptible manner. With TokenLearner
+incorporated in the standard ViT architecture, they are able to reduce the amount of
+compute (measured in FLOPS).
+
+In this example, we will implement the TokenLearner module and demonstrate its
+performance with a mini ViT and the CIFAR-10 dataset. We make use of the following
+references:
+
+* [Official TokenLearner code](https://github.com/google-research/scenic/blob/main/scenic/projects/token_learner/model.py)
+* [Image Classification with ViTs on keras.io](https://keras.io/examples/vision/image_classification_with_vision_transformer/)
+* [TokenLearner slides from NeurIPS 2021](https://nips.cc/media/neurips-2021/Slides/26578.pdf)
+"""
+
+"""
+## Setup
+
+We will need to install TensorFlow Addons to run this example. To install it, execute the
+following:
+
+```shell
+pip install tensorflow-addons
+```
+"""
+
+"""
+## Imports
+"""
+
+import tensorflow as tf
+
+from tensorflow import keras
+from tensorflow.keras import layers
+import tensorflow_addons as tfa
+
+from datetime import datetime
+import matplotlib.pyplot as plt
+import numpy as np
+
+import math
+
+"""
+## Hyperparameters
+
+Please feel free to change the hyperparameters and check your results. The best way to
+get an intuition about the architecture is to experiment with it.
+"""
+
+# DATA
+BATCH_SIZE = 256
+AUTO = tf.data.AUTOTUNE
+INPUT_SHAPE = (32, 32, 3)
+NUM_CLASSES = 10
+
+# OPTIMIZER
+LEARNING_RATE = 1e-3
+WEIGHT_DECAY = 1e-4
+
+# TRAINING
+EPOCHS = 20
+
+# AUGMENTATION
+IMAGE_SIZE = 48  # We will resize input images to this size.
+PATCH_SIZE = 6  # Size of the patches to be extracted from the input images.
+NUM_PATCHES = (IMAGE_SIZE // PATCH_SIZE) ** 2
+
+# ViT ARCHITECTURE
+LAYER_NORM_EPS = 1e-6
+PROJECTION_DIM = 128
+NUM_HEADS = 4
+NUM_LAYERS = 4
+MLP_UNITS = [
+    PROJECTION_DIM * 2,
+    PROJECTION_DIM,
+]
+
+# TOKENLEARNER
+NUM_TOKENS = 4
+
+"""
+## Load and prepare the CIFAR-10 dataset
+"""
+
+# Load the CIFAR-10 dataset.
+(x_train, y_train), (x_test, y_test) = keras.datasets.cifar10.load_data()
+(x_train, y_train), (x_val, y_val) = (
+    (x_train[:40000], y_train[:40000]),
+    (x_train[40000:], y_train[40000:]),
+)
+print(f"Training samples: {len(x_train)}")
+print(f"Validation samples: {len(x_val)}")
+print(f"Testing samples: {len(x_test)}")
+
+# Convert to tf.data.Dataset objects.
+train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
+train_ds = train_ds.shuffle(BATCH_SIZE * 100).batch(BATCH_SIZE).prefetch(AUTO)
+
+val_ds = tf.data.Dataset.from_tensor_slices((x_val, y_val))
+val_ds = val_ds.batch(BATCH_SIZE).prefetch(AUTO)
+
+test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test))
+test_ds = test_ds.batch(BATCH_SIZE).prefetch(AUTO)
+
+"""
+## Data augmentation
+
+The augmentation pipeline consists of:
+
+- Rescaling
+- Resizing
+- Random cropping (fixed-sized or random sized)
+- Random horizontal flipping
+"""
+
+data_augmentation = keras.Sequential(
+    [
+        layers.Rescaling(1 / 255.0),
+        layers.Resizing(INPUT_SHAPE[0] + 20, INPUT_SHAPE[0] + 20),
+        layers.RandomCrop(IMAGE_SIZE, IMAGE_SIZE),
+        layers.RandomFlip("horizontal"),
+    ],
+    name="data_augmentation",
+)
+
+"""
+Note that these layers have their inference behaviour pre-defined. Refer
+[here](https://keras.io/api/layers/preprocessing_layers/image_augmentation/) for more
+details.
+"""
+
+"""
+## Positional embedding module
+
+A [Transformer](https://arxiv.org/abs/1706.03762) architecture consists of **multi-head
+self attention** layers and **fully-connected feed forward** networks (MLP) as the main
+components. Both these components are _permutation invariant_.
+
+To overcome this problem we inject tokens with positional information. The
+`position_embedding` function adds this positional information to the linearly projected
+tokens.
+"""
+
+
+def position_embedding(
+    projected_patches, num_patches=NUM_PATCHES, projection_dim=PROJECTION_DIM
+):
+    # Build the positions.
+    positions = tf.range(start=0, limit=num_patches, delta=1)
+
+    # Encode the positions with an Embedding layer.
+    encoded_positions = layers.Embedding(
+        input_dim=num_patches, output_dim=projection_dim
+    )(positions)
+
+    # Add encoded positions to the projected patches.
+    return projected_patches + encoded_positions
+
+
+"""
+## MLP block for Transformer
+
+This serves as the Fully Connected Feed Forward block for our Transformer.
+"""
+
+
+def mlp(x, dropout_rate, hidden_units):
+    # Iterate over the hidden units and
+    # add Dense => Dropout.
+    for units in hidden_units:
+        x = layers.Dense(units, activation=tf.nn.gelu)(x)
+        x = layers.Dropout(dropout_rate)(x)
+    return x
+
+
+"""
+## TokenLearner module
+
+The following figure presents a pictorial overview of the module
+([source](https://ai.googleblog.com/2021/12/improving-vision-transformer-efficiency.html)).
+([source](https://ai.googleblog.com/2021/12/improving-vision-transformer-efficiency.html)).
+
+![TokenLearner module GIF](https://blogger.googleusercontent.com/img/a/AVvXsEiylT3_nmd9-tzTnz3g3Vb4eTn-L5sOwtGJOad6t2we7FsjXSpbLDpuPrlInAhtE5hGCA_PfYTJtrIOKfLYLYGcYXVh1Ksfh_C1ZC-C8gw6GKtvrQesKoMrEA_LU_Gd5srl5-3iZDgJc1iyCELoXtfuIXKJ2ADDHOBaUjhU8lXTVdr2E7bCVaFgVHHkmA=w640-h208)
+
+The TokenLearner module takes as input an image-shaped tensor. It then passes it through
+multiple single-channel convolutional layers extracting different spatial attention maps
+focusing on different parts of the input. These attention maps are then element-wise
+multiplied to the input and result is aggregated with pooling. This pooled output can be
+trated as a summary of the input and has much lesser number of patches (8, for example)
+than the original one (196, for example). 
+
+Using multiple convolution layers helps with expressivity. Imposing a form of spatial
+attention helps retain relevant information from the inputs. Both of these components are
+crucial to make TokenLearner work especially when we are reducing the number of patches
+significantly. 
+"""
+
+
+def token_learner(inputs, number_of_tokens=NUM_TOKENS):
+    # Layer normalize the inputs.
+    x = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(inputs)  # (B, H, W, C)
+
+    # Applying Conv2D => Reshape => Permute
+    # The reshape and permute is done to help with the next steps of
+    # multiplication and Global Average Pooling.
+    attention_maps = keras.Sequential(
+        [
+            # 3 layers of conv with gelu activation as suggested
+            # in the paper.
+            layers.Conv2D(
+                filters=number_of_tokens,
+                kernel_size=(3, 3),
+                activation=tf.nn.gelu,
+                padding="same",
+                use_bias=False,
+            ),
+            layers.Conv2D(
+                filters=number_of_tokens,
+                kernel_size=(3, 3),
+                activation=tf.nn.gelu,
+                padding="same",
+                use_bias=False,
+            ),
+            layers.Conv2D(
+                filters=number_of_tokens,
+                kernel_size=(3, 3),
+                activation=tf.nn.gelu,
+                padding="same",
+                use_bias=False,
+            ),
+            # This conv layer will generate the attention maps
+            layers.Conv2D(
+                filters=number_of_tokens,
+                kernel_size=(3, 3),
+                activation="sigmoid",  # Note sigmoid for [0, 1] output
+                padding="same",
+                use_bias=False,
+            ),
+            # Reshape and Permute
+            layers.Reshape((-1, number_of_tokens)),  # (B, H*W, num_of_tokens)
+            layers.Permute((2, 1)),
+        ]
+    )(
+        x
+    )  # (B, num_of_tokens, H*W)
+
+    # Reshape the input to align it with the output of the conv block.
+    num_filters = inputs.shape[-1]
+    inputs = layers.Reshape((1, -1, num_filters))(inputs)  # inputs == (B, 1, H*W, C)
+
+    # Element-Wise multiplication of the attention maps and the inputs
+    attended_inputs = (
+        attention_maps[..., tf.newaxis] * inputs
+    )  # (B, num_tokens, H*W, C)
+
+    # Global average pooling the element wise multiplication result.
+    outputs = tf.reduce_mean(attended_inputs, axis=2)  # (B, num_tokens, C)
+    return outputs
+
+
+"""
+## Transformer block
+
+"""
+
+
+def transformer(encoded_patches):
+    # Layer normalization 1.
+    x1 = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(encoded_patches)
+
+    # Multi Head Self Attention layer 1.
+    attention_output = layers.MultiHeadAttention(
+        num_heads=NUM_HEADS, key_dim=PROJECTION_DIM, dropout=0.1
+    )(x1, x1)
+
+    # Skip connection 1.
+    x2 = layers.Add()([attention_output, encoded_patches])
+
+    # Layer normalization 2.
+    x3 = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(x2)
+
+    # MLP layer 1.
+    x4 = mlp(x3, hidden_units=MLP_UNITS, dropout_rate=0.1)
+
+    # Skip connection 2.
+    encoded_patches = layers.Add()([x4, x2])
+    return encoded_patches
+
+
+"""
+## ViT model with the TokenLearner module
+"""
+
+
+def create_vit_classifier(use_token_learner=True, token_learner_units=NUM_TOKENS):
+    inputs = layers.Input(shape=INPUT_SHAPE)  # (B, H, W, C)
+
+    # Augment data.
+    augmented = data_augmentation(inputs)
+
+    # Create patches and project the pathces.
+    projected_patches = layers.Conv2D(
+        filters=PROJECTION_DIM,
+        kernel_size=(PATCH_SIZE, PATCH_SIZE),
+        strides=(PATCH_SIZE, PATCH_SIZE),
+        padding="VALID",
+    )(augmented)
+    _, h, w, c = projected_patches.shape
+    projected_patches = layers.Reshape((h * w, c))(
+        projected_patches
+    )  # (B, number_patches, projection_dim)
+
+    # Add positional embeddings to the projected patches.
+    encoded_patches = position_embedding(
+        projected_patches
+    )  # (B, number_patches, projection_dim)
+    encoded_patches = layers.Dropout(0.1)(encoded_patches)
+
+    # Iterate over the number of layers and stack up blocks of
+    # Transformer.
+    for i in range(NUM_LAYERS):
+        # Add a Transformer block.
+        encoded_patches = transformer(encoded_patches)
+
+        # Add TokenLearner layer in the middle of the
+        # architecture. The paper suggests that anywhere
+        # between 1/2 or 3/4 will work well.
+        if use_token_learner and i == NUM_LAYERS // 2:
+            _, hh, c = encoded_patches.shape
+            h = int(math.sqrt(hh))
+            encoded_patches = layers.Reshape((h, h, c))(
+                encoded_patches
+            )  # (B, h, h, projection_dim)
+            encoded_patches = token_learner(
+                encoded_patches, token_learner_units
+            )  # (B, num_tokens, c)
+
+    # Layer normalization and Global average pooling.
+    representation = layers.LayerNormalization(epsilon=LAYER_NORM_EPS)(encoded_patches)
+    representation = layers.GlobalAvgPool1D()(representation)
+
+    # Classify outputs.
+    outputs = layers.Dense(NUM_CLASSES, activation="softmax")(representation)
+
+    # Create the Keras model.
+    model = keras.Model(inputs=inputs, outputs=outputs)
+    return model
+
+
+"""
+As shown in the [TokenLearner paper](https://openreview.net/forum?id=z-l1kpDXs88), it is
+almost always more advantageous to include the TokenLearner module from the middle of the
+network. 
+"""
+
+"""
+## Training utility
+"""
+
+
+def run_experiment(model):
+    # Initialize the AdamW optimizer.
+    optimizer = tfa.optimizers.AdamW(
+        learning_rate=LEARNING_RATE, weight_decay=WEIGHT_DECAY
+    )
+
+    # Compile the model with the optimizer, loss function
+    # and the metrics.
+    model.compile(
+        optimizer=optimizer,
+        loss="sparse_categorical_crossentropy",
+        metrics=[
+            keras.metrics.SparseCategoricalAccuracy(name="accuracy"),
+            keras.metrics.SparseTopKCategoricalAccuracy(5, name="top-5-accuracy"),
+        ],
+    )
+
+    # Define callbacks
+    checkpoint_filepath = "/tmp/checkpoint"
+    checkpoint_callback = keras.callbacks.ModelCheckpoint(
+        checkpoint_filepath,
+        monitor="val_accuracy",
+        save_best_only=True,
+        save_weights_only=True,
+    )
+
+    # Train the model.
+    _ = model.fit(
+        train_ds,
+        epochs=EPOCHS,
+        validation_data=val_ds,
+        callbacks=[checkpoint_callback],
+    )
+
+    model.load_weights(checkpoint_filepath)
+    _, accuracy, top_5_accuracy = model.evaluate(test_ds)
+    print(f"Test accuracy: {round(accuracy * 100, 2)}%")
+    print(f"Test top 5 accuracy: {round(top_5_accuracy * 100, 2)}%")
+
+
+"""
+## Train and evaluate a ViT with TokenLearner
+"""
+
+vit_token_learner = create_vit_classifier()
+run_experiment(vit_token_learner)
+
+"""
+## Results
+
+We experimented with and without the TokenLearner inside the mini ViT we implemented.
+Here are our results:
+
+| **TokenLearner** | **# tokens in<br> TokenLearner** | **Top-1 Acc<br>(Averaged across 5
+runs)** | **TensorBoard** |
+|:---:|:---:|:---:|:---:|
+| N | - | 56.112% | [Link](https://tensorboard.dev/experiment/vkCwM49dQZ2RiK0ZT4mj7w/) |
+| Y | 8 | **56.55%** | [Link](https://tensorboard.dev/experiment/vkCwM49dQZ2RiK0ZT4mj7w/)
+|
+| N | - | 56.37% | [Link](https://tensorboard.dev/experiment/hdyJ4wznQROwqZTgbtmztQ/) |
+| Y | 4 | **56.4980%** |
+[Link](<br>https://tensorboard.dev/experiment/hdyJ4wznQROwqZTgbtmztQ/) |
+| N | - (# Transformer layers: 8) | 55.36% |
+[Link](https://tensorboard.dev/experiment/sepBK5zNSaOtdCeEG6SV9w/) |
+
+TokenLearner is able to consistently outperform our mini ViT without it. It is also
+interesting to notice that it was also able to outperform a deeper version of our mini
+ViT (with 8 layers). The authors also report similar observations in the paper and they
+attribute this to the adaptiveness of TokenLearner. 
+"""
+
+"""
+## Number of parameters
+
+You may have noticed that adding the TokenLearner module increases the number of
+parameters of the base network. But that does not mean it is less efficient 
+([Dehghani et al.](https://arxiv.org/abs/2110.12894)). The TokenLearner module helps
+reducing the FLOPS in the overall network thereby helping to reduce the memory footprint. 
+"""
+
+"""
+## Final notes
+
+* TokenFuser: The authors of the paper also propose another module named TokenFuser. This
+module helps in remapping the representation of the TokenLearner output back to its
+original spatial resolution. To reuse the TokenLearner in the ViT architecture, the
+TokenFuser is a must. We first learn the tokens from the TokenLearner, build a
+representation of the tokens from a Transformer layer and then remap the representation
+into the original spatial resolution, so that it can again be consumed by a TokenLearner.
+Note here that you can only use the TokenLearner module once in entire ViT model if not
+paired with the TokenFuser.
+* Use of these modules for video: The authors also suggest that TokenFuser goes really
+well with Vision Transformers for Videos ([Arnab et al.](https://arxiv.org/abs/2103.15691)).
+
+We are grateful to [JarvisLabs](https://jarvislabs.ai/) and 
+[Google Developers Experts](https://developers.google.com/programs/experts/)
+program for helping with GPU credits.
+"""

--- a/examples/vision/token_learner.py
+++ b/examples/vision/token_learner.py
@@ -209,7 +209,6 @@ def mlp(x, dropout_rate, hidden_units):
 
 The following figure presents a pictorial overview of the module
 ([source](https://ai.googleblog.com/2021/12/improving-vision-transformer-efficiency.html)).
-([source](https://ai.googleblog.com/2021/12/improving-vision-transformer-efficiency.html)).
 
 ![TokenLearner module GIF](https://blogger.googleusercontent.com/img/a/AVvXsEiylT3_nmd9-tzTnz3g3Vb4eTn-L5sOwtGJOad6t2we7FsjXSpbLDpuPrlInAhtE5hGCA_PfYTJtrIOKfLYLYGcYXVh1Ksfh_C1ZC-C8gw6GKtvrQesKoMrEA_LU_Gd5srl5-3iZDgJc1iyCELoXtfuIXKJ2ADDHOBaUjhU8lXTVdr2E7bCVaFgVHHkmA=w640-h208)
 


### PR DESCRIPTION
In this example we (with @sayakpaul) have implemented [TokenLearner: What Can 8 Learned Tokens Do for Images and Videos?](https://arxiv.org/abs/2106.11297) with a smaller ViT for CIFAR-10 image classification. 

In the paper the authors suggest an adaptive token learning algorithm that makes ViT computationally much more efficient (in terms of FLOPs) and also increases downstream accuracy (here classification accuracy). Experimenting with CIFAR-10 we reduce the number of pathces from 64 to 4 (number of adaptively learned tokens) and also report a boost in the accuracy.

We think this should be a great addition to the keras examples as it would be accessible to the community for further research.

Colab Link: https://colab.research.google.com/drive/1zjAnHQ3LLfS47dxTqaWm77YAa7WljTXo?usp=sharing