### PR TITLE
Remove Cuda Install Steps

### DIFF
--- a/examples/generative/ipynb/random_walks_with_stable_diffusion.ipynb
+++ b/examples/generative/ipynb/random_walks_with_stable_diffusion.ipynb
@@ -78,8 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorflow keras_cv --upgrade --quiet\n",
-    "!apt install --allow-change-held-packages libcudnn8=8.1.0.77-1+cuda11.2"
+    "!pip install tensorflow keras_cv --upgrade --quiet"
    ]
   },
   {

--- a/guides/ipynb/keras_cv/generate_images_with_stable_diffusion.ipynb
+++ b/guides/ipynb/keras_cv/generate_images_with_stable_diffusion.ipynb
@@ -46,8 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorflow keras_cv --upgrade --quiet\n",
-    "!apt install --allow-change-held-packages libcudnn8=8.1.0.77-1+cuda11.2"
+    "!pip install tensorflow keras_cv --upgrade --quiet"
    ]
   },
   {


### PR DESCRIPTION
Remove Cuda 11.2 install steps from Notebooks since its no longer required for Colab.