### PR TITLE
fix typos in 'image augmentation with KerasCV' guide

### DIFF
--- a/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
+++ b/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
@@ -362,7 +362,7 @@
     "`RandomAugmentationPipeline` internally.\n",
     "\n",
     "In this example, we will create a custom `RandomAugmentationPipeline` by removing\n",
-    "`RandomRotation` layers from the standard `RandAugment` policy, and substitutex a\n",
+    "`RandomRotation` layers from the standard `RandAugment` policy, and substitute a\n",
     "`GridMask` layer in its place."
    ]
   },
@@ -578,9 +578,6 @@
     "\n",
     "train_dataset = train_dataset.prefetch(AUTOTUNE)\n",
     "test_dataset = test_dataset.prefetch(AUTOTUNE)\n",
-    "\n",
-    "train_dataset = train_dataset\n",
-    "test_dataset = test_dataset"
    ]
   },
   {

--- a/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
+++ b/guides/ipynb/keras_cv/cut_mix_mix_up_and_rand_augment.ipynb
@@ -577,7 +577,7 @@
     "test_dataset = test_dataset.map(preprocess_for_model, num_parallel_calls=AUTOTUNE)\n",
     "\n",
     "train_dataset = train_dataset.prefetch(AUTOTUNE)\n",
-    "test_dataset = test_dataset.prefetch(AUTOTUNE)\n",
+    "test_dataset = test_dataset.prefetch(AUTOTUNE)\n"
    ]
   },
   {

--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -40,9 +40,9 @@ import matplotlib.pyplot as plt
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow import keras
-from tensorflow.keras import applications
-from tensorflow.keras import losses
-from tensorflow.keras import optimizers
+from keras import applications
+from keras import losses
+from keras import optimizers
 
 """
 ## Data loading
@@ -227,7 +227,7 @@ times. `RandAugment` can be thought of as a specific case of
 `RandomAugmentationPipeline` internally.
 
 In this example, we will create a custom `RandomAugmentationPipeline` by removing
-`RandomRotation` layers from the standard `RandAugment` policy, and substitutex a
+`RandomRotation` layers from the standard `RandAugment` policy, and substitute a
 `GridMask` layer in its place.
 """
 
@@ -329,8 +329,6 @@ test_dataset = test_dataset.map(preprocess_for_model, num_parallel_calls=AUTOTUN
 train_dataset = train_dataset.prefetch(AUTOTUNE)
 test_dataset = test_dataset.prefetch(AUTOTUNE)
 
-train_dataset = train_dataset
-test_dataset = test_dataset
 
 """
 Next we should create a the model itself. Notice that we use `label_smoothing=0.1` in

--- a/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
+++ b/guides/keras_cv/cut_mix_mix_up_and_rand_augment.py
@@ -40,9 +40,9 @@ import matplotlib.pyplot as plt
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow import keras
-from keras import applications
-from keras import losses
-from keras import optimizers
+from tensorflow.keras import applications
+from tensorflow.keras import losses
+from tensorflow.keras import optimizers
 
 """
 ## Data loading

--- a/guides/md/keras_cv/cut_mix_mix_up_and_rand_augment.md
+++ b/guides/md/keras_cv/cut_mix_mix_up_and_rand_augment.md
@@ -250,7 +250,7 @@ times. `RandAugment` can be thought of as a specific case of
 `RandomAugmentationPipeline` internally.
 
 In this example, we will create a custom `RandomAugmentationPipeline` by removing
-`RandomRotation` layers from the standard `RandAugment` policy, and substitutex a
+`RandomRotation` layers from the standard `RandAugment` policy, and substitute a
 `GridMask` layer in its place.
 
 As a first step, let's use the helper method `RandAugment.get_standard_policy()` to
@@ -368,8 +368,6 @@ test_dataset = test_dataset.map(preprocess_for_model, num_parallel_calls=AUTOTUN
 train_dataset = train_dataset.prefetch(AUTOTUNE)
 test_dataset = test_dataset.prefetch(AUTOTUNE)
 
-train_dataset = train_dataset
-test_dataset = test_dataset
 ```
 
 


### PR DESCRIPTION
1) change all `from tensorflow.keras import ~` to `from keras import ~` since the guide imports `from tensorflow import keras` previously. Before the change, those import lines prompt errors while running the file in both local and Google Colab. 

2) fix a minor spelling typo.

3) Not sure why those lines of code are written (I guess redundant). The code works perfectly okay without those lines, so I delete it. However, I will revert the change if you suggest to keep those lines.