### PR TITLE
Update serialization_and_saving.ipynb

### DIFF
--- a/guides/ipynb/serialization_and_saving.ipynb
+++ b/guides/ipynb/serialization_and_saving.ipynb
@@ -310,10 +310,10 @@
    "source": [
     "#### Configuring the SavedModel\n",
     "\n",
-    "*New in TensoFlow 2.4*\n",
+    "*New in TensorFlow 2.4*\n",
     "The argument `save_traces` has been added to `model.save`, which allows you to toggle\n",
     "SavedModel function tracing. Functions are saved to allow the Keras to re-load custom\n",
-    "objects without the original class definitons, so when `save_traces=False`, all custom\n",
+    "objects without the original class definitions, so when `save_traces=False`, all custom\n",
     "objects must have defined `get_config`/`from_config` methods. When loading, the custom\n",
     "objects must be passed to the `custom_objects` argument. `save_traces=False` reduces the\n",
     "disk space used by the SavedModel and saving time."


### PR DESCRIPTION
Fixed the spellings of TensorFlow and definitions.