### PR TITLE
Remove importing PIL

### DIFF
--- a/examples/vision/ipynb/oxford_pets_image_segmentation.ipynb
+++ b/examples/vision/ipynb/oxford_pets_image_segmentation.ipynb
@@ -102,14 +102,13 @@
    "source": [
     "from IPython.display import Image, display\n",
     "from tensorflow.keras.preprocessing.image import load_img\n",
-    "import PIL\n",
     "from PIL import ImageOps\n",
     "\n",
     "# Display input image #7\n",
     "display(Image(filename=input_img_paths[9]))\n",
     "\n",
     "# Display auto-contrast version of corresponding target (per-pixel categories)\n",
-    "img = PIL.ImageOps.autocontrast(load_img(target_img_paths[9]))\n",
+    "img = ImageOps.autocontrast(load_img(target_img_paths[9]))\n",
     "display(img)"
    ]
   },
@@ -345,7 +344,7 @@
     "    \"\"\"Quick utility to display a model's prediction.\"\"\"\n",
     "    mask = np.argmax(val_preds[i], axis=-1)\n",
     "    mask = np.expand_dims(mask, axis=-1)\n",
-    "    img = PIL.ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))\n",
+    "    img = ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))\n",
     "    display(img)\n",
     "\n",
     "\n",
@@ -356,7 +355,7 @@
     "display(Image(filename=val_input_img_paths[i]))\n",
     "\n",
     "# Display ground-truth target mask\n",
-    "img = PIL.ImageOps.autocontrast(load_img(val_target_img_paths[i]))\n",
+    "img = ImageOps.autocontrast(load_img(val_target_img_paths[i]))\n",
     "display(img)\n",
     "\n",
     "# Display mask predicted by our model\n",

--- a/examples/vision/md/oxford_pets_image_segmentation.md
+++ b/examples/vision/md/oxford_pets_image_segmentation.md
@@ -89,14 +89,13 @@ images/Abyssinian_107.jpg | annotations/trimaps/Abyssinian_107.png
 ```python
 from IPython.display import Image, display
 from tensorflow.keras.preprocessing.image import load_img
-import PIL
 from PIL import ImageOps
 
 # Display input image #7
 display(Image(filename=input_img_paths[9]))
 
 # Display auto-contrast version of corresponding target (per-pixel categories)
-img = PIL.ImageOps.autocontrast(load_img(target_img_paths[9]))
+img = ImageOps.autocontrast(load_img(target_img_paths[9]))
 display(img)
 ```
 
@@ -486,7 +485,7 @@ def display_mask(i):
     """Quick utility to display a model's prediction."""
     mask = np.argmax(val_preds[i], axis=-1)
     mask = np.expand_dims(mask, axis=-1)
-    img = PIL.ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))
+    img = ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))
     display(img)
 
 
@@ -497,7 +496,7 @@ i = 10
 display(Image(filename=val_input_img_paths[i]))
 
 # Display ground-truth target mask
-img = PIL.ImageOps.autocontrast(load_img(val_target_img_paths[i]))
+img = ImageOps.autocontrast(load_img(val_target_img_paths[i]))
 display(img)
 
 # Display mask predicted by our model

--- a/examples/vision/oxford_pets_image_segmentation.py
+++ b/examples/vision/oxford_pets_image_segmentation.py
@@ -54,14 +54,13 @@ for input_path, target_path in zip(input_img_paths[:10], target_img_paths[:10]):
 
 from IPython.display import Image, display
 from tensorflow.keras.preprocessing.image import load_img
-import PIL
 from PIL import ImageOps
 
 # Display input image #7
 display(Image(filename=input_img_paths[9]))
 
 # Display auto-contrast version of corresponding target (per-pixel categories)
-img = PIL.ImageOps.autocontrast(load_img(target_img_paths[9]))
+img = ImageOps.autocontrast(load_img(target_img_paths[9]))
 display(img)
 
 """
@@ -227,7 +226,7 @@ def display_mask(i):
     """Quick utility to display a model's prediction."""
     mask = np.argmax(val_preds[i], axis=-1)
     mask = np.expand_dims(mask, axis=-1)
-    img = PIL.ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))
+    img = ImageOps.autocontrast(keras.preprocessing.image.array_to_img(mask))
     display(img)
 
 
@@ -238,7 +237,7 @@ i = 10
 display(Image(filename=val_input_img_paths[i]))
 
 # Display ground-truth target mask
-img = PIL.ImageOps.autocontrast(load_img(val_target_img_paths[i]))
+img = ImageOps.autocontrast(load_img(val_target_img_paths[i]))
 display(img)
 
 # Display mask predicted by our model


### PR DESCRIPTION
Clean-up codes.
- Only `ImageOps` module in PIL is used in the whole code. `import PIL` does nothing.
