### PR TITLE
Update API symbols + genapi specs

### DIFF
--- a/scripts/cv_api_master.py
+++ b/scripts/cv_api_master.py
@@ -194,6 +194,13 @@ REGULARIZATION_MASTER = {
             "generate": [
                 "keras_cv.layers.SqueezeAndExcite2D",
             ],
+        },
+        {
+            "path": "stochastic_depth",
+            "title": "StochasticDepth layer",
+            "generate": [
+                "keras_cv.layers.StochasticDepth",
+            ],
         }
     ],
 }

--- a/scripts/cv_api_master.py
+++ b/scripts/cv_api_master.py
@@ -1,4 +1,3 @@
-
 AUGMENTATION_MASTER = {
     "path": "augmentation/",
     "title": "Augmentation layers",
@@ -29,7 +28,6 @@ AUGMENTATION_MASTER = {
             "title": "FourierMix layer",
             "generate": ["keras_cv.layers.FourierMix"],
         },
-
         {
             "path": "grid_mask",
             "title": "GridMask layer",
@@ -38,7 +36,7 @@ AUGMENTATION_MASTER = {
         {
             "path": "jittered_resize",
             "title": "JitteredResize layer",
-            "generate": ["keras_cv.layers.JitteredResize"]
+            "generate": ["keras_cv.layers.JitteredResize"],
         },
         {
             "path": "mix_up",
@@ -169,7 +167,7 @@ BOUNDING_BOX_UTILS = {
         },
         {
             "path": "validate_format",
-            "title": "Ensure that your bounding boxes comply with the bounding box spec"
+            "title": "Ensure that your bounding boxes comply with the bounding box spec",
             "generate": ["keras_cv.bounding_box.validate_format"],
         },
     ],
@@ -221,7 +219,7 @@ REGULARIZATION_MASTER = {
             "generate": [
                 "keras_cv.layers.StochasticDepth",
             ],
-        }
+        },
     ],
 }
 
@@ -278,23 +276,21 @@ MODELS_MASTER = {
         {
             "path": "faster_rcnn",
             "title": "The FasterRCNN model",
+            "generate": ["keras_cv.models.FasterRCNN"],
+        },
+        {
+            "path": "efficientnetv2",
+            "title": "EfficientNetV2 models",
             "generate": [
-                "keras_cv.models.FasterRCNN"
-            ]
-        }
-    {
-        "path": "efficientnetv2",
-        "title": "EfficientNetV2 models",
-        "generate": [
-            "keras_cv.models.EfficientNetV2B0",
-            "keras_cv.models.EfficientNetV2B1",
-            "keras_cv.models.EfficientNetV2B2",
-            "keras_cv.models.EfficientNetV2B3",
-            "keras_cv.models.EfficientNetV2S",
-            "keras_cv.models.EfficientNetV2M",
-            "keras_cv.models.EfficientNetV2L",
-        ],
-    },
+                "keras_cv.models.EfficientNetV2B0",
+                "keras_cv.models.EfficientNetV2B1",
+                "keras_cv.models.EfficientNetV2B2",
+                "keras_cv.models.EfficientNetV2B3",
+                "keras_cv.models.EfficientNetV2S",
+                "keras_cv.models.EfficientNetV2M",
+                "keras_cv.models.EfficientNetV2L",
+            ],
+        },
         {
             "path": "densenet",
             "title": "DenseNet models",

--- a/scripts/cv_api_master.py
+++ b/scripts/cv_api_master.py
@@ -36,14 +36,14 @@ AUGMENTATION_MASTER = {
             "generate": ["keras_cv.layers.GridMask"],
         },
         {
+            "path": "jittered_resize",
+            "title": "JitteredResize layer",
+            "generate": ["keras_cv.layers.JitteredResize"]
+        },
+        {
             "path": "mix_up",
             "title": "MixUp layer",
             "generate": ["keras_cv.layers.MixUp"],
-        },
-        {
-            "path": "posterization",
-            "title": "Posterization layer",
-            "generate": ["keras_cv.layers.Posterization"],
         },
         {
             "path": "rand_augment",
@@ -118,6 +118,11 @@ PREPROCESSING_MASTER = {
             "title": "Equalization layer",
             "generate": ["keras_cv.layers.Equalization"],
         },
+        {
+            "path": "posterization",
+            "title": "Posterization layer",
+            "generate": ["keras_cv.layers.Posterization"],
+        },
     ],
 }
 
