### PR TITLE
Update writing_a_training_loop_from_scratch.py

### DIFF
--- a/guides/writing_a_training_loop_from_scratch.py
+++ b/guides/writing_a_training_loop_from_scratch.py
@@ -515,7 +515,7 @@ for epoch in range(epochs):
             print("adversarial loss at step %d: %.2f" % (step, g_loss))
 
             # Save one generated image
-            img = keras.utils.array_to_img(generated_images[0] * 255.0, scale=False)
+            img = tf.keras.utils.array_to_img(generated_images[0] * 255.0, scale=False)
             img.save(os.path.join(save_dir, "generated_img" + str(step) + ".png"))
 
         # To limit execution time we stop after 10 steps.


### PR DESCRIPTION
'keras.utils.array_to_img' is not reflecting in  section 'End-to-end example: a GAN training loop from scratch' in guide document as in Github source file. It is still showing 'tf.keras.preprocessing.image.array_to_img' in guide document.