### PR TITLE
Pin the Keras packages versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas
 jupyter
 tensorflow~=2.11.0
 tensorflow_datasets
-keras-tuner
-keras-cv
-keras-nlp
+keras-tuner==1.2.0
+keras-cv==0.4.1
+keras-nlp==0.4.0
 pycocotools


### PR DESCRIPTION
If not pin the versions of the Keras packages (CV, NLP, Tuner), the CI will always pick the latest version to install.
It breaks whenever a new version is released due to inconsistency with the version specified in `autogen.py`.