### PR TITLE
Fix the broken link in Stable diffusion tutorial

### DIFF
--- a/guides/ipynb/keras_cv/generate_images_with_stable_diffusion.ipynb
+++ b/guides/ipynb/keras_cv/generate_images_with_stable_diffusion.ipynb
@@ -161,6 +161,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"
@@ -216,10 +217,10 @@
     "All-in-all, it's a pretty simple system -- the Keras implementation\n",
     "fits in four files that represent less than 500 lines of code in total:\n",
     "\n",
-    "- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/text_encoder.py): 87 LOC\n",
-    "- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/diffusion_model.py): 181 LOC\n",
-    "- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/decoder.py): 86 LOC\n",
-    "- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/stable_diffusion.py): 106 LOC\n",
+    "- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/text_encoder.py): 87 LOC\n",
+    "- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/diffusion_model.py): 181 LOC\n",
+    "- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/decoder.py): 86 LOC\n",
+    "- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/stable_diffusion.py): 106 LOC\n",
     "\n",
     "But this relatively simple system starts looking like magic once you train on billions of pictures and their captions.\n",
     "As Feynman said about the universe: _\"It's not complicated, it's just a lot of it!\"_"

--- a/guides/keras_cv/generate_images_with_stable_diffusion.py
+++ b/guides/keras_cv/generate_images_with_stable_diffusion.py
@@ -137,10 +137,10 @@ Finally, the 64x64 latent image is sent through the decoder to properly render i
 All-in-all, it's a pretty simple system -- the Keras implementation
 fits in four files that represent less than 500 lines of code in total:
 
-- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/text_encoder.py): 87 LOC
-- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/diffusion_model.py): 181 LOC
-- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/decoder.py): 86 LOC
-- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/stable_diffusion.py): 106 LOC
+- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/text_encoder.py): 87 LOC
+- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/diffusion_model.py): 181 LOC
+- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/decoder.py): 86 LOC
+- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/stable_diffusion.py): 106 LOC
 
 But this relatively simple system starts looking like magic once you train on billions of pictures and their captions.
 As Feynman said about the universe: _"It's not complicated, it's just a lot of it!"_

--- a/guides/md/keras_cv/generate_images_with_stable_diffusion.md
+++ b/guides/md/keras_cv/generate_images_with_stable_diffusion.md
@@ -165,10 +165,10 @@ Finally, the 64x64 latent image is sent through the decoder to properly render i
 All-in-all, it's a pretty simple system -- the Keras implementation
 fits in four files that represent less than 500 lines of code in total:
 
-- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/text_encoder.py): 87 LOC
-- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/diffusion_model.py): 181 LOC
-- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/decoder.py): 86 LOC
-- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/generative/stable_diffusion/stable_diffusion.py): 106 LOC
+- [text_encoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/text_encoder.py): 87 LOC
+- [diffusion_model.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/diffusion_model.py): 181 LOC
+- [decoder.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/decoder.py): 86 LOC
+- [stable_diffusion.py](https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/stable_diffusion/stable_diffusion.py): 106 LOC
 
 But this relatively simple system starts looking like magic once you train on billions of pictures and their captions.
 As Feynman said about the universe: _"It's not complicated, it's just a lot of it!"_


### PR DESCRIPTION
Fix the broken code link to keras-cv in "High-performance image generation using Stable Diffusion in KerasCV" tutorial file. https://www.tensorflow.org/tutorials/generative/generate_images_with_stable_diffusion

Recreate PR in order to change all relative files (md, py, ipynb) . Previous PR: https://github.com/keras-team/keras-io/pull/1161