### PR TITLE
Corrects node size

### DIFF
--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -433,10 +433,10 @@ class GraphConvLayer(layers.Layer):
             messages = messages * tf.expand_dims(weights, -1)
         return messages
 
-    def aggregate(self, node_indices, neighbour_messages):
+    def aggregate(self, node_indices, neighbour_messages, node_repesentations):
         # node_indices shape is [num_edges].
         # neighbour_messages shape: [num_edges, representation_dim].
-        num_nodes = tf.math.reduce_max(node_indices) + 1
+        num_nodes = node_repesentations.shape[0]
         if self.aggregation_type == "sum":
             aggregated_message = tf.math.unsorted_segment_sum(
                 neighbour_messages, node_indices, num_segments=num_nodes
@@ -494,7 +494,7 @@ class GraphConvLayer(layers.Layer):
         # Prepare the messages of the neighbours.
         neighbour_messages = self.prepare(neighbour_repesentations, edge_weights)
         # Aggregate the neighbour messages.
-        aggregated_messages = self.aggregate(node_indices, neighbour_messages)
+        aggregated_messages = self.aggregate(node_indices, neighbour_messages, node_repesentations)
         # Update the node embedding with the neighbour messages.
         return self.update(node_repesentations, aggregated_messages)
 

--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -436,6 +436,7 @@ class GraphConvLayer(layers.Layer):
     def aggregate(self, node_indices, neighbour_messages, node_repesentations):
         # node_indices shape is [num_edges].
         # neighbour_messages shape: [num_edges, representation_dim].
+        # node_repesentations shape is [num_nodes, representation_dim]
         num_nodes = node_repesentations.shape[0]
         if self.aggregation_type == "sum":
             aggregated_message = tf.math.unsorted_segment_sum(


### PR DESCRIPTION
The existing implementation assumed the max of `node_indicies` is the size of the nodes. 

The assumption is not alway true. For example, if the largest node index of the nodes is not in  `node_indicies`, this assumption is wrong.

This PR addresses this by directly checking the size of nodes. That is the size of the nodes is the row number of `node_representations`.
