### PR TITLE
Fix Adam() optimizer reference

### DIFF
--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -118,7 +118,7 @@ mnist_digits = np.concatenate([x_train, x_test], axis=0)
 mnist_digits = np.expand_dims(mnist_digits, -1).astype("float32") / 255
 
 vae = VAE(encoder, decoder)
-vae.compile(optimizer=keras.optimizers.Adam())
+vae.compile(optimizer=keras.optimizers.adam_v2.Adam())
 vae.fit(mnist_digits, epochs=30, batch_size=128)
 
 """


### PR DESCRIPTION
`keras.optimizers` v2.8.0 no longer has a direct import of the `Adam` class, it's now in `keras.optimizers.adam_v2` or `keras.optimizer_v2` (which I assume is identical)