### PR TITLE
Fix padding mask broadcasting for encoder transformer

### DIFF
--- a/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
+++ b/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
@@ -367,7 +367,7 @@
     "\n",
     "    def call(self, inputs, mask=None):\n",
     "        if mask is not None:\n",
-    "            padding_mask = tf.cast(mask[:, tf.newaxis, tf.newaxis, :], dtype=\"int32\")\n",
+    "            padding_mask = tf.cast(mask[:, tf.newaxis, :], dtype=\"int32\")\n",
     "        attention_output = self.attention(\n",
     "            query=inputs, value=inputs, key=inputs, attention_mask=padding_mask\n",
     "        )\n",

--- a/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
+++ b/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [fchollet](https://twitter.com/fchollet)<br>\n",
     "**Date created:** 2021/05/26<br>\n",
-    "**Last modified:** 2021/05/26<br>\n",
+    "**Last modified:** 2022/02/25<br>\n",
     "**Description:** Implementing a sequence-to-sequene Transformer and training it on a machine translation task."
    ]
   },

--- a/examples/nlp/md/neural_machine_translation_with_transformer.md
+++ b/examples/nlp/md/neural_machine_translation_with_transformer.md
@@ -272,7 +272,7 @@ class TransformerEncoder(layers.Layer):
 
     def call(self, inputs, mask=None):
         if mask is not None:
-            padding_mask = tf.cast(mask[:, tf.newaxis, tf.newaxis, :], dtype="int32")
+            padding_mask = tf.cast(mask[:, tf.newaxis, :], dtype="int32")
         attention_output = self.attention(
             query=inputs, value=inputs, key=inputs, attention_mask=padding_mask
         )

--- a/examples/nlp/md/neural_machine_translation_with_transformer.md
+++ b/examples/nlp/md/neural_machine_translation_with_transformer.md
@@ -2,7 +2,7 @@
 
 **Author:** [fchollet](https://twitter.com/fchollet)<br>
 **Date created:** 2021/05/26<br>
-**Last modified:** 2021/05/26<br>
+**Last modified:** 2022/02/25<br>
 **Description:** Implementing a sequence-to-sequene Transformer and training it on a machine translation task.
 
 

--- a/examples/nlp/neural_machine_translation_with_transformer.py
+++ b/examples/nlp/neural_machine_translation_with_transformer.py
@@ -2,7 +2,7 @@
 Title: English-to-Spanish translation with a sequence-to-sequence Transformer
 Author: [fchollet](https://twitter.com/fchollet)
 Date created: 2021/05/26
-Last modified: 2021/05/26
+Last modified: 2022/02/25
 Description: Implementing a sequence-to-sequene Transformer and training it on a machine translation task.
 Accelerator: GPU
 """
@@ -239,7 +239,7 @@ class TransformerEncoder(layers.Layer):
 
     def call(self, inputs, mask=None):
         if mask is not None:
-            padding_mask = tf.cast(mask[:, tf.newaxis, tf.newaxis, :], dtype="int32")
+            padding_mask = tf.cast(mask[:, tf.newaxis, :], dtype="int32")
         attention_output = self.attention(
             query=inputs, value=inputs, key=inputs, attention_mask=padding_mask
         )


### PR DESCRIPTION
Fixes Issue #1252 by adjusting the `padding_mask` broadcast in `TransformerEncoder` to be same as `TransformerDecoder`.  Tested in TensorFlow 2.9 and also in 2.11 on Colab.