### PR TITLE
fix a minor typo & markdown table

### DIFF
--- a/examples/generative/ipynb/neural_style_transfer.ipynb
+++ b/examples/generative/ipynb/neural_style_transfer.ipynb
@@ -416,10 +416,9 @@
    },
    "source": [
     "**Example available on HuggingFace**\n",
-    "\n",
-    "Trained Model | Demo \n",
-    "--- | --- \n",
-    "[![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) "
+    "| Trained Model | Demo |\n",
+    "| :--: | :--: |\n",
+    "| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) |"
    ]
   }
  ],

--- a/examples/generative/ipynb/neural_style_transfer.ipynb
+++ b/examples/generative/ipynb/neural_style_transfer.ipynb
@@ -11,7 +11,7 @@
     "**Author:** [fchollet](https://twitter.com/fchollet)<br>\n",
     "**Date created:** 2016/01/11<br>\n",
     "**Last modified:** 2020/05/02<br>\n",
-    "**Description:** Transfering the style of a reference image to target image using gradient descent."
+    "**Description:** Transferring the style of a reference image to target image using gradient descent."
    ]
   },
   {
@@ -416,9 +416,10 @@
    },
    "source": [
     "**Example available on HuggingFace**\n",
-    "| Trained Model | Demo |\n",
-    "| :--: | :--: |\n",
-    "| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) |"
+    "\n",
+    "Trained Model | Demo \n",
+    "--- | --- \n",
+    "[![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) "
    ]
   }
  ],

--- a/examples/generative/md/neural_style_transfer.md
+++ b/examples/generative/md/neural_style_transfer.md
@@ -3,7 +3,7 @@
 **Author:** [fchollet](https://twitter.com/fchollet)<br>
 **Date created:** 2016/01/11<br>
 **Last modified:** 2020/05/02<br>
-**Description:** Transfering the style of a reference image to target image using gradient descent.
+**Description:** Transferring the style of a reference image to target image using gradient descent.
 
 
 <img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/generative/ipynb/neural_style_transfer.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/generative/neural_style_transfer.py)
@@ -371,6 +371,7 @@ display(Image(result_prefix + "_at_iteration_4000.png"))
 
 
 **Example available on HuggingFace**
-| Trained Model | Demo |
-| :--: | :--: |
-| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) |
+
+Trained Model | Demo |
+--- | --- 
+[![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) 

--- a/examples/generative/neural_style_transfer.py
+++ b/examples/generative/neural_style_transfer.py
@@ -3,7 +3,7 @@ Title: Neural style transfer
 Author: [fchollet](https://twitter.com/fchollet)
 Date created: 2016/01/11
 Last modified: 2020/05/02
-Description: Transfering the style of a reference image to target image using gradient descent.
+Description: Transferring the style of a reference image to target image using gradient descent.
 Accelerator: GPU
 """
 
@@ -273,7 +273,8 @@ display(Image(result_prefix + "_at_iteration_4000.png"))
 
 """
 **Example available on HuggingFace**
-| Trained Model | Demo |
-| :--: | :--: |
-| [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) |
+
+Trained Model | Demo 
+--- | --- 
+[![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Model-Neural%20style%20transfer-black.svg)](https://huggingface.co/keras-io/VGG19) | [![Generic badge](https://img.shields.io/badge/%F0%9F%A4%97%20Spaces-Neural%20style%20transfer-black.svg)](https://huggingface.co/spaces/keras-io/neural-style-transfer) 
 """

--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -40,9 +40,9 @@ import matplotlib.pyplot as plt
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow import keras
-from tensorflow.keras import applications
-from tensorflow.keras import losses
-from tensorflow.keras import optimizers
+from keras import applications
+from keras import losses
+from keras import optimizers
 
 """
 ## Data loading
@@ -227,7 +227,7 @@ times. `RandAugment` can be thought of as a specific case of
 `RandomAugmentationPipeline` internally.
 
 In this example, we will create a custom `RandomAugmentationPipeline` by removing
-`RandomRotation` layers from the standard `RandAugment` policy, and substitutex a
+`RandomRotation` layers from the standard `RandAugment` policy, and substitute a
 `GridMask` layer in its place.
 """
 
@@ -329,8 +329,6 @@ test_dataset = test_dataset.map(preprocess_for_model, num_parallel_calls=AUTOTUN
 train_dataset = train_dataset.prefetch(AUTOTUNE)
 test_dataset = test_dataset.prefetch(AUTOTUNE)
 
-train_dataset = train_dataset
-test_dataset = test_dataset
 
 """
 Next we should create a the model itself. Notice that we use `label_smoothing=0.1` in


### PR DESCRIPTION
- fix minor spelling typo, Transfering -> Transferring
- fix a table at the end of the tutorial in order to fit into both GitHub & Colab notebooks markdown guide (Colab markdown reference: https://colab.research.google.com/notebooks/markdown_guide.ipynb)