### PR TITLE
Update English-to-Spanish translation with a sequence-to-sequence Transformer

### DIFF
--- a/examples/nlp/neural_machine_translation_with_transformer.py
+++ b/examples/nlp/neural_machine_translation_with_transformer.py
@@ -325,21 +325,17 @@ latent_dim = 2048
 num_heads = 8
 
 #encoder layer
-encoder_inputs = keras.Input(
-    shape=(None,), dtype="int64", name="encoder_inputs")
+encoder_inputs = keras.Input(shape=(None,), dtype="int64", name="encoder_inputs")
 x = PositionalEmbedding(sequence_length, vocab_size, embed_dim)(encoder_inputs)
 encoder_outputs = TransformerEncoder(embed_dim, latent_dim, num_heads)(x)
 #decoder layer
-decoder_inputs = keras.Input(
-    shape=(None,), dtype="int64", name="decoder_inputs")
+decoder_inputs = keras.Input(shape=(None,), dtype="int64", name="decoder_inputs")
 x = PositionalEmbedding(sequence_length, vocab_size, embed_dim)(decoder_inputs)
 x = TransformerDecoder(embed_dim, latent_dim, num_heads)(x, encoder_outputs)
 x = layers.Dropout(0.5)(x)
 decoder_outputs = layers.Dense(vocab_size, activation="softmax")(x)
 #transformer model
-transformer = keras.Model(
-    [encoder_inputs, decoder_inputs], decoder_outputs, name="transformer"
-)
+transformer = keras.Model([encoder_inputs, decoder_inputs], decoder_outputs, name="transformer")
 
 """
 ## Training our model

--- a/examples/nlp/neural_machine_translation_with_transformer.py
+++ b/examples/nlp/neural_machine_translation_with_transformer.py
@@ -324,20 +324,19 @@ embed_dim = 256
 latent_dim = 2048
 num_heads = 8
 
-encoder_inputs = keras.Input(shape=(None,), dtype="int64", name="encoder_inputs")
+#encoder layer
+encoder_inputs = keras.Input(
+    shape=(None,), dtype="int64", name="encoder_inputs")
 x = PositionalEmbedding(sequence_length, vocab_size, embed_dim)(encoder_inputs)
 encoder_outputs = TransformerEncoder(embed_dim, latent_dim, num_heads)(x)
-encoder = keras.Model(encoder_inputs, encoder_outputs)
-
-decoder_inputs = keras.Input(shape=(None,), dtype="int64", name="decoder_inputs")
-encoded_seq_inputs = keras.Input(shape=(None, embed_dim), name="decoder_state_inputs")
+#decoder layer
+decoder_inputs = keras.Input(
+    shape=(None,), dtype="int64", name="decoder_inputs")
 x = PositionalEmbedding(sequence_length, vocab_size, embed_dim)(decoder_inputs)
-x = TransformerDecoder(embed_dim, latent_dim, num_heads)(x, encoded_seq_inputs)
+x = TransformerDecoder(embed_dim, latent_dim, num_heads)(x, encoder_outputs)
 x = layers.Dropout(0.5)(x)
 decoder_outputs = layers.Dense(vocab_size, activation="softmax")(x)
-decoder = keras.Model([decoder_inputs, encoded_seq_inputs], decoder_outputs)
-
-decoder_outputs = decoder([decoder_inputs, encoder_outputs])
+#transformer model
 transformer = keras.Model(
     [encoder_inputs, decoder_inputs], decoder_outputs, name="transformer"
 )


### PR DESCRIPTION
In the exmaple code, the author used 3 models, an encoder model, a decoder model and a transformer model. It worked fine but I got a little bit confused when I was learning. I think it's better to use just one transformer model, the encoder part and decoder part can be seen as a layer.