### PR TITLE
Fix VAE randomness

### DIFF
--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -19,15 +19,20 @@ from tensorflow.keras import layers
 ## Create a sampling layer
 """
 
-
 class Sampling(layers.Layer):
     """Uses (z_mean, z_log_var) to sample z, the vector encoding a digit."""
+    def __init__(self, epsilon=1.0, **kwargs):
+        super(Sampling, self).__init__(**kwargs)
+        self.epsilon = epsilon
+        
+    def get_config(self):
+        return {"epsilon": self.epsilon}
 
     def call(self, inputs):
         z_mean, z_log_var = inputs
         batch = tf.shape(z_mean)[0]
         dim = tf.shape(z_mean)[1]
-        epsilon = tf.keras.backend.random_normal(shape=(batch, dim))
+        epsilon = keras.layers.GaussianNoise(self.epsilon)(tf.zeros((batch,dim))) 
         return z_mean + tf.exp(0.5 * z_log_var) * epsilon
 
 
@@ -41,7 +46,7 @@ encoder_inputs = keras.Input(shape=(28, 28, 1))
 x = layers.Conv2D(32, 3, activation="relu", strides=2, padding="same")(encoder_inputs)
 x = layers.Conv2D(64, 3, activation="relu", strides=2, padding="same")(x)
 x = layers.Flatten()(x)
-x = layers.Dense(16, activation="relu")(x)
+x = layers.Dense(16, activation="selu")(x)
 z_mean = layers.Dense(latent_dim, name="z_mean")(x)
 z_log_var = layers.Dense(latent_dim, name="z_log_var")(x)
 z = Sampling()([z_mean, z_log_var])


### PR DESCRIPTION
The reparameterization trick did not perturb the gaussian multiplier during training. Now it does.

Introducing a new parameter 𝜖 allows us to reparameterize 𝑧 in a way that allows backprop to flow through the deterministic nodes. 𝜖 should be a source of randomness. 