### PR TITLE
Update cut_mix_mix_up_and_rand_augment.ipynb

### DIFF
--- a/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
+++ b/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
@@ -225,7 +225,7 @@
     "\n",
     "You can read more about these\n",
     "parameters in the\n",
-    "[`RandAugment` API documentation](/api/keras_cv/layers/preprocessing/rand_augment/).\n",
+    "[`RandAugment` API documentation](https://keras.io/api/keras_cv/layers/preprocessing/rand_augment/).\n",
     "\n",
     "Let's use KerasCV's RandAugment implementation."
    ]


### PR DESCRIPTION
Fixing broken link on airflow_workshop.md in the  [RandAugment API documentation](https://keras.io/api/keras_cv/layers/preprocessing/rand_augment/) with correct link.