### PR TITLE
Stop replacing lang syntax for fenced markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pygments>=2.7.4
 jinja2
-markdown
+markdown>=3.3
 requests
 mdx_truly_sane_lists
 sphinx~=3.0.3

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -686,10 +686,6 @@ class KerasIO:
         for key, value in replacements.items():
             md_content = md_content.replace(key, value)
 
-        # Convert ```lang notation to the hilite syntax
-        md_content = md_content.replace("```python\n", "```\n:::python\n")
-        md_content = md_content.replace("```shell\n", "```\n:::none\n")
-
         html_content = markdown.markdown(
             md_content,
             extensions=["fenced_code", "tables", "codehilite", "mdx_truly_sane_lists",],


### PR DESCRIPTION
The CodeHilite to the markdown renderer now supports the usual syntax,
and newer version appear to no longer supports the
`::: syntax`.

I'm not sure exactly when this happened, but we can just depend on
the latest version of python-markdown.