### PR TITLE
Refactor VQ-VAE example to work with recent versions of tensorflow-probability

### DIFF
--- a/examples/generative/ipynb/vq_vae.ipynb
+++ b/examples/generative/ipynb/vq_vae.ipynb
@@ -53,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q tensorflow-probability==0.13.0"
+    "!pip install -q tensorflow-probability"
    ]
   },
   {
@@ -739,10 +739,10 @@
    "source": [
     "# Create a mini sampler model.\n",
     "inputs = layers.Input(shape=pixel_cnn.input_shape[1:])\n",
-    "x = pixel_cnn(inputs, training=False)\n",
-    "dist = tfp.distributions.Categorical(logits=x)\n",
-    "sampled = dist.sample()\n",
-    "sampler = keras.Model(inputs, sampled)"
+    "layers = pixel_cnn(inputs, training=False)\n",
+    "categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)\n",
+    "layers = categorical_layer(layers)\n",
+    "sampler = keras.Model(inputs, layers)"
    ]
   },
   {

--- a/examples/generative/ipynb/vq_vae.ipynb
+++ b/examples/generative/ipynb/vq_vae.ipynb
@@ -741,8 +741,8 @@
     "inputs = layers.Input(shape=pixel_cnn.input_shape[1:])\n",
     "outputs = pixel_cnn(inputs, training=False)\n",
     "categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)\n",
-    "layers = categorical_layer(outputs)\n",
-    "sampler = keras.Model(inputs, layers)"
+    "outputs = categorical_layer(outputs)\n",
+    "sampler = keras.Model(inputs, outputs)"
    ]
   },
   {

--- a/examples/generative/ipynb/vq_vae.ipynb
+++ b/examples/generative/ipynb/vq_vae.ipynb
@@ -739,9 +739,9 @@
    "source": [
     "# Create a mini sampler model.\n",
     "inputs = layers.Input(shape=pixel_cnn.input_shape[1:])\n",
-    "layers = pixel_cnn(inputs, training=False)\n",
+    "outputs = pixel_cnn(inputs, training=False)\n",
     "categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)\n",
-    "layers = categorical_layer(layers)\n",
+    "layers = categorical_layer(outputs)\n",
     "sampler = keras.Model(inputs, layers)"
    ]
   },

--- a/examples/generative/md/vq_vae.md
+++ b/examples/generative/md/vq_vae.md
@@ -795,9 +795,9 @@ them to our decoder to generate novel images.
 ```python
 # Create a mini sampler model.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
-layers = pixel_cnn(inputs, training=False)
+outputs = pixel_cnn(inputs, training=False)
 categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
-layers = categorical_layer(layers)
+layers = categorical_layer(outputs)
 sampler = keras.Model(inputs, layers)
 ```
 

--- a/examples/generative/md/vq_vae.md
+++ b/examples/generative/md/vq_vae.md
@@ -797,8 +797,8 @@ them to our decoder to generate novel images.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
 outputs = pixel_cnn(inputs, training=False)
 categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
-layers = categorical_layer(outputs)
-sampler = keras.Model(inputs, layers)
+outputs = categorical_layer(outputs)
+sampler = keras.Model(inputs, outputs)
 ```
 
 We now construct a prior to generate images. Here, we will generate 10 images.

--- a/examples/generative/md/vq_vae.md
+++ b/examples/generative/md/vq_vae.md
@@ -36,7 +36,7 @@ TensorFlow Probability, which can be installed using the command below.
 
 
 ```python
-!pip install -q tensorflow-probability==0.13.0
+!pip install -q tensorflow-probability
 ```
 
 ---
@@ -795,10 +795,10 @@ them to our decoder to generate novel images.
 ```python
 # Create a mini sampler model.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
-x = pixel_cnn(inputs, training=False)
-dist = tfp.distributions.Categorical(logits=x)
-sampled = dist.sample()
-sampler = keras.Model(inputs, sampled)
+layers = pixel_cnn(inputs, training=False)
+categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
+layers = categorical_layer(layers)
+sampler = keras.Model(inputs, layers)
 ```
 
 We now construct a prior to generate images. Here, we will generate 10 images.

--- a/examples/generative/vq_vae.py
+++ b/examples/generative/vq_vae.py
@@ -495,8 +495,8 @@ them to our decoder to generate novel images.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
 outputs = pixel_cnn(inputs, training=False)
 categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
-layers = categorical_layer(outputs)
-sampler = keras.Model(inputs, layers)
+outputs = categorical_layer(outputs)
+sampler = keras.Model(inputs, outputs)
 
 """
 We now construct a prior to generate images. Here, we will generate 10 images.

--- a/examples/generative/vq_vae.py
+++ b/examples/generative/vq_vae.py
@@ -493,9 +493,9 @@ them to our decoder to generate novel images.
 
 # Create a mini sampler model.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
-layers = pixel_cnn(inputs, training=False)
+outputs = pixel_cnn(inputs, training=False)
 categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
-layers = categorical_layer(layers)
+layers = categorical_layer(outputs)
 sampler = keras.Model(inputs, layers)
 
 """

--- a/examples/generative/vq_vae.py
+++ b/examples/generative/vq_vae.py
@@ -32,7 +32,7 @@ TensorFlow Probability, which can be installed using the command below.
 """
 
 """shell
-pip install -q tensorflow-probability==0.13.0
+pip install -q tensorflow-probability
 """
 
 """
@@ -493,10 +493,10 @@ them to our decoder to generate novel images.
 
 # Create a mini sampler model.
 inputs = layers.Input(shape=pixel_cnn.input_shape[1:])
-x = pixel_cnn(inputs, training=False)
-dist = tfp.distributions.Categorical(logits=x)
-sampled = dist.sample()
-sampler = keras.Model(inputs, sampled)
+layers = pixel_cnn(inputs, training=False)
+categorical_layer = tfp.layers.DistributionLambda(tfp.distributions.Categorical)
+layers = categorical_layer(layers)
+sampler = keras.Model(inputs, layers)
 
 """
 We now construct a prior to generate images. Here, we will generate 10 images.

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -41,7 +41,7 @@ GUIDES_GH_LOCATION = Path("keras-team") / "keras-io" / "blob" / "master" / "guid
 PROJECT_URL = {
     "keras": "https://github.com/keras-team/keras/tree/v2.9.0/",
     "keras_tuner": "https://github.com/keras-team/keras-tuner/tree/1.1.2/",
-    "keras_cv": "https://github.com/keras-team/keras-cv/tree/v0.2.6/",
+    "keras_cv": "https://github.com/keras-team/keras-cv/tree/v0.2.7/",
     "keras_nlp": "https://github.com/keras-team/keras-nlp/tree/v0.2.0/",
 }
 


### PR DESCRIPTION
This is a follow-up of #911 
With help from Christopher Suter, this removes the necessity for pinning the tensorflow-probability package, see https://github.com/tensorflow/probability/issues/1576 for the help he provided.

I took the liberty to rename the `x` variable to `layers`, which I believe to be more apt.