### PR TITLE
VQ-VAE example: pin tensorflow-probability to last known working version

### DIFF
--- a/examples/generative/ipynb/vq_vae.ipynb
+++ b/examples/generative/ipynb/vq_vae.ipynb
@@ -53,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q tensorflow-probability"
+    "!pip install -q tensorflow-probability==0.13.0"
    ]
   },
   {

--- a/examples/generative/md/vq_vae.md
+++ b/examples/generative/md/vq_vae.md
@@ -36,7 +36,7 @@ TensorFlow Probability, which can be installed using the command below.
 
 
 ```python
-!pip install -q tensorflow-probability
+!pip install -q tensorflow-probability==0.13.0
 ```
 
 ---

--- a/examples/generative/vq_vae.py
+++ b/examples/generative/vq_vae.py
@@ -32,7 +32,7 @@ TensorFlow Probability, which can be installed using the command below.
 """
 
 """shell
-pip install -q tensorflow-probability
+pip install -q tensorflow-probability==0.13.0
 """
 
 """


### PR DESCRIPTION
The usage of the `sample()` method used here from tensorflow-probability doesn't work for any version after 0.13.0 for this particular example. See also: https://stackoverflow.com/questions/69620035/typeerror-dimension-value-must-be-integer-or-none-in-keras-vq-vae-example/72561898#72561898