### PR TITLE
Added responsiveness to landing page images.

### DIFF
--- a/theme/css/landing.css
+++ b/theme/css/landing.css
@@ -145,7 +145,7 @@ a:hover {
 }
 
 .showcase .showcase-img {
-  min-height: 25rem;
+  min-height: 20rem;
   background-size: cover;
 }
 


### PR DESCRIPTION
Some images of the landing page are not responsive on some devices. So I played with the CSS of the landing page and found out that `min-height: 20rem` works better than `min-height: 25rem`. That's why I changed it to 20rem.