### PR TITLE
Updated masking_and_padding with new apis

### DIFF
--- a/guides/ipynb/understanding_masking_and_padding.ipynb
+++ b/guides/ipynb/understanding_masking_and_padding.ipynb
@@ -92,7 +92,7 @@
     "one might also truncate long samples before padding short samples).\n",
     "\n",
     "Keras provides a utility function to truncate and pad Python lists to a common length:\n",
-    "`tf.keras.preprocessing.sequence.pad_sequences`."
+    "`tf.keras.utils.pad_sequences`."
    ]
   },
   {
@@ -116,7 +116,7 @@
     "# We recommend using \"post\" padding when working with RNN layers\n",
     "# (in order to be able to use the\n",
     "# CuDNN implementation of the layers).\n",
-    "padded_inputs = tf.keras.preprocessing.sequence.pad_sequences(\n",
+    "padded_inputs = tf.keras.utils.pad_sequences(\n",
     "    raw_inputs, padding=\"post\"\n",
     ")\n",
     "print(padded_inputs)\n",

--- a/guides/md/understanding_masking_and_padding.md
+++ b/guides/md/understanding_masking_and_padding.md
@@ -65,7 +65,7 @@ than the longest item need to be padded with some placeholder value (alternative
 one might also truncate long samples before padding short samples).
 
 Keras provides a utility function to truncate and pad Python lists to a common length:
-`tf.keras.preprocessing.sequence.pad_sequences`.
+`tf.keras.utils.pad_sequences`.
 
 
 ```python
@@ -82,7 +82,7 @@ raw_inputs = [
 # We recommend using "post" padding when working with RNN layers
 # (in order to be able to use the
 # CuDNN implementation of the layers).
-padded_inputs = tf.keras.preprocessing.sequence.pad_sequences(
+padded_inputs = tf.keras.utils.pad_sequences(
     raw_inputs, padding="post"
 )
 print(padded_inputs)

--- a/guides/understanding_masking_and_padding.py
+++ b/guides/understanding_masking_and_padding.py
@@ -59,7 +59,7 @@ than the longest item need to be padded with some placeholder value (alternative
 one might also truncate long samples before padding short samples).
 
 Keras provides a utility function to truncate and pad Python lists to a common length:
-`tf.keras.preprocessing.sequence.pad_sequences`.
+`tf.keras.utils.pad_sequences`.
 """
 
 raw_inputs = [
@@ -75,7 +75,7 @@ raw_inputs = [
 # We recommend using "post" padding when working with RNN layers
 # (in order to be able to use the
 # CuDNN implementation of the layers).
-padded_inputs = tf.keras.preprocessing.sequence.pad_sequences(
+padded_inputs = tf.keras.utils.pad_sequences(
     raw_inputs, padding="post"
 )
 print(padded_inputs)


### PR DESCRIPTION
Updated masking_and_padding with new apis
Old api - tf.keras.preprocessing.sequence.pad_sequences
new api - tf.keras.utils.pad_sequences
Attached [old](https://colab.sandbox.google.com/github/tensorflow/docs/blob/snapshot-keras/site/en/guide/keras/masking_and_padding.ipynb#scrollTo=bb64fb185a05) and [new](https://colab.sandbox.google.com/gist/mohantym/e0939e8637ea2f6d05a180144e8281b9/masking_and_padding.ipynb#scrollTo=906e07f6e562) gist for reference.