### PR TITLE
bug: Image_Captioning.md Fixed

### DIFF
--- a/examples/vision/image_captioning.py
+++ b/examples/vision/image_captioning.py
@@ -227,7 +227,7 @@ def process_input(img_path, captions):
 
 def make_dataset(images, captions):
     dataset = tf.data.Dataset.from_tensor_slices((images, captions))
-    dataset = dataset.shuffle(BATCH_SIZE*8)
+    dataset = dataset.shuffle(BATCH_SIZE * 8)
     dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
     dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)
 

--- a/examples/vision/image_captioning.py
+++ b/examples/vision/image_captioning.py
@@ -227,7 +227,7 @@ def process_input(img_path, captions):
 
 def make_dataset(images, captions):
     dataset = tf.data.Dataset.from_tensor_slices((images, captions))
-    dataset = dataset.shuffle(len(images))
+    dataset = dataset.shuffle(BATCH_SIZE*8)
     dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
     dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)
 

--- a/examples/vision/ipynb/image_captioning.ipynb
+++ b/examples/vision/ipynb/image_captioning.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -309,7 +309,7 @@
     "\n",
     "def make_dataset(images, captions):\n",
     "    dataset = tf.data.Dataset.from_tensor_slices((images, captions))\n",
-    "    dataset = dataset.shuffle(BATCH_SIZE*8)\n",
+    "    dataset = dataset.shuffle(BATCH_SIZE * 8)\n",
     "    dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)\n",
     "    dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)\n",
     "\n",
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -628,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -691,7 +691,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/vision/ipynb/image_captioning.ipynb
+++ b/examples/vision/ipynb/image_captioning.ipynb
@@ -268,8 +268,7 @@
     "        layers.RandomRotation(0.2),\n",
     "        layers.RandomContrast(0.3),\n",
     "    ]\n",
-    ")\n",
-    ""
+    ")\n"
    ]
   },
   {
@@ -310,7 +309,7 @@
     "\n",
     "def make_dataset(images, captions):\n",
     "    dataset = tf.data.Dataset.from_tensor_slices((images, captions))\n",
-    "    dataset = dataset.shuffle(len(images))\n",
+    "    dataset = dataset.shuffle(BATCH_SIZE*8)\n",
     "    dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)\n",
     "    dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)\n",
     "\n",
@@ -320,8 +319,7 @@
     "# Pass the list of images and the list of corresponding captions\n",
     "train_dataset = make_dataset(list(train_data.keys()), list(train_data.values()))\n",
     "\n",
-    "valid_dataset = make_dataset(list(valid_data.keys()), list(valid_data.values()))\n",
-    ""
+    "valid_dataset = make_dataset(list(valid_data.keys()), list(valid_data.values()))\n"
    ]
   },
   {
@@ -771,7 +769,7 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -785,9 +783,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/vision/md/image_captioning.md
+++ b/examples/vision/md/image_captioning.md
@@ -267,7 +267,7 @@ def process_input(img_path, captions):
 
 def make_dataset(images, captions):
     dataset = tf.data.Dataset.from_tensor_slices((images, captions))
-    dataset = dataset.shuffle(BATCH_SIZE*8)
+    dataset = dataset.shuffle(BATCH_SIZE * 8)
     dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
     dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)
 

--- a/examples/vision/md/image_captioning.md
+++ b/examples/vision/md/image_captioning.md
@@ -266,21 +266,11 @@ def process_input(img_path, captions):
 
 
 def make_dataset(images, captions):
-    if split == "train":
-        img_dataset = tf.data.Dataset.from_tensor_slices(images).map(
-            read_train_image, num_parallel_calls=AUTOTUNE
-        )
-    else:
-        img_dataset = tf.data.Dataset.from_tensor_slices(images).map(
-            read_valid_image, num_parallel_calls=AUTOTUNE
-        )
+    dataset = tf.data.Dataset.from_tensor_slices((images, captions))
+    dataset = dataset.shuffle(len(images))
+    dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
+    dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)
 
-    cap_dataset = tf.data.Dataset.from_tensor_slices(captions).map(
-        vectorization, num_parallel_calls=AUTOTUNE
-    )
-
-    dataset = tf.data.Dataset.zip((img_dataset, cap_dataset))
-    dataset = dataset.batch(BATCH_SIZE).shuffle(256).prefetch(AUTOTUNE)
     return dataset
 
 

--- a/examples/vision/md/image_captioning.md
+++ b/examples/vision/md/image_captioning.md
@@ -267,7 +267,7 @@ def process_input(img_path, captions):
 
 def make_dataset(images, captions):
     dataset = tf.data.Dataset.from_tensor_slices((images, captions))
-    dataset = dataset.shuffle(len(images))
+    dataset = dataset.shuffle(BATCH_SIZE*8)
     dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
     dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)
 


### PR DESCRIPTION
In the `image_captioning.md`, make_dataset consists of variables that are not defined. (`split`, `read_train_image` and `read_valid_image`)

### Before
#### NameError: This is how the code looks in official Keras documentation
```py
def make_dataset(images, captions):
    if split == "train":
        img_dataset = tf.data.Dataset.from_tensor_slices(images).map(
            read_train_image, num_parallel_calls=AUTOTUNE
        )
    else:
        img_dataset = tf.data.Dataset.from_tensor_slices(images).map(
            read_valid_image, num_parallel_calls=AUTOTUNE
        )

    cap_dataset = tf.data.Dataset.from_tensor_slices(captions).map(
        vectorization, num_parallel_calls=AUTOTUNE
    )

    dataset = tf.data.Dataset.zip((img_dataset, cap_dataset))
    dataset = dataset.batch(BATCH_SIZE).shuffle(256).prefetch(AUTOTUNE)
    return dataset
```
### After
#### `Removing split variable and syncing image_captioning` with `image_captioning.py`. 

```py
def make_dataset(images, captions):
    dataset = tf.data.Dataset.from_tensor_slices((images, captions))
    dataset = dataset.shuffle(len(images))
    dataset = dataset.map(process_input, num_parallel_calls=AUTOTUNE)
    dataset = dataset.batch(BATCH_SIZE).prefetch(AUTOTUNE)

    return dataset
```