### PR TITLE
Fix `transformer_asr.md`'s markdown

### DIFF
--- a/examples/audio/md/transformer_asr.md
+++ b/examples/audio/md/transformer_asr.md
@@ -334,12 +334,13 @@ def get_data(wavs, id_to_text, maxlen=50):
 ```
 
 <div class="k-default-codeblock">
+
 ```
 Downloading data from https://data.keithito.com/data/speech/LJSpeech-1.1.tar.bz2
 2748579840/2748572632 [==============================] - 57s 0us/step
-
 ```
 </div>
+
 ---
 ## Preprocess the dataset
 
@@ -428,11 +429,12 @@ val_ds = create_tf_dataset(test_data, bs=4)
 ```
 
 <div class="k-default-codeblock">
-```
-vocab size 34
 
 ```
+vocab size 34
+```
 </div>
+
 ---
 ## Callbacks to display predictions
 


### PR DESCRIPTION
Leave a line feed before starting a `snippet` inside `html` tags because markdown formatter doesn't identify `snippets` joined with `html` tags as a valid markdown syntax.

## Before

![Screenshot from 2022-04-17 12-03-46](https://user-images.githubusercontent.com/70365318/163703609-0fd682cd-946b-4635-b3ac-258887934c30.png)
![Screenshot from 2022-04-17 12-04-15](https://user-images.githubusercontent.com/70365318/163703617-7fec49d4-692b-4b90-8516-0d22edc16608.png)

## After

![Screenshot from 2022-04-17 12-04-39](https://user-images.githubusercontent.com/70365318/163703623-8508ef6f-9f05-4e99-86a0-002a4955af76.png)
![Screenshot from 2022-04-17 12-04-57](https://user-images.githubusercontent.com/70365318/163703628-fd0ce0d8-1a4f-411d-afb7-fb76c78739ef.png)

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>