### PR TITLE
Tf text 2.10 is out, we can stop pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ PyYAML
 pandas
 jupyter
 tensorflow==2.10.0
-tensorflow-text==2.10.0rc0
 keras-tuner
 keras-cv
 keras-nlp


### PR DESCRIPTION
We don't need to explicitly pull in the pre-release anymore.