### PR TITLE
Put working link for bounding box format

### DIFF
--- a/guides/ipynb/keras_cv/coco_metrics.ipynb
+++ b/guides/ipynb/keras_cv/coco_metrics.ipynb
@@ -44,7 +44,7 @@
     "`bounding_box_format` parameter.  This parameter is used to tell the components what\n",
     "format your bounding boxes are in.  While this guide uses the `xyxy` format, a full\n",
     "list of supported formats is available in\n",
-    "[the bounding_box API documentation](/api/keras_cv/bounding_box/formats).\n",
+    "[the bounding_box API documentation](https://keras.io/api/keras_cv/bounding_box/formats/).\n",
     "\n",
     "The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,\n",
     "num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the\n",

--- a/guides/ipynb/keras_cv/coco_metrics.ipynb
+++ b/guides/ipynb/keras_cv/coco_metrics.ipynb
@@ -44,7 +44,7 @@
     "`bounding_box_format` parameter.  This parameter is used to tell the components what\n",
     "format your bounding boxes are in.  While this guide uses the `xyxy` format, a full\n",
     "list of supported formats is available in\n",
-    "[the bounding_box API documentation](https://keras.io/api/keras_cv/bounding_box/formats/).\n",
+    "[the bounding_box API documentation](/api/keras_cv/bounding_box/formats/).\n",
     "\n",
     "The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,\n",
     "num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the\n",

--- a/guides/ipynb/keras_cv/coco_metrics.ipynb
+++ b/guides/ipynb/keras_cv/coco_metrics.ipynb
@@ -44,7 +44,7 @@
     "`bounding_box_format` parameter.  This parameter is used to tell the components what\n",
     "format your bounding boxes are in.  While this guide uses the `xyxy` format, a full\n",
     "list of supported formats is available in\n",
-    "[the bounding_box API documentation](../api/keras_cv/bounding_box/formats/).\n",
+    "[the bounding_box API documentation](https://keras.io/api/keras_cv/bounding_box/formats/).\n",
     "\n",
     "The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,\n",
     "num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the\n",

--- a/guides/ipynb/keras_cv/coco_metrics.ipynb
+++ b/guides/ipynb/keras_cv/coco_metrics.ipynb
@@ -44,7 +44,7 @@
     "`bounding_box_format` parameter.  This parameter is used to tell the components what\n",
     "format your bounding boxes are in.  While this guide uses the `xyxy` format, a full\n",
     "list of supported formats is available in\n",
-    "[the bounding_box API documentation](/api/keras_cv/bounding_box/formats/).\n",
+    "[the bounding_box API documentation](../api/keras_cv/bounding_box/formats/).\n",
     "\n",
     "The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,\n",
     "num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the\n",

--- a/guides/keras_cv/coco_metrics.py
+++ b/guides/keras_cv/coco_metrics.py
@@ -26,7 +26,7 @@ All KerasCV components that process bounding boxes, including COCO metrics, requ
 `bounding_box_format` parameter.  This parameter is used to tell the components what
 format your bounding boxes are in.  While this guide uses the `xyxy` format, a full
 list of supported formats is available in
-[the bounding_box API documentation](/api/keras_cv/bounding_box/formats).
+[the bounding_box API documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
 
 The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,
 num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the

--- a/guides/md/keras_cv/coco_metrics.md
+++ b/guides/md/keras_cv/coco_metrics.md
@@ -29,7 +29,7 @@ All KerasCV components that process bounding boxes, including COCO metrics, requ
 `bounding_box_format` parameter.  This parameter is used to tell the components what
 format your bounding boxes are in.  While this guide uses the `xyxy` format, a full
 list of supported formats is available in
-[the bounding_box API documentation](/api/keras_cv/bounding_box/formats).
+[the bounding_box API documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
 
 The metrics expect `y_true` and be a `float` Tensor with the shape `[batch,
 num_images, num_boxes, 5]`, with the ordering of last set of axes determined by the


### PR DESCRIPTION
Throwing 404 error for bounding box format hyperlink.
So Put the working link for the bounding box format. 
https://keras.io/api/keras_cv/bounding_box/formats/