### PR TITLE
Updated direct link for Custom Objects

### DIFF
--- a/guides/ipynb/serialization_and_saving.ipynb
+++ b/guides/ipynb/serialization_and_saving.ipynb
@@ -230,7 +230,7 @@
     "Nevertheless, it is always a good practice to define the `get_config`\n",
     "and `from_config` methods when writing a custom model or layer class.\n",
     "This allows you to easily update the computation later if needed.\n",
-    "See the section about [Custom objects](#custom-objects)\n",
+    "See the section about [Custom objects](#custom_objects)\n",
     "for more information.\n",
     "\n",
     "Example:"
@@ -399,7 +399,7 @@
     "- The *computation graph of custom objects* such as custom layers\n",
     "is not included in the saved file. At loading time, Keras will need access\n",
     "to the Python classes/functions of these objects in order to reconstruct the model.\n",
-    "See [Custom objects](#custom-objects).\n",
+    "See [Custom objects](#custom_objects).\n",
     "- Does not support preprocessing layers."
    ]
   },

--- a/guides/md/serialization_and_saving.md
+++ b/guides/md/serialization_and_saving.md
@@ -180,7 +180,7 @@ and used for inference.
 Nevertheless, it is always a good practice to define the `get_config`
 and `from_config` methods when writing a custom model or layer class.
 This allows you to easily update the computation later if needed.
-See the section about [Custom objects](#custom-objects)
+See the section about [Custom objects](#custom_objects)
 for more information.
 
 Example:
@@ -326,7 +326,7 @@ these losses & metrics are kept, since they are part of the `call` method of the
 - The *computation graph of custom objects* such as custom layers
 is not included in the saved file. At loading time, Keras will need access
 to the Python classes/functions of these objects in order to reconstruct the model.
-See [Custom objects](#custom-objects).
+See [Custom objects](#custom_objects).
 - Does not support preprocessing layers.
 
 ---

--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -162,7 +162,7 @@ and used for inference.
 Nevertheless, it is always a good practice to define the `get_config`
 and `from_config` methods when writing a custom model or layer class.
 This allows you to easily update the computation later if needed.
-See the section about [Custom objects](#custom-objects)
+See the section about [Custom objects](#custom_objects)
 for more information.
 
 Example:
@@ -295,7 +295,7 @@ these losses & metrics are kept, since they are part of the `call` method of the
 - The *computation graph of custom objects* such as custom layers
 is not included in the saved file. At loading time, Keras will need access
 to the Python classes/functions of these objects in order to reconstruct the model.
-See [Custom objects](#custom-objects).
+See [Custom objects](#custom_objects).
 - Does not support preprocessing layers.
 
 """


### PR DESCRIPTION
Updated direct link to access `Custom Objects` definition by changing #custom-objects to #custom_objects in the given link.