### PR TITLE
Update Barlow Twins with TF Similarity BarlowLoss function

### DIFF
--- a/examples/vision/barlow_twins.py
+++ b/examples/vision/barlow_twins.py
@@ -2,15 +2,13 @@
 Title: Barlow Twins for Contrastive SSL
 Author: [Abhiraam Eranti](https://github.com/dewball345)
 Date created: 11/4/21
-Last modified: 1/29/22
-Description: A keras implementation of Barlow Twins (constrastive SSL with redundancy reduction).
+Last modified: 01/29/22
+Description: A Keras implementation of Barlow Twins (constrastive SSL with redundancy reduction).
 """
 
 """
 ## Introduction
-"""
 
-"""
 Self-supervised learning (SSL) is a relatively novel technique in which a model
 learns from unlabeled data, and is often used when the data is corrupted or
 if there is very little of it. A practical use for SSL is to create

--- a/examples/vision/barlow_twins.py
+++ b/examples/vision/barlow_twins.py
@@ -1,8 +1,8 @@
 """
 Title: Barlow Twins for Contrastive SSL
-Author: [Abhiraam Eranti](https://github.com/dewball345)<br>
-Date created: 11/4/21<br>
-Last modified: 1/29/22<br>
+Author: [Abhiraam Eranti](https://github.com/dewball345)
+Date created: 11/4/21
+Last modified: 1/29/22
 Description: A keras implementation of Barlow Twins (constrastive SSL with redundancy reduction).
 """
 
@@ -132,8 +132,8 @@ Original Implementation:
 """
 
 """shell
-!pip install tensorflow-addons
-!pip install --upgrade-strategy=only-if-needed tensorflow_similarity
+pip install tensorflow-addons
+pip install --upgrade-strategy=only-if-needed tensorflow_similarity
 """
 
 import os
@@ -1047,14 +1047,10 @@ with the labeled data.
 
 * [Paper](https://arxiv.org/abs/2103.03230)
 * [Original Pytorch Implementation](https://github.com/facebookresearch/barlowtwins)
-* [Sayak Paul's
-Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
-Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
+* [Sayak Paul's Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
 * Thanks to Sayak Paul for his implementation. It helped me with debugging and
 comparisons of accuracy, loss.
-* [resnet34
-implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
-implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
+* [resnet34 implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
   * Thanks to Yashowardhan Shinde for writing the article.
 
 

--- a/examples/vision/barlow_twins.py
+++ b/examples/vision/barlow_twins.py
@@ -1,11 +1,9 @@
 """
-# Barlow Twins for Contrastive SSL
-
-**Author:** [Abhiraam Eranti](https://github.com/dewball345)<br>
-**Date created:** 11/4/21<br>
-**Last modified:** 1/29/22<br>
-**Description:** A keras implementation of Barlow Twins (constrastive SSL with redundancy
-reduction).
+Title: Barlow Twins for Contrastive SSL
+Author: [Abhiraam Eranti](https://github.com/dewball345)<br>
+Date created: 11/4/21<br>
+Last modified: 1/29/22<br>
+Description: A keras implementation of Barlow Twins (constrastive SSL with redundancy reduction).
 """
 
 """
@@ -606,9 +604,8 @@ representation neurons are correlated with values that are not on the diagonal.
 
 After this the two parts are summed together.
 
-We will be using the 
-[BarlowLoss](https://github.com/tensorflow/similarity/blob/master/tensorflow_similarity/lo
-sses/barlow.py) 
+We will be using the [BarlowLoss](https://github.com/tensorflow/similarity/blob/master/tensorflow_similarity/lo
+sses/barlow.py)
 module from Tensorflow Similarity
 
 A from-scratch implementation is also included below.
@@ -782,13 +779,13 @@ The model has two parts:
 class ResNet34:
     """Resnet34 class.
 
-        Responsible for the Resnet 34 architecture.
-    Modified from
-https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
-https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
-https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
-https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
-        View their website for more information.
+            Responsible for the Resnet 34 architecture.
+        Modified from
+    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+            View their website for more information.
     """
 
     def identity_block(self, x, filter):

--- a/examples/vision/barlow_twins.py
+++ b/examples/vision/barlow_twins.py
@@ -1,10 +1,13 @@
 """
-Title: Barlow Twins for Contrastive SSL
-Author: [Abhiraam Eranti](https://github.com/dewball345)
-Date created: 11/4/21
-Last modified: 12/20/21
-Description: A keras implementation of Barlow Twins (constrastive SSL with redundancy reduction).
+# Barlow Twins for Contrastive SSL
+
+**Author:** [Abhiraam Eranti](https://github.com/dewball345)<br>
+**Date created:** 11/4/21<br>
+**Last modified:** 1/29/22<br>
+**Description:** A keras implementation of Barlow Twins (constrastive SSL with redundancy
+reduction).
 """
+
 """
 ## Introduction
 """
@@ -50,7 +53,7 @@ TL, DR: Barlow twins creates representations that are:
 Also, it is simpler than other methods.
 
 This notebook can train a Barlow Twins model and reach up to
-64% validation accuracy on the CIFAR-10 dataset.
+67% validation accuracy on the CIFAR-10 dataset.
 """
 
 """
@@ -60,12 +63,10 @@ This notebook can train a Barlow Twins model and reach up to
 
 
 
-
 """
 
 """
 ### High-Level Theory
-
 
 """
 
@@ -126,7 +127,6 @@ Reduction](https://arxiv.org/abs/2103.03230)
 Original Implementation:
  [facebookresearch/barlowtwins](https://github.com/facebookresearch/barlowtwins)
 
-
 """
 
 """
@@ -134,7 +134,8 @@ Original Implementation:
 """
 
 """shell
-pip install tensorflow-addons
+!pip install tensorflow-addons
+!pip install --upgrade-strategy=only-if-needed tensorflow_similarity
 """
 
 import os
@@ -152,6 +153,7 @@ import tensorflow_addons as tfa  # LAMB optimizer and gaussian_blur_2d function
 import numpy as np  # np.random.random
 import matplotlib.pyplot as plt  # graphs
 import datetime  # tensorboard logs naming
+import tensorflow_similarity  # loss function module
 
 # XLA optimization for faster performance(up to 10-15 minutes total time saved)
 tf.config.optimizer.set_jit(True)
@@ -604,9 +606,16 @@ representation neurons are correlated with values that are not on the diagonal.
 
 After this the two parts are summed together.
 
+We will be using the 
+[BarlowLoss](https://github.com/tensorflow/similarity/blob/master/tensorflow_similarity/lo
+sses/barlow.py) 
+module from Tensorflow Similarity
 
+A from-scratch implementation is also included below.
+"""
 
-
+"""
+### From-Scratch implementation(for understanding purposes)
 """
 
 
@@ -766,7 +775,7 @@ The model has two parts:
 """
 
 """
-Resnet encoder network implementation:
+### Resnet encoder network implementation:
 """
 
 
@@ -775,8 +784,10 @@ class ResNet34:
 
         Responsible for the Resnet 34 architecture.
     Modified from
-    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
-    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
+https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.
         View their website for more information.
     """
 
@@ -845,7 +856,7 @@ class ResNet34:
 
 
 """
-Projector network:
+### Projector network:
 """
 
 
@@ -959,7 +970,9 @@ bm = BarlowModel()
 # chose the LAMB optimizer due to high batch sizes. Converged MUCH faster
 # than ADAM or SGD
 optimizer = tfa.optimizers.LAMB()
-loss = BarlowLoss(BATCH_SIZE)
+
+# We can just drop in either one of the two(results will be similar for both)
+loss = tensorflow_similarity.losses.Barlow()  # BarlowLoss(BATCH_SIZE)
 
 bm.compile(optimizer=optimizer, loss=loss)
 
@@ -1022,12 +1035,12 @@ model.fit(xy_ds, epochs=35, validation_data=test_ds)
 
 *   Barlow Twins is a simple and concise method for contrastive and self-supervised
 learning.
-*   With this resnet-34 model architecture, we were able to reach 62-64% validation
+*   With this resnet-34 model architecture, we were able to reach 67% validation
 accuracy.
 
 ## Use-Cases of Barlow-Twins(and contrastive learning in General)
 
-*   Semi-supervised learning: You can see that this model gave a 62-64% boost in accuracy
+*   Semi-supervised learning: You can see that this model gave a 67% boost in accuracy
 when it wasn't even trained with the labels. It can be used when you have little labeled
 data but a lot of unlabeled data.
 * You do barlow twins training on the unlabeled data, and then you do secondary training
@@ -1037,12 +1050,15 @@ with the labeled data.
 
 * [Paper](https://arxiv.org/abs/2103.03230)
 * [Original Pytorch Implementation](https://github.com/facebookresearch/barlowtwins)
-* [Sayak Paul's Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
+* [Sayak Paul's
+Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
+Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).
 * Thanks to Sayak Paul for his implementation. It helped me with debugging and
 comparisons of accuracy, loss.
-* [resnet34 implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
+* [resnet34
+implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
+implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)
   * Thanks to Yashowardhan Shinde for writing the article.
-
 
 
 """

--- a/examples/vision/ipynb/barlow_twins.ipynb
+++ b/examples/vision/ipynb/barlow_twins.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "# Barlow Twins for Contrastive SSL\n",
     "\n",
-    "**Author:** [Abhiraam Eranti](https://github.com/dewball345)<br>\n",
-    "**Date created:** 11/4/21<br>\n",
-    "**Last modified:** 12/20/21<br>\n",
+    "**Author:** [Abhiraam Eranti](https://github.com/dewball345)<br><br>\n",
+    "**Date created:** 11/4/21<br><br>\n",
+    "**Last modified:** 1/29/22<br><br>\n",
     "**Description:** A keras implementation of Barlow Twins (constrastive SSL with redundancy reduction)."
    ]
   },
@@ -69,7 +69,7 @@
     "Also, it is simpler than other methods.\n",
     "\n",
     "This notebook can train a Barlow Twins model and reach up to\n",
-    "64% validation accuracy on the CIFAR-10 dataset."
+    "67% validation accuracy on the CIFAR-10 dataset."
    ]
   },
   {
@@ -82,7 +82,6 @@
     "\n",
     "\n",
     "\n",
-    "\n",
     ""
    ]
   },
