### PR TITLE
Asynchronous ensembles design

### DIFF
--- a/examples/keras_recipes/asynch_ensemble_multiprocessing.py
+++ b/examples/keras_recipes/asynch_ensemble_multiprocessing.py
@@ -1,0 +1,206 @@
+"""
+Title: Asynchronous ensemble based on multiprocessing package.
+Author: [PierrickPochelu](https://github.com/PierrickPochelu)
+Date created: 2022/10/17
+Last modified: 2022/10/17
+Description: Asynchronous ensemble based on multiprocessing package.
+"""
+
+"""
+## Introduction
+Asynchronous ensemble based on multiple tensorflow sessions and the built-in multiprocessing package.  The ensemble of N models is generally more accurate than base models. The asynchronous ensemble exploites more efficiently massively-parallel devices than iterating on the computing of base models.
+"""
+
+"""
+### Reading data
+"""
+import tensorflow as tf
+from tensorflow.keras.utils import to_categorical
+from tensorflow.keras import datasets, layers, models
+from tensorflow.keras import Input, Model, optimizers, layers
+from tensorflow.keras.layers import (
+    Conv2D,
+    Activation,
+    MaxPooling2D,
+    Dropout,
+    Flatten,
+    Dense,
+)
+import numpy as np
+import time
+import os
+import warnings
+
+warnings.filterwarnings("ignore")
+
+(train_images, train_labels), (test_images, test_labels) = datasets.cifar10.load_data()
+train_images, test_images = train_images / 255.0, test_images / 255.0
+train_labels = to_categorical(train_labels)
+test_labels = to_categorical(test_labels)
+
+NB_SAMPLES = 6000  # Sampling for faster experiences
+train_images = train_images[:NB_SAMPLES]
+train_labels = train_labels[:NB_SAMPLES]
+test_images = test_images[:NB_SAMPLES]
+test_labels = test_labels[:NB_SAMPLES]
+
+
+"""
+### Settings
+"""
+
+ENSEMBLE_SIZE = 4
+NB_EPOCHS = 1
+GPUID = [-1, -1, -1, -1]  #  # asignement of models with devices
+BATCH_SIZE = 16
+
+
+def keras_model(x):
+    x = layers.Conv2D(32, (3, 3), activation="relu")(x)
+    x = layers.MaxPooling2D((2, 2))(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.MaxPooling2D((2, 2))(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.Flatten()(x)
+    x = layers.Dense(64, activation="relu")(x)
+    x = layers.Dense(10, activation="softmax")(x)
+    x = layers.Softmax()(x)
+    return x
+
+
+"""
+## Asynchronous ensemble design
+"""
+from multiprocessing import Queue, Process, Barrier
+import os
+
+
+def evaluate_model(model, x, y):
+    start_time = time.time()
+    y_pred = model.predict(x, batch_size=BATCH_SIZE)
+    enlapsed = time.time() - start_time
+    acc = np.mean(np.argmax(y, axis=1) == np.argmax(y_pred, axis=1))
+    return {"accuracy": round(acc, 2), "time": round(enlapsed, 2)}
+
+
+def keras_model_builder(config):
+    input_shape = (32, 32, 3)
+    loss = "categorical_crossentropy"
+    opt = "adam"
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(config["gpuid"])
+    os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
+    input = Input(shape=input_shape)
+    output = keras_model(input)
+    model = Model(inputs=input, outputs=output)
+    model.compile(loss=loss, optimizer=opt)
+    return model
+
+
+class MyProcess(Process):
+    def __init__(
+        self,
+        rank: int,
+        config: dict,
+        dataset: list,
+        shared_input_queue: Queue,
+        shared_output_queue: Queue,
+    ):
+        Process.__init__(self, name="ModelProcessor")
+        self.rank = rank
+        self.config = config
+        self.dataset = dataset  # List of np.ndarray xtrain, ytrain, xtest, ytest
+        self.shared_input_queue = shared_input_queue  # 'go' or 'stop'
+        self.shared_output_queue = shared_output_queue  # "initok" or predictions
+        self.model = None
+        self.info = None
+
+    def _asynchronous_predict(self):
+        finish = False
+        while finish == False:
+            msg = self.shared_input_queue.get()  # wait
+            if msg == "go":
+                out = self.model.predict(self.dataset[2], batch_size=BATCH_SIZE)
+                self.shared_output_queue.put((self.rank, out))
+            else:
+                finish = True
+
+    def train(self):
+        self.model.fit(
+            x=self.dataset[0],
+            y=self.dataset[1],
+            batch_size=BATCH_SIZE,
+            epochs=NB_EPOCHS,
+        )
+
+    def run(self):
+        self.model = keras_model_builder(self.config)
+        self.train()
+        info = evaluate_model(self.model, x=self.dataset[2], y=self.dataset[3])
+        self.shared_output_queue.put((self.rank, info))  # notify the main process
+
+        self._asynchronous_predict()  # run forever
+
+
+input_queue = Queue()
+output_queue = Queue()
+processes = []
+
+"""
+## Training of models
+### Build the processes
+"""
+for i in range(ENSEMBLE_SIZE):
+    proc = MyProcess(
+        rank=i,
+        config={"gpuid": GPUID[i]},
+        dataset=[train_images, train_labels, test_images, test_labels],
+        shared_input_queue=input_queue,
+        shared_output_queue=output_queue,
+    )
+    proc.start()  # start and wait
+    processes.append(proc)
+print("The building/training is launched ...")
+
+"""
+### Wait every processes is ready
+"""
+training_start_time = time.time()
+for i in range(ENSEMBLE_SIZE):
+    thread_id, msg = output_queue.get()
+    if isinstance(msg, dict):
+        print(
+            f"Model rank: {thread_id} accuracy: {msg['accuracy']} time: {msg['time']}"
+        )
+    else:
+        raise ValueError(f"thread {thread_id} received an unexpected message")
+
+
+"""
+## Inference
+"""
+
+"""
+### Ensemble evaluation
+"""
+inference_start_time = time.time()
+for process in processes:
+    input_queue.put("go")
+
+preds = np.zeros(test_labels.shape, np.float32)
+for process in processes:
+    thread_id, msg = output_queue.get()
+    preds += msg
+acc = np.mean(np.argmax(test_labels, axis=1) == np.argmax(preds, axis=1))
+inf_time = time.time() - inference_start_time
+print(f"Ensemble accuracy: {round(acc,2)} inference time: {round(inf_time,2)}")
+
+
+"""
+Conclusion: the asynchronous ensemble exploits well the underlying parallelism. The ensemble of N models is faster than N*T models, with T the average computing time of one model.
+"""
+
+"""
+### Stop processes
+"""
+for i in range(ENSEMBLE_SIZE):
+    input_queue.put("stop")

--- a/examples/keras_recipes/asynch_ensemble_shared_session.py
+++ b/examples/keras_recipes/asynch_ensemble_shared_session.py
@@ -1,0 +1,153 @@
+"""
+Title: Asynchronous ensemble with sharing of the tensorflow session.
+Author: [PierrickPochelu](https://github.com/PierrickPochelu)
+Date created: 2022/10/17
+Last modified: 2022/10/17
+Description: Asynchronous ensemble with sharing of the tensorflow session.
+"""
+
+"""
+## Introduction
+Asynchronous ensemble based on multiple tensorflow sessions and the built-in multiprocessing package.  The ensemble of N models is generally more accurate than base models. The asynchronous ensemble exploites more efficiently massively-parallel devices than iterating on the computing of base models.
+"""
+
+"""
+### Reading data
+"""
+import tensorflow as tf
+from tensorflow.keras.utils import to_categorical
+from tensorflow.keras import datasets, layers, models
+from tensorflow.keras import Input, Model, optimizers, layers
+from tensorflow.keras.layers import (
+    Conv2D,
+    Activation,
+    MaxPooling2D,
+    Dropout,
+    Flatten,
+    Dense,
+)
+import numpy as np
+import time
+import os
+import warnings
+
+warnings.filterwarnings("ignore")
+
+os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
+
+
+(train_images, train_labels), (test_images, test_labels) = datasets.cifar10.load_data()
+train_images, test_images = train_images / 255.0, test_images / 255.0
+train_labels = to_categorical(train_labels)
+test_labels = to_categorical(test_labels)
+
+NB_SAMPLES = 6000  # Sampling for faster experiences
+train_images = train_images[:NB_SAMPLES]
+train_labels = train_labels[:NB_SAMPLES]
+test_images = test_images[:NB_SAMPLES]
+test_labels = test_labels[:NB_SAMPLES]
+
+"""
+### Settings
+"""
+
+ENSEMBLE_SIZE = 4
+NB_EPOCHS = 1
+GPUIDS = [-1, -1, -1, -1]  # asignement of models with devices
+BATCH_SIZE = 16
+
+
+def keras_model(x):
+    x = layers.Conv2D(32, (3, 3), activation="relu")(x)
+    x = layers.MaxPooling2D((2, 2))(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.MaxPooling2D((2, 2))(x)
+    x = layers.Conv2D(64, (3, 3), activation="relu")(x)
+    x = layers.Flatten()(x)
+    x = layers.Dense(64, activation="relu")(x)
+    x = layers.Dense(10, activation="softmax")(x)
+    x = layers.Softmax()(x)
+    return x
+
+
+"""
+## Asynchronous ensemble design
+"""
+
+
+def evaluate_model(model, x, y):
+    start_time = time.time()
+    y_pred = model.predict(x, batch_size=BATCH_SIZE)
+    enlapsed = time.time() - start_time
+    acc = np.mean(np.argmax(y, axis=1) == np.argmax(y_pred, axis=1))
+    return {"accuracy": round(acc, 2), "time": round(enlapsed, 2)}
+
+
+def from_gpu_id_to_device_name(gpuid):
+    if gpuid == -1:
+        return "/device:CPU:0"
+    else:
+        return "/device:GPU:" + str(gpuid)
+
+
+class ensemble:
+    def __init__(self, ensemble_size, gpus):
+        self.loss = "categorical_crossentropy"
+        self.opt = "adam"
+
+        self.model_list = []
+        output_list = []
+
+        with tf.device(from_gpu_id_to_device_name(gpus[0])):
+            input = Input(shape=(32, 32, 3))
+
+        for i in range(ensemble_size):
+            with tf.device(from_gpu_id_to_device_name(gpus[i])):
+                input_i = tf.identity(input)
+                output_i = keras_model(input_i)
+                model_i = Model(inputs=input_i, outputs=output_i)
+                output_list.append(output_i)
+                self.model_list.append(model_i)
+
+        with tf.device(from_gpu_id_to_device_name(gpus[0])):
+            merge = tf.stack(output_list, axis=-1)
+            combined_predictions = tf.reduce_mean(merge, axis=-1)
+
+        self.ensemble = Model(inputs=input, outputs=combined_predictions)
+        self.ensemble.compile(loss=self.loss, optimizer=self.opt)
+
+    def fit(self, train_images, train_labels):
+        for model_i in self.model_list:
+            model_i.compile(loss=self.loss, optimizer=self.opt)
+            model_i.fit(
+                x=train_images, y=train_labels, batch_size=BATCH_SIZE, epochs=NB_EPOCHS
+            )
+
+    def predict(self, x, batch_size):
+        return self.ensemble.predict(x, batch_size=batch_size)
+
+
+"""
+## Training of models
+"""
+ensemble = ensemble(ensemble_size=ENSEMBLE_SIZE, gpus=GPUIDS)
+ensemble.fit(train_images, train_labels)
+
+"""
+## Inference
+### Models evaluation
+"""
+for i, base_model in enumerate(ensemble.model_list):
+    info = evaluate_model(base_model, test_images, test_labels)
+    print(f"Model id: {i} accuracy: {info['accuracy']} time: {info['time']}")
+
+"""
+### Ensemble evaluation
+"""
+info = evaluate_model(ensemble, test_images, test_labels)
+print(f"Ensemble accuracy: {info['accuracy']} inference time: {info['time']}")
+
+"""
+Conclusion: the asynchronous ensemble exploits well the underlying parallelism. The ensemble of N models is faster than N*T models, with T the average computing time of one model.
+"""
+


### PR DESCRIPTION
An ensemble is generally more accurate than the models in it. And more, the ensemble is known to be statistically more robust (reproducibility to random seeds and uncertainty estimate calibration). Asynchronous ensembles may exploit efficiently the underlying massively parallel devices (e.g., GPU). A proper asynchronous design does not multiply the computing time compared to the number of base models.

This is why I propose two designs: 

- **Design named shared_session.** Models are built in the same TF session. One TF session (arbitrary rank=0) is responsible for gathering and combining predictions.
- **Design named multiprocessing.** Models are built in independent TF sessions. They are distributed with the `multiprocessing` built-in python package. The parent process gathers and combines predictions with Numpy.

In both cases, on my Intel CPU I5, an ensemble of 4 CNNs is only 2 times slower than 1 CNN.