### PR TITLE
Add model and space link for melgan_spectrogram_inversion, mpnn-molecular-graphs, wgan-graphs

### DIFF
--- a/examples/audio/ipynb/melgan_spectrogram_inversion.ipynb
+++ b/examples/audio/ipynb/melgan_spectrogram_inversion.ipynb
@@ -255,8 +255,7 @@
     "                \"freq_max\": self.freq_max,\n",
     "            }\n",
     "        )\n",
-    "        return config\n",
-    ""
+    "        return config\n"
    ]
   },
   {
@@ -322,8 +321,7 @@
     "    )(lrelu5)\n",
     "    add3 = layers.Add()([c6, add2])\n",
     "\n",
-    "    return add3\n",
-    ""
+    "    return add3\n"
    ]
   },
   {
@@ -364,8 +362,7 @@
     "    lrelu1 = layers.LeakyReLU()(conv_t)\n",
     "    res_stack = residual_stack(lrelu1, conv_dim)\n",
     "    lrelu2 = layers.LeakyReLU()(res_stack)\n",
-    "    return lrelu2\n",
-    ""
+    "    return lrelu2\n"
    ]
   },
   {
@@ -418,8 +415,7 @@
     "    conv7 = addon_layers.WeightNormalization(\n",
     "        layers.Conv1D(1, 3, 1, \"same\"), data_init=False\n",
     "    )(lrelu6)\n",
-    "    return [lrelu1, lrelu2, lrelu3, lrelu4, lrelu5, lrelu6, conv7]\n",
-    ""
+    "    return [lrelu1, lrelu2, lrelu3, lrelu4, lrelu5, lrelu6, conv7]\n"
    ]
   },
   {
@@ -598,8 +594,7 @@
     "\n",
     "    # Calculating the final discriminator loss after scaling\n",
     "    disc_loss = tf.reduce_mean(real_loss) + tf.reduce_mean(fake_loss)\n",
-    "    return disc_loss\n",
-    ""
+    "    return disc_loss\n"
    ]
   },
   {
@@ -698,8 +693,7 @@
     "        return {\n",
     "            \"gen_loss\": self.gen_loss_tracker.result(),\n",
     "            \"disc_loss\": self.disc_loss_tracker.result(),\n",
-    "        }\n",
-    ""
+    "        }\n"
    ]
   },
   {
@@ -827,7 +821,13 @@
     "understand the reasoning behind the architecture and training process\n",
     "2. For in-depth understanding of the feature matching loss, you can refer to [Improved\n",
     "Techniques for Training GANs](https://arxiv.org/pdf/1606.03498v1.pdf) (Tim Salimans et\n",
-    "al.)."
+    "al.).\n",
+    "\n",
+    "Example available on HuggingFace\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/keras-io/MelGAN-spectrogram-inversion) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/spaces/keras-io/MelGAN-spectrogram-inversion) |"
    ]
   }
  ],

--- a/examples/audio/md/melgan_spectrogram_inversion.md
+++ b/examples/audio/md/melgan_spectrogram_inversion.md
@@ -943,3 +943,9 @@ understand the reasoning behind the architecture and training process
 2. For in-depth understanding of the feature matching loss, you can refer to [Improved
 Techniques for Training GANs](https://arxiv.org/pdf/1606.03498v1.pdf) (Tim Salimans et
 al.).
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/keras-io/MelGAN-spectrogram-inversion) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/spaces/keras-io/MelGAN-spectrogram-inversion) |