@@ -92,8 +91,7 @@
     "colab_type": "text"
    },
    "source": [
-    "### High-Level Theory\n",
-    ""
+    "### High-Level Theory"
    ]
   },
   {
@@ -171,8 +169,7 @@
     "Reduction](https://arxiv.org/abs/2103.03230)\n",
     "\n",
     "Original Implementation:\n",
-    " [facebookresearch/barlowtwins](https://github.com/facebookresearch/barlowtwins)\n",
-    ""
+    " [facebookresearch/barlowtwins](https://github.com/facebookresearch/barlowtwins)"
    ]
   },
   {
@@ -192,7 +189,8 @@
    },
    "outputs": [],
    "source": [
-    "!pip install tensorflow-addons"
+    "!!pip install tensorflow-addons\n",
+    "!!pip install --upgrade-strategy=only-if-needed tensorflow_similarity"
    ]
   },
   {
@@ -218,6 +216,7 @@
     "import numpy as np  # np.random.random\n",
     "import matplotlib.pyplot as plt  # graphs\n",
     "import datetime  # tensorboard logs naming\n",
+    "import tensorflow_similarity  # loss function module\n",
     "\n",
     "# XLA optimization for faster performance(up to 10-15 minutes total time saved)\n",
     "tf.config.optimizer.set_jit(True)"
@@ -761,8 +760,20 @@
     "\n",
     "After this the two parts are summed together.\n",
     "\n",
+    "We will be using the [BarlowLoss](https://github.com/tensorflow/similarity/blob/master/tensorflow_similarity/lo\n",
+    "sses/barlow.py)\n",
+    "module from Tensorflow Similarity\n",
     "\n",
-    ""
+    "A from-scratch implementation is also included below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### From-Scratch implementation(for understanding purposes)"
    ]
   },
   {
@@ -941,7 +952,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Resnet encoder network implementation:"
+    "### Resnet encoder network implementation:"
    ]
   },
   {
@@ -956,11 +967,13 @@
     "class ResNet34:\n",
     "    \"\"\"Resnet34 class.\n",
     "\n",
-    "        Responsible for the Resnet 34 architecture.\n",
-    "    Modified from\n",
+    "            Responsible for the Resnet 34 architecture.\n",
+    "        Modified from\n",
     "    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.\n",
     "    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.\n",
-    "        View their website for more information.\n",
+    "    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.\n",
+    "    https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2.\n",
+    "            View their website for more information.\n",
     "    \"\"\"\n",
     "\n",
     "    def identity_block(self, x, filter):\n",
@@ -1034,7 +1047,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Projector network:"
+    "### Projector network:"
    ]
   },
   {
@@ -1184,7 +1197,9 @@
     "# chose the LAMB optimizer due to high batch sizes. Converged MUCH faster\n",
     "# than ADAM or SGD\n",
     "optimizer = tfa.optimizers.LAMB()\n",
-    "loss = BarlowLoss(BATCH_SIZE)\n",
+    "\n",
+    "# We can just drop in either one of the two(results will be similar for both)\n",
+    "loss = tensorflow_similarity.losses.Barlow()  # BarlowLoss(BATCH_SIZE)\n",
     "\n",
     "bm.compile(optimizer=optimizer, loss=loss)\n",
     "\n",
@@ -1267,12 +1282,12 @@
     "\n",
     "*   Barlow Twins is a simple and concise method for contrastive and self-supervised\n",
     "learning.\n",
-    "*   With this resnet-34 model architecture, we were able to reach 62-64% validation\n",
+    "*   With this resnet-34 model architecture, we were able to reach 67% validation\n",
     "accuracy.\n",
     "\n",
     "## Use-Cases of Barlow-Twins(and contrastive learning in General)\n",
     "\n",
-    "*   Semi-supervised learning: You can see that this model gave a 62-64% boost in accuracy\n",
+    "*   Semi-supervised learning: You can see that this model gave a 67% boost in accuracy\n",
     "when it wasn't even trained with the labels. It can be used when you have little labeled\n",
     "data but a lot of unlabeled data.\n",
     "* You do barlow twins training on the unlabeled data, and then you do secondary training\n",
@@ -1284,12 +1299,13 @@
     "* [Original Pytorch Implementation](https://github.com/facebookresearch/barlowtwins)\n",
     "* [Sayak Paul's\n",
     "Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).\n",
+    "Implementation](https://colab.research.google.com/github/sayakpaul/Barlow-Twins-TF/blob/main/Barlow_Twins.ipynb#scrollTo=GlWepkM8_prl).\n",
     "* Thanks to Sayak Paul for his implementation. It helped me with debugging and\n",
     "comparisons of accuracy, loss.\n",
     "* [resnet34\n",
     "implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)\n",
+    "implementation](https://www.analyticsvidhya.com/blog/2021/08/how-to-code-your-resnet-from-scratch-in-tensorflow/#h2_2)\n",
     "  * Thanks to Yashowardhan Shinde for writing the article.\n",
-    "\n",
     ""
    ]
   }


### PR DESCRIPTION
This update replaces the previous loss function implementation with the one from TF Similarity. This is a drop-in replacement and the results look to be the same. The previous implementation is included for understanding purposes though it is preferable to use the updated one. Also changed the accuracy metrics because it was mentioned in the notebook that it was 64% though in the demo it went as high as 67%.

@ebursztein I could not find a way to use the augmenters with my program(current augmenters are keras.io layers which run probabilistically). I'm also a little concerned with `tf.map_func`, because I found that it slowed things down a lot. 
