### PR TITLE
Fixed the broken link for `TensorBoard` callback

### DIFF
--- a/guides/training_with_built_in_methods.py
+++ b/guides/training_with_built_in_methods.py
@@ -1196,5 +1196,5 @@ keras.callbacks.TensorBoard(
 
 """
 For more information, see the
-[documentation for the `TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/).
+[documentation for the `TensorBoard` callback](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/TensorBoard).
 """


### PR DESCRIPTION
The link for "documentation for the `TensorBoard` callback" was taking to this page `https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/tensorboard/` which was populating `404 error` due to case sensitivity in tensorboard spelling . Fixed the link by mentioning correct working link - `https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/TensorBoard/`