### PR TITLE
Update Keras-NLP version to match requirements

### DIFF
--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -42,7 +42,7 @@ PROJECT_URL = {
     "keras": "https://github.com/keras-team/keras/tree/v2.11.0/",
     "keras_tuner": "https://github.com/keras-team/keras-tuner/tree/v1.3.0/",
     "keras_cv": "https://github.com/keras-team/keras-cv/tree/v0.4.1/",
-    "keras_nlp": "https://github.com/keras-team/keras-nlp/tree/v0.4.0/",
+    "keras_nlp": "https://github.com/keras-team/keras-nlp/tree/v0.4.1/",
 }
 
 


### PR DESCRIPTION
Keras-NLP version in `requirements.txt` was updated to `0.4.1` (#1244).  This also needs to be updated in the `autogen.py` URL for the project.