### PR TITLE
Fixes #1075 : Display test image

### DIFF
--- a/examples/vision/image_classification_from_scratch.py
+++ b/examples/vision/image_classification_from_scratch.py
@@ -328,6 +328,7 @@ Note that data augmentation and dropout are inactive at inference time.
 img = keras.preprocessing.image.load_img(
     "PetImages/Cat/6779.jpg", target_size=image_size
 )
+plt.imshow(img); # Display test image
 img_array = keras.preprocessing.image.img_to_array(img)
 img_array = tf.expand_dims(img_array, 0)  # Create batch axis
 

--- a/examples/vision/ipynb/image_classification_from_scratch.ipynb
+++ b/examples/vision/ipynb/image_classification_from_scratch.ipynb
@@ -540,7 +540,7 @@
     "img = keras.preprocessing.image.load_img(\n",
     "    \"PetImages/Cat/6779.jpg\", target_size=image_size\n",
     ")\n",
-    "plt.imshow(img);\n",
+    "plt.imshow(img); # Display test image\n",
     "img_array = keras.preprocessing.image.img_to_array(img)\n",
     "img_array = tf.expand_dims(img_array, 0)  # Create batch axis\n",
     "\n",

--- a/examples/vision/ipynb/image_classification_from_scratch.ipynb
+++ b/examples/vision/ipynb/image_classification_from_scratch.ipynb
@@ -540,6 +540,7 @@
     "img = keras.preprocessing.image.load_img(\n",
     "    \"PetImages/Cat/6779.jpg\", target_size=image_size\n",
     ")\n",
+    "plt.imshow(img);",
     "img_array = keras.preprocessing.image.img_to_array(img)\n",
     "img_array = tf.expand_dims(img_array, 0)  # Create batch axis\n",
     "\n",

--- a/examples/vision/ipynb/image_classification_from_scratch.ipynb
+++ b/examples/vision/ipynb/image_classification_from_scratch.ipynb
@@ -540,7 +540,7 @@
     "img = keras.preprocessing.image.load_img(\n",
     "    \"PetImages/Cat/6779.jpg\", target_size=image_size\n",
     ")\n",
-    "plt.imshow(img);",
+    "plt.imshow(img);\n",
     "img_array = keras.preprocessing.image.img_to_array(img)\n",
     "img_array = tf.expand_dims(img_array, 0)  # Create batch axis\n",
     "\n",

--- a/examples/vision/md/image_classification_from_scratch.md
+++ b/examples/vision/md/image_classification_from_scratch.md
@@ -449,6 +449,7 @@ Note that data augmentation and dropout are inactive at inference time.
 img = keras.preprocessing.image.load_img(
     "PetImages/Cat/6779.jpg", target_size=image_size
 )
+plt.imshow(img); # Display test image
 img_array = keras.preprocessing.image.img_to_array(img)
 img_array = tf.expand_dims(img_array, 0)  # Create batch axis
 


### PR DESCRIPTION
Can add a simple line at the end to show what the image looks like along with it's predictions.
Please ignore multiple commits. Overall it's adding 1 line - 

`plt.imshow(img); # Display test image`

to the following 3 files - 
1. examples/vision/image_classification_from_scratch.py
2. examples/vision/ipynb/image_classification_from_scratch.ipynb
3. examples/vision/md/image_classification_from_scratch.md
