### PR TITLE
Update mnist_convnet.py

### DIFF
--- a/examples/vision/mnist_convnet.py
+++ b/examples/vision/mnist_convnet.py
@@ -66,7 +66,7 @@ model.summary()
 batch_size = 128
 epochs = 15
 
-model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
+model.compile(loss="sparse_categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
 
 model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_split=0.1)
 


### PR DESCRIPTION
Fix error change from loss function from categorical_crossentropy to sparse_categorical_crossentropy. Without this example dont run training. For users who just start learn keras that error causes frustration