### PR TITLE
Change assign variable dataset spilit

### DIFF
--- a/guides/functional_api.py
+++ b/guides/functional_api.py
@@ -142,7 +142,7 @@ fit the model on the data (while monitoring performance on a validation split),
 then evaluate the model on the test data:
 """
 
-(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+(x_train, x_test), (y_train, y_test) = keras.datasets.mnist.load_data()
 
 x_train = x_train.reshape(60000, 784).astype("float32") / 255
 x_test = x_test.reshape(10000, 784).astype("float32") / 255


### PR DESCRIPTION
Problem when i excute code line 145, a little bit bug load_data(), if using (x_train, y_train), (x_test, y_test) will return y_train.shape = (60000,). It F so we need convert to (x_train, x_test), (y_train, y_test). 
Hopefully check it and merge it! Thanks.