### PR TITLE
Updated black version in requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ markdown>=3.3
 requests
 mdx_truly_sane_lists
 sphinx~=3.0.3
-black==19.10b0
+black==22.1.0
 pathlib
 tensorflow
 PyYAML


### PR DESCRIPTION
I noticed the black version in continuous_integration.yml is different from the version mentioned in requirements file:
https://github.com/keras-team/keras-io/blob/master/.github/workflows/continuous_integration.yml

This is causing differences in formatting of python file done locally vs the formatting check happening as part of the workflow run and causing the check for black to fail 

Hence updating requirements file to match version mentioned in continuous_integration.yml 
