### PR TITLE
Update functional_api.py

### DIFF
--- a/guides/functional_api.py
+++ b/guides/functional_api.py
@@ -135,7 +135,7 @@ The `Model` class offers a built-in training loop (the `fit()` method)
 and a built-in evaluation loop (the `evaluate()` method). Note
 that you can easily [customize these loops](/guides/customizing_what_happens_in_fit/)
 to implement training routines beyond supervised learning
-(e.g. [GANs](/examples/generative/dcgan_overriding_train_step/)).
+(e.g. [GANs](https://www.tensorflow.org/tutorials/generative/dcgan)).
 
 Here, load the MNIST image data, reshape it into vectors,
 fit the model on the data (while monitoring performance on a validation split),

--- a/guides/functional_api.py
+++ b/guides/functional_api.py
@@ -135,7 +135,7 @@ The `Model` class offers a built-in training loop (the `fit()` method)
 and a built-in evaluation loop (the `evaluate()` method). Note
 that you can easily [customize these loops](/guides/customizing_what_happens_in_fit/)
 to implement training routines beyond supervised learning
-(e.g. [GANs](https://www.tensorflow.org/tutorials/generative/dcgan)).
+(e.g. [GANs](https://keras.io/examples/generative/dcgan_overriding_train_step/)).
 
 Here, load the MNIST image data, reshape it into vectors,
 fit the model on the data (while monitoring performance on a validation split),


### PR DESCRIPTION
Updated broken link for " (e.g. GANs)" as (https://www.tensorflow.org/tutorials/generative/dcgan) in "Training, evaluation, and inference" section.