### PR TITLE
Update formatting of Applications page

### DIFF
--- a/templates/api/applications/index.md
+++ b/templates/api/applications/index.md
@@ -40,30 +40,31 @@ then any model loaded from this repository will get built according to the Tenso
 | [EfficientNetB5](efficientnet/#efficientnetb5-function) | 118 | 83.6% | 96.7% | 30.6M | 312 | 579.2 | 25.3 |
 | [EfficientNetB6](efficientnet/#efficientnetb6-function) | 166 | 84.0% | 96.8% | 43.3M | 360 | 958.1 | 40.4 |
 | [EfficientNetB7](efficientnet/#efficientnetb7-function) | 256 | 84.3% | 97.0% | 66.7M | 438 | 1578.9 | 61.6 | 
-| [EfficientNetV2B0](efficientnet_v2/#efficientnetv2b0-function) | 29 | 0.787 | 0.943 | 7,200,312 | - | - | - |
-| [EfficientNetV2B1](efficientnet_v2/#efficientnetv2b1-function) | 34 | 0.798 | 0.950 | 8,212,124 | - | - | - |
-| [EfficientNetV2B2](efficientnet_v2/#efficientnetv2b2-function) | 42 | 0.805 | 0.951 | 10,178,374 | - | - | - |
-| [EfficientNetV2B3](efficientnet_v2/#efficientnetv2b3-function) | 59 | 0.820 | 0.958 | 14,467,622 | - | - | - |
-| [EfficientNetV2S](efficientnet_v2/#efficientnetv2s-function) | 88 | 0.839 | 0.967 | 21,612,360 | - | - | - |
-| [EfficientNetV2M](efficientnet_v2/#efficientnetv2m-function) | 220 | 0.853 | 0.974 | 54,431,388 | - | - | - |
-| [EfficientNetV2L](efficientnet_v2/#efficientnetv2l-function) | 479 | 0.857 | 0.975 | 119,027,848 | - | - | - |
-| [EfficientNetV2B0](efficientnet_v2/#efficientnetv2b0-function) | 29 | 0.787 | 0.943 | 7,200,312 | - | - | - |
-| [EfficientNetV2B1](efficientnet_v2/#efficientnetv2b1-function) | 34 | 0.798 | 0.950 | 8,212,124 | - | - | - |
-| [EfficientNetV2B2](efficientnet_v2/#efficientnetv2b2-function) | 42 | 0.805 | 0.951 | 10,178,374 | - | - | - |
-| [EfficientNetV2B3](efficientnet_v2/#efficientnetv2b3-function) | 59 | 0.820 | 0.958 | 14,467,622 | - | - | - |
-| [EfficientNetV2S](efficientnet_v2/#efficientnetv2s-function) | 88 | 0.839 | 0.967 | 21,612,360 | - | - | - |
-| [EfficientNetV2M](efficientnet_v2/#efficientnetv2m-function) | 220 | 0.853 | 0.974 | 54,431,388 | - | - | - |
-| [EfficientNetV2L](efficientnet_v2/#efficientnetv2l-function) | 479 | 0.857 | 0.975 | 119,027,848 | - | - | - |
-<br>
+| [EfficientNetV2B0](efficientnet_v2/#efficientnetv2b0-function) | 29 | 78.7% | 94.3% | 7.2M | - | - | - |
+| [EfficientNetV2B1](efficientnet_v2/#efficientnetv2b1-function) | 34 | 79.8% | 95.0% | 8.2M | - | - | - |
+| [EfficientNetV2B2](efficientnet_v2/#efficientnetv2b2-function) | 42 | 80.5% | 95.1% | 10.2M | - | - | - |
+| [EfficientNetV2B3](efficientnet_v2/#efficientnetv2b3-function) | 59 | 82.0% | 95.8% | 14.5M | - | - | - |
+| [EfficientNetV2S](efficientnet_v2/#efficientnetv2s-function) | 88 | 83.9% | 96.7% | 21.6M | - | - | - |
+| [EfficientNetV2M](efficientnet_v2/#efficientnetv2m-function) | 220 | 85.3% | 97.4% | 54.4M | - | - | - |
+| [EfficientNetV2L](efficientnet_v2/#efficientnetv2l-function) | 479 | 85.7% | 97.5% | 119.0M | - | - | - |
+| [EfficientNetV2B0](efficientnet_v2/#efficientnetv2b0-function) | 29 | 78.7% | 94.3% | 7.2M | - | - | - |
+| [EfficientNetV2B1](efficientnet_v2/#efficientnetv2b1-function) | 34 | 79.8% | 95.0% | 8.2M | - | - | - |
+| [EfficientNetV2B2](efficientnet_v2/#efficientnetv2b2-function) | 42 | 80.5% | 95.1% | 10.2M | - | - | - |
+| [EfficientNetV2B3](efficientnet_v2/#efficientnetv2b3-function) | 59 | 82.0% | 95.8% | 14.5M | - | - | - |
+| [EfficientNetV2S](efficientnet_v2/#efficientnetv2s-function) | 88 | 83.9% | 96.7% | 21.6M | - | - | - |
+| [EfficientNetV2M](efficientnet_v2/#efficientnetv2m-function) | 220 | 85.3% | 97.4% | 54.4M | - | - | - |
+| [EfficientNetV2L](efficientnet_v2/#efficientnetv2l-function) | 479 | 85.7% | 97.5% | 119.0M | - | - | - |
+
 The top-1 and top-5 accuracy refers to the model's performance on the ImageNet validation dataset.
 
 Depth refers to the topological depth of the network. This includes activation layers, batch normalization layers etc.
 
 Time per inference step is the average of 30 batches and 10 repetitions.
-   - CPU: AMD EPYC Processor (with IBPB) (92 core)
-   - Ram: 1.7T
-   - GPU: Tesla A100
-   - Batch size: 32
+
+- CPU: AMD EPYC Processor (with IBPB) (92 core)
+- RAM: 1.7T
+- GPU: Tesla A100
+- Batch size: 32
 
 Depth counts the number of layers with parameters.
 


### PR DESCRIPTION
- Format Top-1 Accuracy and Top-5 Accuracy as percentages in line with models above. [1]
- Format Parameters count in millions in line with models above. [1]
- Add newline in front of sentence explaining top-1 and top-5 accuracy, so the explanation is outside the table in line with sentences explaining other columns. [2]
- Add newline in front of list of components so its formatted correctly as a list. [2]
- RAM in upper-case. [2]

## 1
![1](https://user-images.githubusercontent.com/8426204/156925031-33d526bb-4ba5-4e2b-8411-bb3019bc97e5.png)

## 2
![2](https://user-images.githubusercontent.com/8426204/156925026-c44d5ce7-a255-42d0-827d-e1d4b59b14a1.png)