--- a/examples/audio/melgan_spectrogram_inversion.py
+++ b/examples/audio/melgan_spectrogram_inversion.py
@@ -602,4 +602,10 @@ understand the reasoning behind the architecture and training process
 2. For in-depth understanding of the feature matching loss, you can refer to [Improved
 Techniques for Training GANs](https://arxiv.org/pdf/1606.03498v1.pdf) (Tim Salimans et
 al.).
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/keras-io/MelGAN-spectrogram-inversion) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/spaces/keras-io/MelGAN-spectrogram-inversion) |
 """

--- a/examples/generative/ipynb/wgan-graphs.ipynb
+++ b/examples/generative/ipynb/wgan-graphs.ipynb
@@ -401,10 +401,10 @@
     "[relational graph convolutional layers](https://arxiv.org/abs/1703.06103) implements non-linearly transformed\n",
     "neighborhood aggregations. We can define these layers as follows:\n",
     "\n",
-    "`H^{l+1} = \u03c3(D^{-1} @ A @ H^{l+1} @ W^{l})`\n",
+    "`H^{l+1} = σ(D^{-1} @ A @ H^{l+1} @ W^{l})`\n",
     "\n",
     "\n",
-    "Where `\u03c3` denotes the non-linear transformation (commonly a ReLU activation), `A` the\n",
+    "Where `σ` denotes the non-linear transformation (commonly a ReLU activation), `A` the\n",
     "adjacency tensor, `H^{l}` the feature tensor at the `l:th` layer, `D^{-1}` the inverse\n",
     "diagonal degree tensor of `A`, and `W^{l}` the trainable weight tensor at the `l:th`\n",
     "layer. Specifically, for each bond type (relation), the degree tensor expresses, in the\n",
@@ -414,8 +414,7 @@
     "WGAN without normalization seems to work just fine. Furthermore, in contrast to the\n",
     "[original paper](https://arxiv.org/abs/1703.06103), no self-loop is defined, as we don't\n",
     "want to train the generator to predict \"self-bonding\".\n",
-    "\n",
-    ""
+    "\n"
    ]
   },
   {
@@ -648,8 +647,7 @@
     "        return tf.reduce_mean(\n",
     "            tf.reduce_mean(grads_adjacency_penalty, axis=(-2, -1))\n",
     "            + tf.reduce_mean(grads_features_penalty, axis=(-1))\n",
-    "        )\n",
-    ""
+    "        )\n"
    ]
   },
   {
@@ -742,7 +740,13 @@
     "molecules (for instance, to optimize solubility or protein-binding of an existing\n",
     "molecule). For that however, a reconstruction loss would likely be needed, which is\n",
     "tricky to implement as there's no easy and obvious way to compute similarity between two\n",
-    "molecular graphs."
+    "molecular graphs.\n",
+    "\n",
+    "Example available on HuggingFace\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-wgan%20graphs-black.svg)](https://huggingface.co/keras-io/wgan-molecular-graphs) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-wgan%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/Generating-molecular-graphs-by-WGAN-GP) |"
    ]
   }
  ],

--- a/examples/generative/md/wgan-graphs.md
+++ b/examples/generative/md/wgan-graphs.md
@@ -761,3 +761,9 @@ molecules (for instance, to optimize solubility or protein-binding of an existin
 molecule). For that however, a reconstruction loss would likely be needed, which is
 tricky to implement as there's no easy and obvious way to compute similarity between two
 molecular graphs.
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-wgan%20graphs-black.svg)](https://huggingface.co/keras-io/wgan-molecular-graphs) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-wgan%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/Generating-molecular-graphs-by-WGAN-GP) |

--- a/examples/generative/wgan-graphs.py
+++ b/examples/generative/wgan-graphs.py
@@ -603,4 +603,10 @@ molecules (for instance, to optimize solubility or protein-binding of an existin
 molecule). For that however, a reconstruction loss would likely be needed, which is
 tricky to implement as there's no easy and obvious way to compute similarity between two
 molecular graphs.
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-wgan%20graphs-black.svg)](https://huggingface.co/keras-io/wgan-molecular-graphs) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-wgan%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/Generating-molecular-graphs-by-WGAN-GP) |
 """

--- a/examples/graph/ipynb/mpnn-molecular-graphs.ipynb
+++ b/examples/graph/ipynb/mpnn-molecular-graphs.ipynb
@@ -282,8 +282,7 @@
     "        \"bond_type\": {\"single\", \"double\", \"triple\", \"aromatic\"},\n",
     "        \"conjugated\": {True, False},\n",
     "    }\n",
