### PR TITLE
Clarify why TextVectorization works on CPU

### DIFF
--- a/guides/ipynb/preprocessing_layers.ipynb
+++ b/guides/ipynb/preprocessing_layers.ipynb
@@ -190,7 +190,7 @@
     "exist, those can be loaded directly into the lookup tables by passing a path to the\n",
     "vocabulary file in the layer's constructor arguments.\n",
     "\n",
-    "Here's an example where we instantiate a `StringLookup` layer with precomputed vocabulary:"
+    "Here's an example where you instantiate a `StringLookup` layer with precomputed vocabulary:"
    ]
   },
   {
@@ -229,7 +229,7 @@
     "\n",
     "With this option, preprocessing will happen on device, synchronously with the rest of the\n",
     "model execution, meaning that it will benefit from GPU acceleration.\n",
-    "If you're training on GPU, this is the best option for the `Normalization` layer, and for\n",
+    "If you're training on a GPU, this is the best option for the `Normalization` layer, and for\n",
     "all image preprocessing and data augmentation layers.\n",
     "\n",
     "**Option 2:** apply it to your `tf.data.Dataset`, so as to obtain a dataset that yields\n",
@@ -239,7 +239,7 @@
     "dataset = dataset.map(lambda x, y: (preprocessing_layer(x), y))\n",
     "```\n",
     "\n",
-    "With this option, your preprocessing will happen on CPU, asynchronously, and will be\n",
+    "With this option, your preprocessing will happen on a CPU, asynchronously, and will be\n",
     "buffered before going into the model.\n",
     "In addition, if you call `dataset.prefetch(tf.data.AUTOTUNE)` on your dataset,\n",
     "the preprocessing will happen efficiently in parallel with training:\n",
@@ -251,11 +251,15 @@
     "```\n",
     "\n",
     "This is the best option for `TextVectorization`, and all structured data preprocessing\n",
-    "layers. It can also be a good option if you're training on CPU\n",
-    "and you use image preprocessing layers.\n",
+    "layers. It can also be a good option if you're training on a CPU and you use image preprocessing\n",
+    "layers.\n",
     "\n",
-    "**When running on TPU, you should always place preprocessing layers in the `tf.data` pipeline**\n",
-    "(with the exception of `Normalization` and `Rescaling`, which run fine on TPU and are commonly\n",
+    "Note that the `TextVectorization` layer can only be executed on a CPU, as it is mostly a\n",
+    "dictionary lookup operation. Therefore, if you are training your model on a GPU or a TPU,\n",
+    "you should put the `TextVectorization` layer in the `tf.data` pipeline to get the best performance.\n",
+    "\n",
+    "**When running on a TPU, you should always place preprocessing layers in the `tf.data` pipeline**\n",
+    "(with the exception of `Normalization` and `Rescaling`, which run fine on a TPU and are commonly\n",
     "used as the first layer is an image model)."
    ]
   },
@@ -307,7 +311,7 @@
     "[tf.distribute](https://www.tensorflow.org/api_docs/python/tf/distribute) API\n",
     "for running training across multiple machines.\n",
     "\n",
-    "In general, preprocessing layers should be placed inside a `strategy.scope()`\n",
+    "In general, preprocessing layers should be placed inside a `tf.distribute.Strategy.scope()`\n",
     "and called either inside or before the model as discussed above.\n",
     "\n",
     "```python\n",
@@ -317,9 +321,9 @@
     "    dense_layer = tf.keras.layers.Dense(16)\n",
     "```\n",
     "\n",
-    "For more details, refer to the\n",
-    "[preprocessing section](https://www.tensorflow.org/tutorials/distribute/input#data_preprocessing)\n",
-    "of the distributed input guide."
+    "For more details, refer to the _Data preprocessing_ section\n",
+    "of the [Distributed input](https://www.tensorflow.org/tutorials/distribute/input)\n",
+    "tutorial."
    ]
   },
   {
@@ -642,7 +646,7 @@
     "colab_type": "text"
    },
    "source": [
-    "### Encoding text as a dense matrix of ngrams with multi-hot encoding\n",
+    "### Encoding text as a dense matrix of N-grams with multi-hot encoding\n",
     "\n",
     "This is how you should preprocess text to be passed to a `Dense` layer."
    ]
@@ -712,7 +716,7 @@
     "colab_type": "text"
    },
    "source": [
-    "### Encoding text as a dense matrix of ngrams with TF-IDF weighting\n",
+    "### Encoding text as a dense matrix of N-grams with TF-IDF weighting\n",
     "\n",
     "This is an alternative way of preprocessing text before passing it to a `Dense` layer."
    ]
@@ -790,11 +794,11 @@
     "You may find yourself working with a very large vocabulary in a `TextVectorization`, a `StringLookup` layer,\n",
     "or an `IntegerLookup` layer. Typically, a vocabulary larger than 500MB would be considered \"very large\".\n",
     "\n",
-    "In such case, for best performance, you should avoid using `adapt()`.\n",
+    "In such a case, for best performance, you should avoid using `adapt()`.\n",
     "Instead, pre-compute your vocabulary in advance\n",
     "(you could use Apache Beam or TF Transform for this)\n",
     "and store it in a file. Then load the vocabulary into the layer at construction\n",
-    "time by passing the filepath as the `vocabulary` argument.\n",
+    "time by passing the file path as the `vocabulary` argument.\n",
     "\n",
     "\n",
     "### Using lookup layers on a TPU pod or with `ParameterServerStrategy`.\n",


### PR DESCRIPTION
As discussed with @fchollet @mattdangerw @MarkDaoust 

This PR introduces the following improvements:

- Clarify that the Keras `TextVectorization` layer should be used as part of a `tf.data` input pipeline (runs only on CPUs, won't utilize hardware acceleration if included inside a `Model`, affecting performance).
- Perform some minor linting.

---

- Guide: Working with preprocessing layers (https://keras.io/guides/preprocessing_layers/, https://www.tensorflow.org/guide/keras/preprocessing_layers)
- Section: Preprocessing data before the model or inside the model

