### PR TITLE
Fix CI: Update black version to match requirements.txt

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Ensure files are formatted with black
       run: |
         pip install --upgrade pip
-        pip install black==22.1.0
+        pip install black~=22.3.0
         black --check --diff ./examples
   docker-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes the black CI. The docker one is accidentally fixed by #1148.

black 22.1.0 is not compatible with the current version of `click` and fails on run. 
black 22.3.0 is, and seems to be working with the rest of the project (see the requirements.txt).

Ci is failing in:

https://github.com/keras-team/keras-io/pull/1149
https://github.com/keras-team/keras-io/pull/1148


with:

```
Successfully installed black-22.1.0 click-8.1.3 mypy-extensions-0.4.3 pathspec-0.10.2 platformdirs-2.6.0 tomli-2.0.1 typing-extensions-4.4.0
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.15/x64/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "src/black/__init__.py", line 1423, in patched_main
  File "src/black/__init__.py", line 1409, in patch_click
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/click/__init__.py)
Error: Process completed with exit code 1.
```