### PR TITLE
Update writing_a_training_loop_from_scratch.py

### DIFF
--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -515,7 +515,7 @@ for epoch in range(epochs):
             print("adversarial loss at step %d: %.2f" % (step, g_loss))
 
             # Save one generated image
-            img = tf.keras.preprocessing.image.array_to_img(
+            img = keras.utils.array_to_img(
                 generated_images[0] * 255.0, scale=False
             )
             img.save(os.path.join(save_dir, "generated_img" + str(step) + ".png"))


### PR DESCRIPTION
Updated 'tf.keras.preprocessing.image.array_to_img' to 'keras.utils.array_to_img' in 'End-to-end example: a GAN training loop from scratch' and ran the program successfully after changes.