### PR TITLE
Fix broken link for KerasNLP Getting Started guide

### DIFF
--- a/templates/api/keras_nlp/index.md
+++ b/templates/api/keras_nlp/index.md
@@ -4,6 +4,6 @@ KerasNLP is a toolbox of modular building blocks ranging from pretrained
 state-of-the-art models, to low-level Transformer Encoder layers. For an
 introduction to the library see the  [KerasNLP home page](/keras_nlp). For a
 high-level introduction to the API see our
-[getting started guide](guides/keras_nlp/getting_started/).
+[getting started guide](/guides/keras_nlp/getting_started/).
 
 {{toc}}


### PR DESCRIPTION
Need absolute reference to link to guide from the API page.

TESTED: built site locally and checked link.