### PR TITLE
Fix markdown syntax for a list in the KerasTuner guide.

### DIFF
--- a/guides/ipynb/keras_tuner/getting_started.ipynb
+++ b/guides/ipynb/keras_tuner/getting_started.ipynb
@@ -767,6 +767,7 @@
     "Here is [a list of the built-in metrics](https://keras.io/api/metrics/).\n",
     "\n",
     "To use a built-in metric as the objective, you need to follow these steps:\n",
+    "\n",
     "* Compile the model with the the built-in metric. For example, you want to use\n",
     "`MeanAbsoluteError()`. You need to compile the model with\n",
     "`metrics=[MeanAbsoluteError()]`. You may also use its name string instead:\n",

--- a/guides/keras_tuner/getting_started.py
+++ b/guides/keras_tuner/getting_started.py
@@ -499,6 +499,7 @@ There are many other built-in metrics in Keras you can use as the objective.
 Here is [a list of the built-in metrics](https://keras.io/api/metrics/).
 
 To use a built-in metric as the objective, you need to follow these steps:
+
 * Compile the model with the the built-in metric. For example, you want to use
 `MeanAbsoluteError()`. You need to compile the model with
 `metrics=[MeanAbsoluteError()]`. You may also use its name string instead:

--- a/guides/md/keras_tuner/getting_started.md
+++ b/guides/md/keras_tuner/getting_started.md
@@ -713,6 +713,7 @@ There are many other built-in metrics in Keras you can use as the objective.
 Here is [a list of the built-in metrics](https://keras.io/api/metrics/).
 
 To use a built-in metric as the objective, you need to follow these steps:
+
 * Compile the model with the the built-in metric. For example, you want to use
 `MeanAbsoluteError()`. You need to compile the model with
 `metrics=[MeanAbsoluteError()]`. You may also use its name string instead:


### PR DESCRIPTION
Without the extra newline at its start, keras.io renders the first item as part of the preceding paragraph, see
[screenshot](https://user-images.githubusercontent.com/37290325/195843643-06d93dd7-f4bf-43e5-bda6-5ac14157069f.png).
