### PR TITLE
Fix: Provide reference

### DIFF
--- a/examples/vision/ipynb/shiftvit.ipynb
+++ b/examples/vision/ipynb/shiftvit.ipynb
@@ -901,6 +901,8 @@
    },
    "outputs": [],
    "source": [
+    "# Some code is taken from:\n"
+    "# https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.\n"
     "\n",
     "class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):\n",
     "    \"\"\"A LearningRateSchedule that uses a warmup cosine decay schedule.\"\"\"\n",

--- a/examples/vision/ipynb/shiftvit.ipynb
+++ b/examples/vision/ipynb/shiftvit.ipynb
@@ -901,9 +901,8 @@
    },
    "outputs": [],
    "source": [
-    "# Some code is taken from:\n"
-    "# https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.\n"
-    "\n",
+    "# Some code is taken from:\n",
+    "# https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.\n",
     "class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):\n",
     "    \"\"\"A LearningRateSchedule that uses a warmup cosine decay schedule.\"\"\"\n",
     "\n",

--- a/examples/vision/md/shiftvit.md
+++ b/examples/vision/md/shiftvit.md
@@ -734,7 +734,8 @@ cosine decay.
 
 
 ```python
-
+# Some code is taken from:
+# https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.
 class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses a warmup cosine decay schedule."""
 

--- a/examples/vision/shiftvit.py
+++ b/examples/vision/shiftvit.py
@@ -704,7 +704,8 @@ and then cool down the model with a slowly decaying learning rate. In the warmup
 decay, the learning rate linearly increases for the warmup steps and then decays with a
 cosine decay.
 """
-
+# Some code is taken from:
+# https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.
 
 class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses a warmup cosine decay schedule."""

--- a/examples/vision/shiftvit.py
+++ b/examples/vision/shiftvit.py
@@ -704,9 +704,9 @@ and then cool down the model with a slowly decaying learning rate. In the warmup
 decay, the learning rate linearly increases for the warmup steps and then decays with a
 cosine decay.
 """
+
 # Some code is taken from:
 # https://www.kaggle.com/ashusma/training-rfcx-tensorflow-tpu-effnet-b2.
-
 class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
     """A LearningRateSchedule that uses a warmup cosine decay schedule."""
 


### PR DESCRIPTION
The reference to the warmup cosine was missing. I apologise for not getting to this earlier. Did not mean to plagarise any code. As soon as @sayakpaul noticed it and let me know, I made the changes.

Hope this is taken as my mistake and not otherwise.