### PR TITLE
Demos hosted on Keras Examples

### DIFF
--- a/examples/nlp/bidirectional_lstm_imdb.py
+++ b/examples/nlp/bidirectional_lstm_imdb.py
@@ -4,6 +4,7 @@ Author: [fchollet](https://twitter.com/fchollet)
 Date created: 2020/05/03
 Last modified: 2020/05/03
 Description: Train a 2-layer bidirectional LSTM on the IMDB movie review sentiment classification dataset.
+Space ID: keras-io/bidirectional_lstm_imdb
 """
 """
 ## Setup
@@ -51,4 +52,4 @@ x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 """
 
 model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
-model.fit(x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val))
+model.fit(x_train, y_train, batch_size=32, epochs=1, validation_data=(x_val, y_val))

--- a/examples/nlp/ipynb/bidirectional_lstm_imdb.ipynb
+++ b/examples/nlp/ipynb/bidirectional_lstm_imdb.ipynb
@@ -36,8 +36,7 @@
     "from tensorflow.keras import layers\n",
     "\n",
     "max_features = 20000  # Only consider the top 20k words\n",
-    "maxlen = 200  # Only consider the first 200 words of each movie review\n",
-    ""
+    "maxlen = 200  # Only consider the first 200 words of each movie review"
    ]
   },
   {
@@ -67,8 +66,7 @@
     "# Add a classifier\n",
     "outputs = layers.Dense(1, activation=\"sigmoid\")(x)\n",
     "model = keras.Model(inputs, outputs)\n",
-    "model.summary()\n",
-    ""
+    "model.summary()"
    ]
   },
   {
@@ -93,9 +91,10 @@
     ")\n",
     "print(len(x_train), \"Training sequences\")\n",
     "print(len(x_val), \"Validation sequences\")\n",
+    "# Use pad_sequence to standardize sequence length:\n",
+    "# this will truncate sequences longer than 200 words and zero-pad sequences shorter than 200 words.\n",
     "x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)\n",
-    "x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)\n",
-    ""
+    "x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)"
    ]
   },
   {
@@ -115,9 +114,8 @@
    },
    "outputs": [],
    "source": [
-    "model.compile(\"adam\", \"binary_crossentropy\", metrics=[\"accuracy\"])\n",
-    "model.fit(x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val))\n",
-    ""
+    "model.compile(optimizer=\"adam\", loss=\"binary_crossentropy\", metrics=[\"accuracy\"])\n",
+    "model.fit(x_train, y_train, batch_size=32, epochs=1, validation_data=(x_val, y_val))"
    ]
   }
  ],

--- a/examples/nlp/md/bidirectional_lstm_imdb.md
+++ b/examples/nlp/md/bidirectional_lstm_imdb.md
@@ -6,8 +6,8 @@
 **Description:** Train a 2-layer bidirectional LSTM on the IMDB movie review sentiment classification dataset.
 
 
-<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/nlp/ipynb/bidirectional_lstm_imdb.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/nlp/bidirectional_lstm_imdb.py)
-
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/nlp/ipynb/bidirectional_lstm_imdb.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/nlp/bidirectional_lstm_imdb.py) 
+<span class="k-dot">•</span><img class="k-inline-icon" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg"/>[**Try on Spaces**](https://huggingface.co/spaces/keras-io/bidirectional_lstm_imdb)
 
 
 ---
@@ -21,7 +21,6 @@ from tensorflow.keras import layers
 
 max_features = 20000  # Only consider the top 20k words
 maxlen = 200  # Only consider the first 200 words of each movie review
-
 ```
 
 ---
@@ -40,24 +39,29 @@ x = layers.Bidirectional(layers.LSTM(64))(x)
 outputs = layers.Dense(1, activation="sigmoid")(x)
 model = keras.Model(inputs, outputs)
 model.summary()
-
 ```
 
 <div class="k-default-codeblock">
 ```
+2022-02-28 21:05:41.054001: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
+To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
+
 Model: "model"
 _________________________________________________________________
-Layer (type)                 Output Shape              Param #   
+ Layer (type)                Output Shape              Param #   
 =================================================================
-input_1 (InputLayer)         [(None, None)]            0         
-_________________________________________________________________
-embedding (Embedding)        (None, None, 128)         2560000   
-_________________________________________________________________
-bidirectional (Bidirectional (None, None, 128)         98816     
-_________________________________________________________________
-bidirectional_1 (Bidirection (None, 128)               98816     
-_________________________________________________________________
-dense (Dense)                (None, 1)                 129       
+ input_1 (InputLayer)        [(None, None)]            0         
+                                                                 
+ embedding (Embedding)       (None, None, 128)         2560000   
+                                                                 
+ bidirectional (Bidirectiona  (None, None, 128)        98816     
+ l)                                                              
+                                                                 
+ bidirectional_1 (Bidirectio  (None, 128)              98816     
+ nal)                                                            
+                                                                 
+ dense (Dense)               (None, 1)                 129       
+                                                                 
 =================================================================
 Total params: 2,757,761
 Trainable params: 2,757,761
@@ -76,9 +80,10 @@ _________________________________________________________________
 )
 print(len(x_train), "Training sequences")
 print(len(x_val), "Validation sequences")
+# Use pad_sequence to standardize sequence length:
+# this will truncate sequences longer than 200 words and zero-pad sequences shorter than 200 words.
 x_train = keras.preprocessing.sequence.pad_sequences(x_train, maxlen=maxlen)
 x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
-
 ```
 
 <div class="k-default-codeblock">
@@ -93,17 +98,15 @@ x_val = keras.preprocessing.sequence.pad_sequences(x_val, maxlen=maxlen)
 
 
 ```python
-model.compile("adam", "binary_crossentropy", metrics=["accuracy"])
-model.fit(x_train, y_train, batch_size=32, epochs=2, validation_data=(x_val, y_val))
-
+model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+model.fit(x_train, y_train, batch_size=32, epochs=1, validation_data=(x_val, y_val))
 ```
 
 <div class="k-default-codeblock">
 ```
-Epoch 1/2
-782/782 [==============================] - 220s 281ms/step - loss: 0.4117 - accuracy: 0.8083 - val_loss: 0.6497 - val_accuracy: 0.6983
-Epoch 2/2
-726/782 [==========================>...] - ETA: 11s - loss: 0.3170 - accuracy: 0.8683
+782/782 [==============================] - 231s 289ms/step - loss: 0.3906 - accuracy: 0.8232 - val_loss: 0.3107 - val_accuracy: 0.8704
+
+<keras.callbacks.History at 0x7f8312162490>
 
 ```
 </div>

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -125,7 +125,7 @@ class KerasIO:
         save_file(fpath, md)
 
     def preprocess_tutobook_md_source(
-        self, md_content, fname, github_repo_dir, img_dir, site_img_dir
+        self, md_content, fname, github_repo_dir, img_dir, site_img_dir, spaces_dir
     ):
         # Insert colab button and github button.
         name = fname[:-3]
@@ -145,9 +145,19 @@ class KerasIO:
             + github_repo_dir
             + "/"
             + fname
-            + ")",
-            "\n",
+            + ") "
         ]
+        if spaces_dir != "None":
+            button_lines.append(
+            '<span class="k-dot">•</span>'
+            + '<img class="k-inline-icon" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg"/>'
+            + "[**Try on Spaces**](https://huggingface.co/"
+            + spaces_dir
+            + ")"
+            + "\n"
+            )
+        else:
+            button_lines.append("\n")
         md_content_lines = md_content_lines[:6] + button_lines + md_content_lines[6:]
         md_content = "\n".join(md_content_lines)
         # Normalize img urls
@@ -159,7 +169,7 @@ class KerasIO:
         return md_content
 
     def make_tutobook_sources_for_directory(
-        self, src_dir, target_dir, img_dir, site_img_dir, github_repo_dir
+        self, src_dir, target_dir, img_dir, site_img_dir, github_repo_dir, spaces_dir
     ):
         # e.g.
         # make_tutobook_sources_for_directory(
@@ -181,7 +191,7 @@ class KerasIO:
                 tutobooks.py_to_md(py_path, nb_path, md_path, img_dir)
                 md_content = open(md_path).read()
                 md_content = self.preprocess_tutobook_md_source(
-                    md_content, fname, github_repo_dir, img_dir, site_img_dir
+                    md_content, fname, github_repo_dir, img_dir, site_img_dir, spaces_dir
                 )
                 open(md_path, "w").write(md_content)
         shutil.rmtree(working_ipynb_dir)
@@ -234,13 +244,14 @@ class KerasIO:
         py_path = Path(self.examples_dir) / folder / (name + ".py")
         md_path = md_dir / (name + ".md")
         nb_path = ipynb_dir / (name + ".ipynb")
-        tutobooks.py_to_nb(py_path, nb_path, fill_outputs=False)
+        attributes = tutobooks.py_to_nb(py_path, nb_path, fill_outputs=False)
         tutobooks.py_to_md(py_path, nb_path, md_path, img_dir, working_dir=working_dir)
         md_content = open(md_path).read()
         github_repo_dir = str(EXAMPLES_GH_LOCATION / folder)
         site_img_dir = os.path.join("img", "examples", folder, name)
+        spaces_dir = attributes["spaces_dir"]
         md_content = self.preprocess_tutobook_md_source(
-            md_content, name + ".py", github_repo_dir, img_dir, site_img_dir
+            md_content, name + ".py", github_repo_dir, img_dir, site_img_dir, spaces_dir
         )
         open(md_path, "w").write(md_content)
 
@@ -264,13 +275,14 @@ class KerasIO:
         md_path = md_dir / (name + ".md")
         nb_path = ipynb_dir / (name + ".ipynb")
 
-        tutobooks.py_to_nb(py_path, nb_path, fill_outputs=False)
+        attributes = tutobooks.py_to_nb(py_path, nb_path, fill_outputs=False)
         tutobooks.py_to_md(py_path, nb_path, md_path, img_dir, working_dir=working_dir)
         md_content = open(md_path).read()
         github_repo_dir = str(GUIDES_GH_LOCATION)
         site_img_dir = "img/guides/" + name
+        spaces_dir = attributes["spaces_dir"]
         md_content = self.preprocess_tutobook_md_source(
-            md_content, name + ".py", github_repo_dir, img_dir, site_img_dir
+            md_content, name + ".py", github_repo_dir, img_dir, site_img_dir, spaces_dir
         )
         open(md_path, "w").write(md_content)
 

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -151,7 +151,7 @@ class KerasIO:
             button_lines.append(
             '<span class="k-dot">•</span>'
             + '<img class="k-inline-icon" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg"/>'
-            + "[**Try on Spaces**](https://huggingface.co/"
+            + "[**Try on Spaces**](https://huggingface.co/spaces/"
             + spaces_dir
             + ")"
             + "\n"

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -147,7 +147,7 @@ class KerasIO:
             + fname
             + ") "
         ]
-        if spaces_dir != "None":
+        if spaces_dir != None:
             button_lines.append(
             '<span class="k-dot">•</span>'
             + '<img class="k-inline-icon" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg"/>'

--- a/scripts/tutobooks.py
+++ b/scripts/tutobooks.py
@@ -203,6 +203,7 @@ def py_to_nb(py_path, nb_path, fill_outputs=False):
                     else:
                         print("Removing created file:", fname)
                         os.remove(fpath)
+    return attributes
 
 
 def nb_to_md(nb_path, md_path, img_dir, working_dir=None):
@@ -443,7 +444,7 @@ def _get_next_script_element(py):
 
 def _parse_header(header):
     lines = header.split("\n")
-    if len(lines) != 5:
+    if len(lines) != 6:
         raise ValueError("Invalid header, it should be only 5 lines.")
     title = lines[0][len("Title: ") :]
     author_line = lines[1]
@@ -456,6 +457,7 @@ def _parse_header(header):
     date_created = lines[2][len("Date created: ") :]
     last_modified = lines[3][len("Last modified: ") :]
     description = lines[4][len("Description: ") :]
+    spaces_dir = lines[5][len("Spaces ID: ") :]
     return {
         "title": title,
         "author": author,
@@ -463,6 +465,7 @@ def _parse_header(header):
         "date_created": date_created,
         "last_modified": last_modified,
         "description": description,
+        "spaces_dir": spaces_dir
     }
 
 

--- a/scripts/tutobooks.py
+++ b/scripts/tutobooks.py
@@ -444,8 +444,8 @@ def _get_next_script_element(py):
 
 def _parse_header(header):
     lines = header.split("\n")
-    if len(lines) != 6:
-        raise ValueError("Invalid header, it should be only 5 lines.")
+    if not (len(lines) == 5 or len(lines) == 6):
+        raise ValueError("Invalid header, it should be 5 or 6 lines.")
     title = lines[0][len("Title: ") :]
     author_line = lines[1]
     if author_line.startswith("Authors"):
@@ -457,7 +457,10 @@ def _parse_header(header):
     date_created = lines[2][len("Date created: ") :]
     last_modified = lines[3][len("Last modified: ") :]
     description = lines[4][len("Description: ") :]
-    spaces_dir = lines[5][len("Spaces ID: ") :]
+    if len(lines) == 6:
+        spaces_dir = lines[5][len("Spaces ID: ") :]
+    else:
+        spaces_dir = None
     return {
         "title": title,
         "author": author,

--- a/scripts/tutobooks.py
+++ b/scripts/tutobooks.py
@@ -458,7 +458,7 @@ def _parse_header(header):
     last_modified = lines[3][len("Last modified: ") :]
     description = lines[4][len("Description: ") :]
     if len(lines) == 6:
-        spaces_dir = lines[5][len("Spaces ID: ") :]
+        spaces_dir = lines[5][len("Space ID: ") :]
     else:
         spaces_dir = None
     return {


### PR DESCRIPTION
Hello 👋 
This PR addresses issue in #793. 
I changed `tutobooks.py` and `autogen.py` so that when you add a Huggingface Space ID (that has a demo of the Keras example) it will put a button "Try on Spaces" that has the redirection to the hosted demo. The contributors can enter the Space ID to header like: "merve/keras_example" and the files necessary to host the example will have it. The Space ID part of header is completely optional. 

It looks like below (except for the underline 😅), in this PR I also added the generated files for Bidirectional LSTM with IMDB example so you can see how it works.
If you don't want this I can also add it at the end of the Introduction section in markdown.
We've done 34 demos hosted on [Spaces](https://huggingface.co/keras-io),  I can add all of them to the notebooks when this is approved.
Example use:
```
"""
Title: Bidirectional LSTM on IMDB
Author: [fchollet](https://twitter.com/fchollet)
Date created: 2020/05/03
Last modified: 2020/05/03
Description: Train a 2-layer bidirectional LSTM on the IMDB movie review sentiment classification dataset.
Space ID: keras-io/bidirectional_lstm_imdb
"""
```
<img width="989" alt="Ekran Resmi 2022-02-28 17 52 11" src="https://user-images.githubusercontent.com/53175384/156036838-e65387fa-1345-4685-9884-4d47843ec7b9.png">