-    ")\n",
-    ""
+    ")\n"
    ]
   },
   {
@@ -432,8 +431,7 @@
     "print(\"Graph (including self-loops):\")\n",
     "print(\"\\tatom features\\t\", graph[0].shape)\n",
     "print(\"\\tbond features\\t\", graph[1].shape)\n",
-    "print(\"\\tpair indices\\t\", graph[2].shape)\n",
-    ""
+    "print(\"\\tpair indices\\t\", graph[2].shape)\n"
    ]
   },
   {
@@ -492,8 +490,7 @@
     "    dataset = tf.data.Dataset.from_tensor_slices((X, (y)))\n",
     "    if shuffle:\n",
     "        dataset = dataset.shuffle(1024)\n",
-    "    return dataset.batch(batch_size).map(prepare_batch, -1).prefetch(-1)\n",
-    ""
+    "    return dataset.batch(batch_size).map(prepare_batch, -1).prefetch(-1)\n"
    ]
   },
   {
@@ -609,8 +606,7 @@
     "            atom_features_updated, _ = self.update_step(\n",
     "                atom_features_aggregated, atom_features_updated\n",
     "            )\n",
-    "        return atom_features_updated\n",
-    ""
+    "        return atom_features_updated\n"
    ]
   },
   {
@@ -699,8 +695,7 @@
     "        attention_output = self.attention(x, x, attention_mask=padding_mask)\n",
     "        proj_input = self.layernorm_1(x + attention_output)\n",
     "        proj_output = self.layernorm_2(proj_input + self.dense_proj(proj_input))\n",
-    "        return self.average_pooling(proj_output)\n",
-    ""
+    "        return self.average_pooling(proj_output)\n"
    ]
   },
   {
@@ -844,7 +839,13 @@
     "In this tutorial, we demonstarted a message passing neural network (MPNN) to\n",
     "predict blood-brain barrier permeability (BBBP) for a number of different molecules. We\n",
     "first had to construct graphs from SMILES, then build a Keras model that could\n",
-    "operate on these graphs, and finally train the model to make the predictions."
+    "operate on these graphs, and finally train the model to make the predictions.\n",
+    "\n",
+    "Example available on HuggingFace\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/keras-io/MPNN-for-molecular-property-prediction) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/molecular-property-prediction) |"
    ]
   }
  ],

--- a/examples/graph/md/mpnn-molecular-graphs.md
+++ b/examples/graph/md/mpnn-molecular-graphs.md
@@ -896,3 +896,9 @@ In this tutorial, we demonstarted a message passing neural network (MPNN) to
 predict blood-brain barrier permeability (BBBP) for a number of different molecules. We
 first had to construct graphs from SMILES, then build a Keras model that could
 operate on these graphs, and finally train the model to make the predictions.
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/keras-io/MPNN-for-molecular-property-prediction) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/molecular-property-prediction) |

--- a/examples/graph/mpnn-molecular-graphs.py
+++ b/examples/graph/mpnn-molecular-graphs.py
@@ -666,4 +666,10 @@ In this tutorial, we demonstarted a message passing neural network (MPNN) to
 predict blood-brain barrier permeability (BBBP) for a number of different molecules. We
 first had to construct graphs from SMILES, then build a Keras model that could
 operate on these graphs, and finally train the model to make the predictions.
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/keras-io/MPNN-for-molecular-property-prediction) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-mpnn%20molecular%20graphs-black.svg)](https://huggingface.co/spaces/keras-io/molecular-property-prediction) |
 """

--- a/templates/examples/audio/melgan_spectrogram_inversion.md
+++ b/templates/examples/audio/melgan_spectrogram_inversion.md
@@ -943,3 +943,9 @@ understand the reasoning behind the architecture and training process
 2. For in-depth understanding of the feature matching loss, you can refer to [Improved
 Techniques for Training GANs](https://arxiv.org/pdf/1606.03498v1.pdf) (Tim Salimans et
 al.).
+
+Example available on HuggingFace
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/keras-io/MelGAN-spectrogram-inversion) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-MelGan%20spectrogram%20inversion-black.svg)](https://huggingface.co/spaces/keras-io/MelGAN-spectrogram-inversion) |


### PR DESCRIPTION
As per the ongoing hugs keras sprint, have updated the following examples:

Audio Data:

- melgan_spectrogram_inversion

Graph Data:

- mpnn-molecular-graphs

Generative Deep Learning

- wgan-graphs

Will be glad to address any issues/changes.