### PR TITLE
Add model and space link for imbalanced_classification, attention_mil, tab_transformer

### DIFF
--- a/examples/structured_data/imbalanced_classification.py
+++ b/examples/structured_data/imbalanced_classification.py
@@ -144,4 +144,11 @@ In the real world, one would put an even higher weight on class 1,
 so as to reflect that False Negatives are more costly than False Positives.
 
 Next time your credit card gets  declined in an online purchase -- this is why.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Imbalanced%20Classification-black.svg)](https://huggingface.co/keras-io/imbalanced_classification) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Imbalanced%20Classification-black.svg)](https://huggingface.co/spaces/keras-io/Credit_Card_Fraud_Detection) |
+
 """

--- a/examples/structured_data/ipynb/imbalanced_classification.ipynb
+++ b/examples/structured_data/ipynb/imbalanced_classification.ipynb
@@ -67,8 +67,7 @@
     "features = np.array(all_features, dtype=\"float32\")\n",
     "targets = np.array(all_targets, dtype=\"uint8\")\n",
     "print(\"features.shape:\", features.shape)\n",
-    "print(\"targets.shape:\", targets.shape)\n",
-    ""
+    "print(\"targets.shape:\", targets.shape)\n"
    ]
   },
   {
@@ -95,8 +94,7 @@
     "val_targets = targets[-num_val_samples:]\n",
     "\n",
     "print(\"Number of training samples:\", len(train_features))\n",
-    "print(\"Number of validation samples:\", len(val_features))\n",
-    ""
+    "print(\"Number of validation samples:\", len(val_features))\n"
    ]
   },
   {
@@ -124,8 +122,7 @@
     ")\n",
     "\n",
     "weight_for_0 = 1.0 / counts[0]\n",
-    "weight_for_1 = 1.0 / counts[1]\n",
-    ""
+    "weight_for_1 = 1.0 / counts[1]\n"
    ]
   },
   {
@@ -150,8 +147,7 @@
     "val_features -= mean\n",
     "std = np.std(train_features, axis=0)\n",
     "train_features /= std\n",
-    "val_features /= std\n",
-    ""
+    "val_features /= std\n"
    ]
   },
   {
@@ -185,8 +181,7 @@
     "        keras.layers.Dense(1, activation=\"sigmoid\"),\n",
     "    ]\n",
     ")\n",
-    "model.summary()\n",
-    ""
+    "model.summary()\n"
    ]
   },
   {
@@ -231,8 +226,7 @@
     "    callbacks=callbacks,\n",
     "    validation_data=(val_features, val_targets),\n",
     "    class_weight=class_weight,\n",
-    ")\n",
-    ""
+    ")\n"
    ]
   },
   {
@@ -252,7 +246,13 @@
     "In the real world, one would put an even higher weight on class 1,\n",
     "so as to reflect that False Negatives are more costly than False Positives.\n",
     "\n",
-    "Next time your credit card gets  declined in an online purchase -- this is why."
+    "Next time your credit card gets  declined in an online purchase -- this is why.\n",
+    "\n",
+    "Example available on HuggingFace.\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Imbalanced%20Classification-black.svg)](https://huggingface.co/keras-io/imbalanced_classification) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Imbalanced%20Classification-black.svg)](https://huggingface.co/spaces/keras-io/Credit_Card_Fraud_Detection) |\n"
    ]
   }
  ],

--- a/examples/structured_data/ipynb/tabtransformer.ipynb
+++ b/examples/structured_data/ipynb/tabtransformer.ipynb
@@ -301,8 +301,7 @@
     "        na_value=\"?\",\n",
     "        shuffle=shuffle,\n",
     "    ).map(prepare_example, num_parallel_calls=tf.data.AUTOTUNE, deterministic=False)\n",
-    "    return dataset.cache()\n",
-    ""
+    "    return dataset.cache()\n"
    ]
   },
   {
@@ -356,8 +355,7 @@
     "\n",
     "    print(f\"Validation accuracy: {round(accuracy * 100, 2)}%\")\n",
     "\n",
-    "    return history\n",
-    ""
+    "    return history\n"
    ]
   },
   {
@@ -393,8 +391,7 @@
     "            inputs[feature_name] = layers.Input(\n",
     "                name=feature_name, shape=(), dtype=tf.string\n",
     "            )\n",
-    "    return inputs\n",
-    ""
+    "    return inputs\n"
    ]
   },
   {
@@ -458,8 +455,7 @@
     "            numerical_feature = tf.expand_dims(inputs[feature_name], -1)\n",
     "            numerical_feature_list.append(numerical_feature)\n",
     "\n",
-    "    return encoded_categorical_feature_list, numerical_feature_list\n",
-    ""
+    "    return encoded_categorical_feature_list, numerical_feature_list\n"
    ]
   },
   {
@@ -488,8 +484,7 @@
     "        mlp_layers.append(layers.Dense(units, activation=activation))\n",
     "        mlp_layers.append(layers.Dropout(dropout_rate))\n",
     "\n",
-    "    return keras.Sequential(mlp_layers, name=name)\n",
-    ""
+    "    return keras.Sequential(mlp_layers, name=name)\n"
    ]
   },
   {
@@ -793,7 +788,13 @@
     "For a scenario where there are a few labeled examples and a large number of unlabeled\n",
     "examples, a pre-training procedure can be employed to train the Transformer layers using unlabeled data.\n",
     "This is followed by fine-tuning of the pre-trained Transformer layers along with\n",
-    "the top MLP layer using the labeled data."
+    "the top MLP layer using the labeled data.\n",
+    "\n",
+    "Example available on HuggingFace.\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/🤗%20Model-TabTransformer-black.svg)](https://huggingface.co/keras-io/tab_transformer) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-TabTransformer-black.svg)](https://huggingface.co/spaces/keras-io/TabTransformer_Classification) |"
    ]
   }
  ],

--- a/examples/structured_data/md/imbalanced_classification.md
+++ b/examples/structured_data/md/imbalanced_classification.md
@@ -280,3 +280,9 @@ In the real world, one would put an even higher weight on class 1,
 so as to reflect that False Negatives are more costly than False Positives.
 
 Next time your credit card gets  declined in an online purchase -- this is why.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Imbalanced%20Classification-black.svg)](https://huggingface.co/keras-io/imbalanced_classification) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Imbalanced%20Classification-black.svg)](https://huggingface.co/spaces/keras-io/Credit_Card_Fraud_Detection) |

--- a/examples/structured_data/md/tabtransformer.md
+++ b/examples/structured_data/md/tabtransformer.md
@@ -696,3 +696,9 @@ For a scenario where there are a few labeled examples and a large number of unla
 examples, a pre-training procedure can be employed to train the Transformer layers using unlabeled data.
 This is followed by fine-tuning of the pre-trained Transformer layers along with
 the top MLP layer using the labeled data.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-TabTransformer-black.svg)](https://huggingface.co/keras-io/tab_transformer) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-TabTransformer-black.svg)](https://huggingface.co/spaces/keras-io/TabTransformer_Classification) |

--- a/examples/structured_data/tabtransformer.py
+++ b/examples/structured_data/tabtransformer.py
@@ -561,4 +561,11 @@ For a scenario where there are a few labeled examples and a large number of unla
 examples, a pre-training procedure can be employed to train the Transformer layers using unlabeled data.
 This is followed by fine-tuning of the pre-trained Transformer layers along with
 the top MLP layer using the labeled data.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-TabTransformer-black.svg)](https://huggingface.co/keras-io/tab_transformer) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-TabTransformer-black.svg)](https://huggingface.co/spaces/keras-io/TabTransformer_Classification) |
+
 """

--- a/examples/vision/attention_mil_classification.py
+++ b/examples/vision/attention_mil_classification.py
@@ -570,4 +570,11 @@ the regularization techniques are necessary.
 bag sizes are fixed here.
 - In order not to rely on the random initial weights of a single model, averaging ensemble
 methods should be considered.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Attention%20MIL-black.svg)](https://huggingface.co/keras-io/attention_mil) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Attention%20MIL-black.svg)](https://huggingface.co/spaces/keras-io/Attention_based_Deep_Multiple_Instance_Learning) |
+
 """

--- a/examples/vision/ipynb/attention_mil_classification.ipynb
+++ b/examples/vision/ipynb/attention_mil_classification.ipynb
@@ -225,7 +225,7 @@
     "\n",
     "A **Gated attention mechanism** can be used to deal with complex relations. Another weight\n",
     "matrix, **u**, is added to the computation.\n",
-    "A sigmoid non-linearity is used to overcome approximately linear behavior for *x* \u2208 [\u22121, 1]\n",
+    "A sigmoid non-linearity is used to overcome approximately linear behavior for *x* ∈ [−1, 1]\n",
     "by hyperbolic tangent non-linearity."
    ]
   },
@@ -338,8 +338,7 @@
     "            )\n",
     "\n",
     "        # w^T*(tanh(v*h_k^T)) / w^T*(tanh(v*h_k^T)*sigmoid(u*h_k^T))\n",
-    "        return tf.tensordot(instance, self.w_weight_params, axes=1)\n",
-    ""
+    "        return tf.tensordot(instance, self.w_weight_params, axes=1)\n"
    ]
   },
   {
@@ -476,8 +475,7 @@
     "    # Classification output node.\n",
     "    output = layers.Dense(2, activation=\"softmax\")(concat)\n",
     "\n",
-    "    return keras.Model(inputs, output)\n",
-    ""
+    "    return keras.Model(inputs, output)\n"
    ]
   },
   {
@@ -518,8 +516,7 @@
     "    return {\n",
     "        0: (1 / negative_count) * (total_count / 2),\n",
     "        1: (1 / positive_count) * (total_count / 2),\n",
-    "    }\n",
-    ""
+    "    }\n"
    ]
   },
   {
@@ -712,7 +709,13 @@
     "- In the paper, the bag sizes can differ from one bag to another. For simplicity, the\n",
     "bag sizes are fixed here.\n",
     "- In order not to rely on the random initial weights of a single model, averaging ensemble\n",
-    "methods should be considered."
+    "methods should be considered.\n",
+    "\n",
+    "Example available on HuggingFace.\n",
+    "\n",
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Attention%20MIL-black.svg)](https://huggingface.co/keras-io/attention_mil) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Attention%20MIL-black.svg)](https://huggingface.co/spaces/keras-io/Attention_based_Deep_Multiple_Instance_Learning) |"
    ]
   }
  ],

--- a/examples/vision/ipynb/deit.ipynb
+++ b/examples/vision/ipynb/deit.ipynb
@@ -239,8 +239,7 @@
     "            random_tensor = keep_prob + tf.random.uniform(shape, 0, 1)\n",
     "            random_tensor = tf.floor(random_tensor)\n",
     "            return (x / keep_prob) * random_tensor\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -305,8 +304,7 @@
     "    # Skip connection 2.\n",
     "    outputs = layers.Add()([x2, x4])\n",
     "\n",
-    "    return keras.Model(encoded_patches, outputs, name=name)\n",
-    ""
+    "    return keras.Model(encoded_patches, outputs, name=name)\n"
    ]
   },
   {
@@ -416,8 +414,7 @@
     "\n",
     "        # Classification head.\n",
     "        output = self.head(encoded_patches)\n",
-    "        return output\n",
-    ""
+    "        return output\n"
    ]
   },
   {
@@ -521,8 +518,7 @@
     "        elif training:\n",
     "            # Only return separate classification predictions when training in distilled\n",
     "            # mode.\n",
-    "            return x, x_dist\n",
-    ""
+    "            return x, x_dist\n"
    ]
   },
   {
@@ -667,8 +663,7 @@
     "        return results\n",
     "\n",
     "    def call(self, inputs):\n",
-    "        return self.student(inputs / 255.0, training=False)\n",
-    ""
+    "        return self.student(inputs / 255.0, training=False)\n"
    ]
   },
   {

--- a/examples/vision/md/attention_mil_classification.md
+++ b/examples/vision/md/attention_mil_classification.md
@@ -788,3 +788,9 @@ the regularization techniques are necessary.
 bag sizes are fixed here.
 - In order not to rely on the random initial weights of a single model, averaging ensemble
 methods should be considered.
+
+Example available on HuggingFace.
+
+| Trained Model | Demo |
+| :--: | :--: |
+| [![Generic badge](https://img.shields.io/badge/🤗%20Model-Attention%20MIL-black.svg)](https://huggingface.co/keras-io/attention_mil) | [![Generic badge](https://img.shields.io/badge/🤗%20Spaces-Attention%20MIL-black.svg)](https://huggingface.co/spaces/keras-io/Attention_based_Deep_Multiple_Instance_Learning) |


### PR DESCRIPTION
As per the ongoing hugs keras sprint, have updated the following examples:

Vision Data:

- attention_mil

Structured Data:

- tab_transformer
- imbalanced_classification

Will be glad to address any issues/changes.