### PR TITLE
Fix vq_vae.py

### DIFF
--- a/examples/generative/ipynb/vq_vae.ipynb
+++ b/examples/generative/ipynb/vq_vae.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "\n",
     "def get_decoder(latent_dim=16):\n",
-    "    latent_inputs = keras.Input(shape=get_encoder().output.shape[1:])\n",
+    "    latent_inputs = keras.Input(shape=get_encoder(latent_dim).output.shape[1:])\n",
     "    x = layers.Conv2DTranspose(64, 3, activation=\"relu\", strides=2, padding=\"same\")(\n",
     "        latent_inputs\n",
     "    )\n",

--- a/examples/generative/md/vq_vae.md
+++ b/examples/generative/md/vq_vae.md
@@ -169,7 +169,7 @@ def get_encoder(latent_dim=16):
 
 
 def get_decoder(latent_dim=16):
-    latent_inputs = keras.Input(shape=get_encoder().output.shape[1:])
+    latent_inputs = keras.Input(shape=get_encoder(latent_dim).output.shape[1:])
     x = layers.Conv2DTranspose(64, 3, activation="relu", strides=2, padding="same")(
         latent_inputs
     )

--- a/examples/generative/vq_vae.py
+++ b/examples/generative/vq_vae.py
@@ -162,7 +162,7 @@ def get_encoder(latent_dim=16):
 
 
 def get_decoder(latent_dim=16):
-    latent_inputs = keras.Input(shape=get_encoder().output.shape[1:])
+    latent_inputs = keras.Input(shape=get_encoder(latent_dim).output.shape[1:])
     x = layers.Conv2DTranspose(64, 3, activation="relu", strides=2, padding="same")(
         latent_inputs
     )


### PR DESCRIPTION
There was a problem with the function get_decoder, because when it wants to get the output shape of the encoder, it directly calls the get_encoder function without parameter, so it assumes that the current latent_dim is the default latent_dim: 16. So, to address this issue, it can just pass the current latent_dim parameter when calling get_encoder function.