### PR TITLE
Updated Dependencies and DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.7
+FROM python:3.9
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
 COPY ./ ./
 WORKDIR scripts
+RUN pip install git+https://github.com/keras-team/keras-nlp.git tensorflow --upgrade
 RUN python autogen.py make
 
 CMD ["python", "-u", "autogen.py", "serve"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ jupyter
 tensorflow~=2.11.0
 tensorflow_datasets
 keras-tuner
-keras-cv
+keras-cv==0.3.4
 keras-nlp
+pycocotools


### PR DESCRIPTION
Solves: #1201 


I was trying to build the docker container, but it showed errors due to mismatched dependencies.

```py
You do not have pycocotools installed, so KerasCV pycoco metrics are not available. Please run `pip install pycocotools`.
```

Also had to downgrade `keras-cv` as 

```py
RuntimeError: For project keras_cv, URL https://github.com/keras-team/keras-cv/tree/v0.3.4/ has version number 0.3.4 which does not match the current imported package version 0.4.1
```

Also had to get `keras-nlp` from the source as pip didn't have the latest version 0.4.0 available and had to upgrade python as keras-nlp doesn't support `python:3.7`.