@@ -151,6 +156,21 @@ BOUNDING_BOX_UTILS = {
             "path": "clip_to_image",
             "title": "Clip bounding boxes to be within the bounds of provided images",
             "generate": ["keras_cv.bounding_box.clip_to_image"],
+        },
+        {
+            "path": "to_dense",
+            "title": "Convert a bounding box dictionary to -1 padded Dense tensors",
+            "generate": ["keras_cv.bounding_box.to_dense"],
+        },
+        {
+            "path": "to_ragged",
+            "title": "Convert a bounding box dictionary batched Ragged tensors",
+            "generate": ["keras_cv.bounding_box.to_ragged"],
+        },
+        {
+            "path": "validate_format",
+            "title": "Ensure that your bounding boxes comply with the bounding box spec"
+            "generate": ["keras_cv.bounding_box.validate_format"],
         },
     ],
 }
@@ -255,6 +275,26 @@ MODELS_MASTER = {
                 "keras_cv.models.RetinaNet",
             ],
         },
+        {
+            "path": "faster_rcnn",
+            "title": "The FasterRCNN model",
+            "generate": [
+                "keras_cv.models.FasterRCNN"
+            ]
+        }
+    {
+        "path": "efficientnetv2",
+        "title": "EfficientNetV2 models",
+        "generate": [
+            "keras_cv.models.EfficientNetV2B0",
+            "keras_cv.models.EfficientNetV2B1",
+            "keras_cv.models.EfficientNetV2B2",
+            "keras_cv.models.EfficientNetV2B3",
+            "keras_cv.models.EfficientNetV2S",
+            "keras_cv.models.EfficientNetV2M",
+            "keras_cv.models.EfficientNetV2L",
+        ],
+    },
         {
             "path": "densenet",
             "title": "DenseNet models",

--- a/scripts/cv_api_master.py
+++ b/scripts/cv_api_master.py
@@ -1,6 +1,7 @@
-PREPROCESSING_MASTER = {
-    "path": "preprocessing/",
-    "title": "Preprocessing layers",
+
+AUGMENTATION_MASTER = {
+    "path": "augmentation/",
+    "title": "Augmentation layers",
     "toc": True,
     "children": [
         {
@@ -24,20 +25,11 @@ PREPROCESSING_MASTER = {
             "generate": ["keras_cv.layers.CutMix"],
         },
         {
-            "path": "equalization",
-            "title": "Equalization layer",
-            "generate": ["keras_cv.layers.Equalization"],
-        },
-        {
             "path": "fourier_mix",
             "title": "FourierMix layer",
             "generate": ["keras_cv.layers.FourierMix"],
         },
-        {
-            "path": "grayscale",
-            "title": "Grayscale layer",
-            "generate": ["keras_cv.layers.Grayscale"],
-        },
+
         {
             "path": "grid_mask",
             "title": "GridMask layer",
@@ -106,6 +98,29 @@ PREPROCESSING_MASTER = {
     ],
 }
 
+PREPROCESSING_MASTER = {
+    "path": "preprocessing/",
+    "title": "Preprocessing layers",
+    "toc": True,
+    "children": [
+        {
+            "path": "resizing",
+            "title": "Resizing layer",
+            "generate": ["keras_cv.layers.Resizing"],
+        },
+        {
+            "path": "grayscale",
+            "title": "Grayscale layer",
+            "generate": ["keras_cv.layers.Grayscale"],
+        },
+        {
+            "path": "equalization",
+            "title": "Equalization layer",
+            "generate": ["keras_cv.layers.Equalization"],
+        },
+    ],
+}
+
 BOUNDING_BOX_FORMATS = {
     "path": "formats",
     "title": "Bounding box formats",
@@ -158,6 +173,27 @@ REGULARIZATION_MASTER = {
             "generate": [
                 "keras_cv.layers.DropBlock2D",
             ],
+        },
+        {
+            "path": "drop_path",
+            "title": "DropPath layer",
+            "generate": [
+                "keras_cv.layers.DropPath",
+            ],
+        },
+        {
+            "path": "squeeze_and_excite_2d",
+            "title": "SqueezeAndExcite2D layer",
+            "generate": [
+                "keras_cv.layers.SqueezeAndExcite2D",
+            ],
+        },
+        {
+            "path": "squeeze_and_excite_2d",
+            "title": "SqueezeAndExcite2D layer",
+            "generate": [
+                "keras_cv.layers.SqueezeAndExcite2D",
+            ],
         }
     ],
 }
@@ -166,31 +202,32 @@ LAYERS_MASTER = {
     "path": "layers/",
     "title": "Layers",
     "toc": True,
-    "children": [PREPROCESSING_MASTER, REGULARIZATION_MASTER],
+    "children": [AUGMENTATION_MASTER, PREPROCESSING_MASTER, REGULARIZATION_MASTER],
 }
 
-
-METRICS_MASTER = {
-    "path": "metrics/",
-    "title": "Metrics",
-    "toc": True,
-    "children": [
-        {
-            "path": "coco_mean_average_precision",
-            "title": "COCOMeanAveragePrecision metric",
-            "generate": [
-                "keras_cv.metrics.COCOMeanAveragePrecision",
-            ],
-        },
-        {
-            "path": "coco_recall",
-            "title": "COCORecall metric",
-            "generate": [
-                "keras_cv.metrics.COCORecall",
-            ],
-        },
-    ],
-}
+#
+# METRICS_MASTER = {
+#     "path": "metrics/",
+#     "title": "Metrics",
+#     "toc": True,
+#     "children": [
+#         # Temporarily remove COCO metrics
+#         # {
+#         #     "path": "coco_mean_average_precision",
+#         #     "title": "COCOMeanAveragePrecision metric",
+#         #     "generate": [
+#         #         "keras_cv.metrics.COCOMeanAveragePrecision",
+#         #     ],
+#         # },
+#         # {
+#         #     "path": "coco_recall",
+#         #     "title": "COCORecall metric",
+#         #     "generate": [
+#         #         "keras_cv.metrics.COCORecall",
+#         #     ],
+#         # },
+#     ],
+# }
 
 MODELS_MASTER = {
     "path": "models/",
@@ -227,5 +264,5 @@ CV_API_MASTER = {
     "path": "keras_cv/",
     "title": "KerasCV",
     "toc": True,
-    "children": [LAYERS_MASTER, METRICS_MASTER, MODELS_MASTER, BOUNDING_BOX_MASTER],
+    "children": [LAYERS_MASTER, MODELS_MASTER, BOUNDING_BOX_MASTER],
 }

--- a/templates/keras_cv/bounding_box/index.md
+++ b/templates/keras_cv/bounding_box/index.md
@@ -4,7 +4,18 @@ All KerasCV components that process bounding boxes require a `bounding_box_forma
 argument.  This argument allows you to seamlessly integrate KerasCV components into
 your own workflows while preserving proper behavior of the components themselves.
 
-The bounding box formats supported in KerasCV 
+Bounding boxes are represented by dictionaries with two keys: `'boxes'` and `'classes'`:
+
+```
+{
+  'boxes': [batch, num_boxes, 4],
+  'classes': [batch, num_boxes]
+}
+```
+
+To ensure your bounding boxes comply with the KerasCV specification, you can use [`keras_cv.bounding_box.validate_format(boxes)`](https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/validate_format.py).
+
+The bounding box formats supported in KerasCV
 [are listed in the API docs](/api/keras_cv/bounding_box/formats)
 If a format you would like to use is missing,
 [feel free to open a GitHub issue on KerasCV](https://github.com/keras-team/keras-cv/issues)!


### PR DESCRIPTION
Lets still hold off on the v0.4.0 publicity push until:

- keras.io/guides/retinanet is fixed
- keras.io/keras_cv is updated

I will update keras.io/keras_cv in a separate PR