### PR TITLE
Update KerasCV tutorial to also install tf-nightly

### DIFF
--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -28,7 +28,7 @@ This tutorial requires you to have KerasCV installed. It also requires installin
 the TensorFlow nightly at this time.
 
 ```shell
-pip install tf-nightly
+pip install -U tf-nightly
 pip install keras-cv
 ```
 

--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -28,7 +28,7 @@ This tutorial requires you to have KerasCV installed. It also requires installin
 the TensorFlow nightly at this time.
 
 ```shell
-pip install -U tf-nightly
+pip install tensorflow==2.9.0
 pip install keras-cv
 ```
 

--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -24,9 +24,11 @@ through the process of customizing a KerasCV data augmentation pipeline.
 """
 ## Imports & setup
 
-This tutorial requires you to have KerasCV installed:
+This tutorial requires you to have KerasCV installed. It also requires installing
+the TensorFlow nightly at this time.
 
 ```shell
+pip install tf-nightly
 pip install keras-cv
 ```
 


### PR DESCRIPTION
This is (for the time being) required for the BaseImageAugmentationLayer (whose module is only available at nightly).