### PR TITLE
Add `Semantic Similarity with KerasNLP` tutorial

### DIFF
--- a/examples/nlp/ipynb/semantic_similarity_with_keras_nlp.ipynb
+++ b/examples/nlp/ipynb/semantic_similarity_with_keras_nlp.ipynb
@@ -257,7 +257,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Our BERT classifier achieved an accuracy of around 65% on the validation split. Now,\n",
+    "Our BERT classifier achieved an accuracy of around 76% on the validation split. Now,\n",
     "let's evaluate its performance on the test split.\n",
     "\n",
     "### Evaluate the performance of the trained model on test data."
@@ -280,9 +280,9 @@
     "colab_type": "text"
    },
    "source": [
-    "Our baseline BERT model achieved a similar accuracy of around 68% on the test split.\n",
-    "Now, let's try to improve its performance by recompiling the model with a different\n",
-    "learning rate."
+    "Our baseline BERT model achieved a similar accuracy of around 76% on the test split.\n",
+    "Now, let's try to improve its performance by recompiling the model with a slightly\n",
+    "higher learning rate."
    ]
   },
   {
@@ -298,7 +298,7 @@
     ")\n",
     "bert_classifier.compile(\n",
     "    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
-    "    optimizer=keras.optimizers.Adam(1e-4),\n",
+    "    optimizer=keras.optimizers.Adam(5e-5),\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
     "\n",
@@ -312,10 +312,9 @@
     "colab_type": "text"
    },
    "source": [
-    "This time, we achieve around 72% validation accuracy on both the validation and test\n",
-    "splits after just one epoch, which is quite impressive!\n",
-    "\n",
-    "Now, let's see if we can further improve the model by using a learning rate scheduler."
+    "Just tweaking the learning rate alone was not enough to boost performance, which\n",
+    "stayed right around 76%. Let's try again, but this time with\n",
+    "`keras.optimizers.AdamW`, and a learning rate schedule."
    ]
   },
   {
@@ -364,7 +363,7 @@
     "bert_classifier.compile(\n",
     "    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "    optimizer=keras.optimizers.AdamW(\n",
-    "        TriangularSchedule(0.001, warmup_steps, total_steps)\n",
+    "        TriangularSchedule(1e-4, warmup_steps, total_steps)\n",
     "    ),\n",
     "    metrics=[\"accuracy\"],\n",
     ")\n",
@@ -378,9 +377,8 @@
     "colab_type": "text"
    },
    "source": [
-    "Great! With the learning rate scheduler and the `AdamW` optimizer, our validation\n",
-    "accuracy improved to around 79% within one epoch, and it hiked to 86% in three\n",
-    "epochs.\n",
+    "Success! With the learning rate scheduler and the `AdamW` optimizer, our validation\n",
+    "accuracy improved to around 79%.\n",
     "\n",
     "Now, let's evaluate our final model on the test set and see how it performs."
    ]

--- a/examples/nlp/ipynb/semantic_similarity_with_keras_nlp.ipynb
+++ b/examples/nlp/ipynb/semantic_similarity_with_keras_nlp.ipynb
@@ -1,0 +1,592 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Semantic Similarity with KerasNLP\n",
+    "\n",
+    "**Author:** [Anshuman Mishra](https://github.com/shivance/)<br>\n",
+    "**Date created:** 2023/02/25<br>\n",
+    "**Last modified:** 2023/02/25<br>\n",
+    "**Description:** Use pretrained models from KerasNLP for the Semantic Similarity Task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Semantic similarity refers to the task of determining the degree of similarity between two\n",
+    "sentences in terms of their meaning. We already saw in [this](https://keras.io/examples/nlp/semantic_similarity_with_bert/)\n",
+    "example how to use SNLI (Stanford Natural Language Inference) corpus to predict sentence\n",
+    "semantic similarity with the HuggingFace Transformers library. In this tutorial we will\n",
+    "learn how to use [KerasNLP](https://keras.io/keras_nlp/), an extension of the core Keras API,\n",
+    "for the same task. Furthermore, we will discover how KerasNLP effectively reduces boilerplate\n",
+    "code and simplifies the process of building and utilizing models. For more information on KerasNLP,\n",
+    "please refer to [KerasNLP's official documentation](https://keras.io/keras_nlp/).\n",
+    "\n",
+    "This guide is broken down into the following parts:\n",
+    "\n",
+    "1. *Setup*, task definition, and establishing a baseline.\n",
+    "2. *Establishing baseline* with BERT.\n",
+    "3. *Saving and Reloading* the model.\n",
+    "4. *Performing inference* with the model.\n",
+    "5  *Improving accuracy* with RoBERTa\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "The following guide uses [Keras Core](https://keras.io/keras_core/) to work in\n",
+    "any of `tensorflow`, `jax` or `torch`. Support for Keras Core is baked into\n",
+    "KerasNLP, simply change the `KERAS_BACKEND` environment variable below to change\n",
+    "the backend you would like to use. We select the `jax` backend below, which will\n",
+    "give us a particularly fast train step below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q keras-nlp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # or \"tensorflow\" or \"torch\"\n",
+    "\n",
+    "\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "import keras_core as keras\n",
+    "import keras_nlp\n",
+    "import tensorflow_datasets as tfds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "To load the SNLI dataset, we use the tensorflow-datasets library, which\n",
+    "contains over 550,000 samples in total. However, to ensure that this example runs\n",
+    "quickly, we use only 20% of the training samples.\n",
+    "\n",
+    "## Overview of SNLI Dataset\n",
+    "\n",
+    "Every sample in the dataset contains three components: `hypothesis`, `premise`,\n",
+    "and `label`. epresents the original caption provided to the author of the pair,\n",
+    "while the hypothesis refers to the hypothesis caption created by the author of\n",
+    "the pair. The label is assigned by annotators to indicate the similarity between\n",
+    "the two sentences.\n",
+    "\n",
+    "The dataset contains three possible similarity label values: Contradiction, Entailment,\n",
+    "and Neutral. Contradiction represents completely dissimilar sentences, while Entailment\n",
+    "denotes similar meaning sentences. Lastly, Neutral refers to sentences where no clear\n",
+    "similarity or dissimilarity can be established between them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "snli_train = tfds.load(\"snli\", split=\"train[:20%]\")\n",
+    "snli_val = tfds.load(\"snli\", split=\"validation\")\n",
+    "snli_test = tfds.load(\"snli\", split=\"test\")\n",
+    "\n",
+    "# Here's an example of how our training samples look like, where we randomly select\n",
+    "# four samples:\n",
+    "sample = snli_test.batch(4).take(1).get_single_element()\n",
+    "sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Preprocessing\n",
+    "\n",
+    "In our dataset, we have identified that some samples have missing or incorrectly labeled\n",
+    "data, which is denoted by a value of -1. To ensure the accuracy and reliability of our model,\n",
+    "we simply filter out these samples from our dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def filter_labels(sample):\n",
+    "    return sample[\"label\"] >= 0\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Here's a utility function that splits the example into an `(x, y)` tuple that is suitable\n",
+    "for `model.fit()`. By default, `keras_nlp.models.BertClassifier` will tokenize and pack\n",
+    "together raw strings using a `\"[SEP]\"` token during training. Therefore, this label\n",
+    "splitting is all the data preparation that we need to perform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def split_labels(sample):\n",
+    "    x = (sample[\"hypothesis\"], sample[\"premise\"])\n",
+    "    y = sample[\"label\"]\n",
+    "    return x, y\n",
+    "\n",
+    "\n",
+    "train_ds = (\n",
+    "    snli_train.filter(filter_labels)\n",
+    "    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "    .batch(16)\n",
+    ")\n",
+    "val_ds = (\n",
+    "    snli_val.filter(filter_labels)\n",
+    "    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "    .batch(16)\n",
+    ")\n",
+    "test_ds = (\n",
+    "    snli_test.filter(filter_labels)\n",
+    "    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "    .batch(16)\n",
+    ")\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Establishing baseline with BERT.\n",
+    "\n",
+    "We use the BERT model from KerasNLP to establish a baseline for our semantic similarity\n",
+    "task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT\n",
+    "Backbone, mapping the backbone outputs to a logit output suitable for a classification task.\n",
+    "This significantly reduces the need for custom code.\n",
+    "\n",
+    "KerasNLP models have built-in tokenization capabilities that handle tokenization by default\n",
+    "based on the selected model. However, users can also use custom preprocessing techniques\n",
+    "as per their specific needs. If we pass a tuple as input, the model will tokenize all the\n",
+    "strings and concatenate them with a `\"[SEP]\"` separator.\n",
+    "\n",
+    "We use this model with pretrained weights, and we can use the `from_preset()` method\n",
+    "to use our own preprocessor. For the SNLI dataset, we set `num_classes` to 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier = keras_nlp.models.BertClassifier.from_preset(\n",
+    "    \"bert_tiny_en_uncased\", num_classes=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Please note that the BERT Tiny model has only 4,386,307 trainable parameters.\n",
+    "\n",
+    "KerasNLP task models come with compilation defaults. We can now train the model we just\n",
+    "instantiated by calling the `fit()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Our BERT classifier achieved an accuracy of around 65% on the validation split. Now,\n",
+    "let's evaluate its performance on the test split.\n",
+    "\n",
+    "### Evaluate the performance of the trained model on test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Our baseline BERT model achieved a similar accuracy of around 68% on the test split.\n",
+    "Now, let's try to improve its performance by recompiling the model with a different\n",
+    "learning rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier = keras_nlp.models.BertClassifier.from_preset(\n",
+    "    \"bert_tiny_en_uncased\", num_classes=3\n",
+    ")\n",
+    "bert_classifier.compile(\n",
+    "    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "    optimizer=keras.optimizers.Adam(1e-4),\n",
+    "    metrics=[\"accuracy\"],\n",
+    ")\n",
+    "\n",
+    "bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)\n",
+    "bert_classifier.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "This time, we achieve around 72% validation accuracy on both the validation and test\n",
+    "splits after just one epoch, which is quite impressive!\n",
+    "\n",
+    "Now, let's see if we can further improve the model by using a learning rate scheduler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "class TriangularSchedule(keras.optimizers.schedules.LearningRateSchedule):\n",
+    "    \"\"\"Linear ramp up for `warmup` steps, then linear decay to zero at `total` steps.\"\"\"\n",
+    "\n",
+    "    def __init__(self, rate, warmup, total):\n",
+    "        self.rate = rate\n",
+    "        self.warmup = warmup\n",
+    "        self.total = total\n",
+    "\n",
+    "    def get_config(self):\n",
+    "        config = {\"rate\": self.rate, \"warmup\": self.warmup, \"total\": self.total}\n",
+    "        return config\n",
+    "\n",
+    "    def __call__(self, step):\n",
+    "        step = keras.ops.cast(step, dtype=\"float32\")\n",
+    "        rate = keras.ops.cast(self.rate, dtype=\"float32\")\n",
+    "        warmup = keras.ops.cast(self.warmup, dtype=\"float32\")\n",
+    "        total = keras.ops.cast(self.total, dtype=\"float32\")\n",
+    "\n",
+    "        warmup_rate = rate * step / self.warmup\n",
+    "        cooldown_rate = rate * (total - step) / (total - warmup)\n",
+    "        triangular_rate = keras.ops.minimum(warmup_rate, cooldown_rate)\n",
+    "        return keras.ops.maximum(triangular_rate, 0.0)\n",
+    "\n",
+    "\n",
+    "bert_classifier = keras_nlp.models.BertClassifier.from_preset(\n",
+    "    \"bert_tiny_en_uncased\", num_classes=3\n",
+    ")\n",
+    "\n",
+    "# Get the total count of training batches.\n",
+    "# This requires walking the dataset to filter all -1 labels.\n",
+    "epochs = 3\n",
+    "total_steps = sum(1 for _ in train_ds.as_numpy_iterator()) * epochs\n",
+    "warmup_steps = int(total_steps * 0.2)\n",
+    "\n",
+    "bert_classifier.compile(\n",
+    "    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "    optimizer=keras.optimizers.AdamW(\n",
+    "        TriangularSchedule(0.001, warmup_steps, total_steps)\n",
+    "    ),\n",
+    "    metrics=[\"accuracy\"],\n",
+    ")\n",
+    "\n",
+    "bert_classifier.fit(train_ds, validation_data=val_ds, epochs=epochs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Great! With the learning rate scheduler and the `AdamW` optimizer, our validation\n",
+    "accuracy improved to around 79% within one epoch, and it hiked to 86% in three\n",
+    "epochs.\n",
+    "\n",
+    "Now, let's evaluate our final model on the test set and see how it performs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Our Tiny BERT model achieved an accuracy of approximately 79% on the test set\n",
+    "with the use of a learning rate scheduler. This is a significant improvement over\n",
+    "our previous results. Fine-tuning a pretrained BERT\n",
+    "model can be a powerful tool in natural language processing tasks, and even a\n",
+    "small model like Tiny BERT can achieve impressive results.\n",
+    "\n",
+    "Let's save our model for now\n",
+    "and move on to learning how to perform inference with it.\n",
+    "\n",
+    "## Save and Reload the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "bert_classifier.save(\"bert_classifier.keras\")\n",
+    "restored_model = keras.models.load_model(\"bert_classifier.keras\")\n",
+    "restored_model.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Performing inference with the model.\n",
+    "\n",
+    "Let's see how to perform inference with KerasNLP models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# Convert to Hypothesis-Premise pair, for forward pass through model\n",
+    "sample = (sample[\"hypothesis\"], sample[\"premise\"])\n",
+    "sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The default preprocessor in KerasNLP models handles input tokenization automatically,\n",
+    "so we don't need to perform tokenization explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "predictions = bert_classifier.predict(sample)\n",
+    "\n",
+    "\n",
+    "def softmax(x):\n",
+    "    return np.exp(x) / np.exp(x).sum(axis=0)\n",
+    "\n",
+    "\n",
+    "# Get the class predictions with maximum probabilities\n",
+    "predictions = softmax(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Improving accuracy with RoBERTa\n",
+    "\n",
+    "Now that we have established a baseline, we can attempt to improve our results\n",
+    "by experimenting with different models. Thanks to KerasNLP, fine-tuning a RoBERTa\n",
+    "checkpoint on the same dataset is easy with just a few lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# Inittializing a RoBERTa from preset\n",
+    "roberta_classifier = keras_nlp.models.RobertaClassifier.from_preset(\n",
+    "    \"roberta_base_en\", num_classes=3\n",
+    ")\n",
+    "\n",
+    "roberta_classifier.fit(train_ds, validation_data=val_ds, epochs=1)\n",
+    "\n",
+    "roberta_classifier.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The RoBERTa base model has significantly more trainable parameters than the BERT\n",
+    "Tiny model, with almost 30 times as many at 124,645,635 parameters. As a result, it took\n",
+    "approximately 1.5 hours to train on a P100 GPU. However, the performance\n",
+    "improvement was substantial, with accuracy increasing to 88% on both the validation\n",
+    "and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on\n",
+    "our P100 GPU.\n",
+    "\n",
+    "Despite using a different model, the steps to perform inference with RoBERTa are\n",
+    "the same as with BERT!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "predictions = roberta_classifier.predict(sample)\n",
+    "print(tf.math.argmax(predictions, axis=1).numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We hope this tutorial has been helpful in demonstrating the ease and effectiveness\n",
+    "of using KerasNLP and BERT for semantic similarity tasks.\n",
+    "\n",
+    "Throughout this tutorial, we demonstrated how to use a pretrained BERT model to\n",
+    "establish a baseline and improve performance by training a larger RoBERTa model\n",
+    "using just a few lines of code.\n",
+    "\n",
+    "The KerasNLP toolbox provides a range of modular building blocks for preprocessing\n",
+    "text, including pretrained state-of-the-art models and low-level Transformer Encoder\n",
+    "layers. We believe that this makes experimenting with natural language solutions\n",
+    "more accessible and efficient."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "semantic_similarity_with_keras_nlp",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/nlp/md/semantic_similarity_with_keras_nlp.md
+++ b/examples/nlp/md/semantic_similarity_with_keras_nlp.md
@@ -195,13 +195,13 @@ bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 
 <div class="k-default-codeblock">
 ```
-[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - loss: 0.8587 - sparse_categorical_accuracy: 0.6023 - val_loss: 0.5883 - val_sparse_categorical_accuracy: 0.7654
+[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - loss: 0.8584 - sparse_categorical_accuracy: 0.6049 - val_loss: 0.5857 - val_sparse_categorical_accuracy: 0.7608
 
-<keras_core.src.callbacks.history.History at 0x7f16081712d0>
+<keras_core.src.callbacks.history.History at 0x7fc6cbf41ea0>
 
 ```
 </div>
-Our BERT classifier achieved an accuracy of around 65% on the validation split. Now,
+Our BERT classifier achieved an accuracy of around 76% on the validation split. Now,
 let's evaluate its performance on the test split.
 
 ### Evaluate the performance of the trained model on test data.
@@ -213,15 +213,15 @@ bert_classifier.evaluate(test_ds)
 
 <div class="k-default-codeblock">
 ```
-[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - loss: 0.5871 - sparse_categorical_accuracy: 0.7656
+[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - loss: 0.5709 - sparse_categorical_accuracy: 0.7742
 
-[0.5927907824516296, 0.7624185681343079]
+[0.5832399725914001, 0.7678135633468628]
 
 ```
 </div>
-Our baseline BERT model achieved a similar accuracy of around 68% on the test split.
-Now, let's try to improve its performance by recompiling the model with a different
-learning rate.
+Our baseline BERT model achieved a similar accuracy of around 76% on the test split.
+Now, let's try to improve its performance by recompiling the model with a slightly
+higher learning rate.
 
 
 ```python
@@ -230,7 +230,7 @@ bert_classifier = keras_nlp.models.BertClassifier.from_preset(
 )
 bert_classifier.compile(
     loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-    optimizer=keras.optimizers.Adam(1e-4),
+    optimizer=keras.optimizers.Adam(5e-5),
     metrics=["accuracy"],
 )
 
@@ -240,17 +240,16 @@ bert_classifier.evaluate(test_ds)
 
 <div class="k-default-codeblock">
 ```
-[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - accuracy: 0.6291 - loss: 0.8222 - val_accuracy: 0.7677 - val_loss: 0.5664
-[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - accuracy: 0.7834 - loss: 0.5510
+[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - accuracy: 0.5944 - loss: 0.8679 - val_accuracy: 0.7645 - val_loss: 0.5811
+[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - accuracy: 0.7676 - loss: 0.5742
 
-[0.5623738169670105, 0.7759568691253662]
+[0.5850245356559753, 0.762723982334137]
 
 ```
 </div>
-This time, we achieve around 72% validation accuracy on both the validation and test
-splits after just one epoch, which is quite impressive!
-
-Now, let's see if we can further improve the model by using a learning rate scheduler.
+Just tweaking the learning rate alone was not enough to boost performance, which
+stayed right around 76%. Let's try again, but this time with
+`keras.optimizers.AdamW`, and a learning rate schedule.
 
 
 ```python
@@ -292,7 +291,7 @@ warmup_steps = int(total_steps * 0.2)
 bert_classifier.compile(
     loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
     optimizer=keras.optimizers.AdamW(
-        TriangularSchedule(0.001, warmup_steps, total_steps)
+        TriangularSchedule(1e-4, warmup_steps, total_steps)
     ),
     metrics=["accuracy"],
 )
@@ -303,19 +302,18 @@ bert_classifier.fit(train_ds, validation_data=val_ds, epochs=epochs)
 <div class="k-default-codeblock">
 ```
 Epoch 1/3
-[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - accuracy: 0.5692 - loss: 0.9046 - val_accuracy: 0.6447 - val_loss: 0.8326
+[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m49s[0m 7ms/step - accuracy: 0.5340 - loss: 0.9392 - val_accuracy: 0.7620 - val_loss: 0.5826
 Epoch 2/3
-[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m46s[0m 7ms/step - accuracy: 0.6456 - loss: 0.8291 - val_accuracy: 0.7090 - val_loss: 0.7116
+[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m46s[0m 7ms/step - accuracy: 0.7314 - loss: 0.6511 - val_accuracy: 0.7871 - val_loss: 0.5338
 Epoch 3/3
-[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m46s[0m 7ms/step - accuracy: 0.7070 - loss: 0.7124 - val_accuracy: 0.7333 - val_loss: 0.6597
+[1m6867/6867[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m46s[0m 7ms/step - accuracy: 0.7719 - loss: 0.5683 - val_accuracy: 0.7913 - val_loss: 0.5251
 
-<keras_core.src.callbacks.history.History at 0x7f14ec34d570>
+<keras_core.src.callbacks.history.History at 0x7fc5d069b850>
 
 ```
 </div>
-Great! With the learning rate scheduler and the `AdamW` optimizer, our validation
-accuracy improved to around 79% within one epoch, and it hiked to 86% in three
-epochs.
+Success! With the learning rate scheduler and the `AdamW` optimizer, our validation
+accuracy improved to around 79%.
 
 Now, let's evaluate our final model on the test set and see how it performs.
 
@@ -326,9 +324,9 @@ bert_classifier.evaluate(test_ds)
 
 <div class="k-default-codeblock">
 ```
-[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - accuracy: 0.7292 - loss: 0.6692
+[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m2s[0m 3ms/step - accuracy: 0.7963 - loss: 0.5189
 
-[0.6788273453712463, 0.725366473197937]
+[0.5268478393554688, 0.791530966758728]
 
 ```
 </div>
@@ -358,9 +356,9 @@ restored_model.evaluate(test_ds)
 /home/matt/miniconda3/envs/gpu/lib/python3.10/site-packages/keras_core/src/saving/saving_lib.py:338: UserWarning: Skipping variable loading for optimizer 'adam', because it has 2 variables whereas the saved optimizer has 83 variables. 
   trackable.load_own_variables(weights_store.get(inner_path))
 
-[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m3s[0m 4ms/step - loss: 0.6692 - sparse_categorical_accuracy: 0.7292
+[1m614/614[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m3s[0m 4ms/step - loss: 0.5189 - sparse_categorical_accuracy: 0.7963
 
-[0.6788273453712463, 0.725366473197937]
+[0.5268478393554688, 0.791530966758728]
 
 ```
 </div>
@@ -413,7 +411,7 @@ predictions = softmax(predictions)
 
 <div class="k-default-codeblock">
 ```
-[1m1/1[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m1s[0m 702ms/step
+[1m1/1[0m [32m━━━━━━━━━━━━━━━━━━━━[0m[37m[0m [1m1s[0m 734ms/step
 
 ```
 </div>

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -154,7 +154,7 @@ instantiated by calling the `fit()` method.
 bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 
 """
-Our BERT classifier achieved an accuracy of around 65% on the validation split. Now,
+Our BERT classifier achieved an accuracy of around 76% on the validation split. Now,
 let's evaluate its performance on the test split.
 
 ### Evaluate the performance of the trained model on test data.
@@ -163,9 +163,9 @@ let's evaluate its performance on the test split.
 bert_classifier.evaluate(test_ds)
 
 """
-Our baseline BERT model achieved a similar accuracy of around 68% on the test split.
-Now, let's try to improve its performance by recompiling the model with a different
-learning rate.
+Our baseline BERT model achieved a similar accuracy of around 76% on the test split.
+Now, let's try to improve its performance by recompiling the model with a slightly
+higher learning rate.
 """
 
 bert_classifier = keras_nlp.models.BertClassifier.from_preset(
@@ -173,7 +173,7 @@ bert_classifier = keras_nlp.models.BertClassifier.from_preset(
 )
 bert_classifier.compile(
     loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-    optimizer=keras.optimizers.Adam(1e-4),
+    optimizer=keras.optimizers.Adam(5e-5),
     metrics=["accuracy"],
 )
 
@@ -181,10 +181,9 @@ bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 bert_classifier.evaluate(test_ds)
 
 """
-This time, we achieve around 72% validation accuracy on both the validation and test
-splits after just one epoch, which is quite impressive!
-
-Now, let's see if we can further improve the model by using a learning rate scheduler.
+Just tweaking the learning rate alone was not enough to boost performance, which
+stayed right around 76%. Let's try again, but this time with
+`keras.optimizers.AdamW`, and a learning rate schedule.
 """
 
 
@@ -225,7 +224,7 @@ warmup_steps = int(total_steps * 0.2)
 bert_classifier.compile(
     loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
     optimizer=keras.optimizers.AdamW(
-        TriangularSchedule(0.001, warmup_steps, total_steps)
+        TriangularSchedule(1e-4, warmup_steps, total_steps)
     ),
     metrics=["accuracy"],
 )
@@ -233,9 +232,8 @@ bert_classifier.compile(
 bert_classifier.fit(train_ds, validation_data=val_ds, epochs=epochs)
 
 """
-Great! With the learning rate scheduler and the `AdamW` optimizer, our validation
-accuracy improved to around 79% within one epoch, and it hiked to 86% in three
-epochs.
+Success! With the learning rate scheduler and the `AdamW` optimizer, our validation
+accuracy improved to around 79%.
 
 Now, let's evaluate our final model on the test set and see how it performs.
 """

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -3,20 +3,20 @@ Title: Semantic Similarity with KerasNLP
 Author: [Anshuman Mishra](https://github.com/shivance/)
 Date created: 2023/02/25
 Last modified: 2023/02/25
-Description: Use pretrained models from KerasNLP for the Semantic Similarity Task
+Description: Use pretrained models from KerasNLP for the Semantic Similarity Task.
 Accelerator: GPU
 """
 
 """
 ## Introduction
 
-Semantic similarity refers to the task of determining the degree of similarity between two 
-sentences in terms of their meaning. We already saw in [this](https://keras.io/examples/nlp/semantic_similarity_with_bert/) 
-example how to use SNLI (Stanford Natural Language Inference) corpus to predict sentence 
-semantic similarity with the HuggingFace Transformers library. In this tutorial we will 
-learn how to use [KerasNLP](https://keras.io/keras_nlp/), an extension of the core Keras API, 
-for the same task. Furthermore, we will discover how KerasNLP effectively reduces boilerplate 
-code and simplifies the process of building and utilizing models. For more information on KerasNLP, 
+Semantic similarity refers to the task of determining the degree of similarity between two
+sentences in terms of their meaning. We already saw in [this](https://keras.io/examples/nlp/semantic_similarity_with_bert/)
+example how to use SNLI (Stanford Natural Language Inference) corpus to predict sentence
+semantic similarity with the HuggingFace Transformers library. In this tutorial we will
+learn how to use [KerasNLP](https://keras.io/keras_nlp/), an extension of the core Keras API,
+for the same task. Furthermore, we will discover how KerasNLP effectively reduces boilerplate
+code and simplifies the process of building and utilizing models. For more information on KerasNLP,
 please refer to [KerasNLP's official documentation](https://keras.io/keras_nlp/).
 
 This guide is broken down into following parts:
@@ -44,21 +44,21 @@ import keras_nlp
 import tensorflow_datasets as tfds
 
 """
-To load the SNLI dataset, we will utilize the tensorflow-datasets library, which 
-contains over 550,000 samples in total. However, to ensure that this example runs 
+To load the SNLI dataset, we will utilize the tensorflow-datasets library, which
+contains over 550,000 samples in total. However, to ensure that this example runs
 quickly, we will only use 20% of the training samples.
 
 ## Overview of SNLI Dataset:
 
-Every sample in the dataset contains three components: `hypothesis`, `premise`, 
-and `label`. epresents the original caption provided to the author of the pair, 
-while the hypothesis refers to the hypothesis caption created by the author of 
-the pair. The label is assigned by annotators to indicate the similarity between 
+Every sample in the dataset contains three components: `hypothesis`, `premise`,
+and `label`. epresents the original caption provided to the author of the pair,
+while the hypothesis refers to the hypothesis caption created by the author of
+the pair. The label is assigned by annotators to indicate the similarity between
 the two sentences.
 
-The dataset contains three possible similarity label values: Contradiction, Entailment, 
-and Neutral. Contradiction represents completely dissimilar sentences, while Entailment 
-denotes similar meaning sentences. Lastly, Neutral refers to sentences where no clear 
+The dataset contains three possible similarity label values: Contradiction, Entailment,
+and Neutral. Contradiction represents completely dissimilar sentences, while Entailment
+denotes similar meaning sentences. Lastly, Neutral refers to sentences where no clear
 similarity or dissimilarity can be established between them.
 """
 
@@ -74,8 +74,8 @@ sample
 """
 ### Preprocessing
 
-In our dataset, we have identified that some samples have missing or incorrectly labeled 
-data, which is denoted by a value of -1. To ensure the accuracy and reliability of our model, 
+In our dataset, we have identified that some samples have missing or incorrectly labeled
+data, which is denoted by a value of -1. To ensure the accuracy and reliability of our model,
 we will simply filter out these samples from our dataset.
 """
 
@@ -85,9 +85,9 @@ def filter_labels(sample):
 
 
 """
-Here's a utility function that splits the example into an `(x, y)` tuple that is suitable 
-for `model.fit()`. By default, `keras_nlp.models.BertClassifier` will tokenize and pack 
-together raw strings using a `"[SEP]"` token during training. Therefore, this label 
+Here's a utility function that splits the example into an `(x, y)` tuple that is suitable
+for `model.fit()`. By default, `keras_nlp.models.BertClassifier` will tokenize and pack
+together raw strings using a `"[SEP]"` token during training. Therefore, this label
 splitting is all the data preparation that we need to perform.
 """
 
@@ -118,17 +118,17 @@ test_ds = (
 """
 ## Establishing baseline with BERT.
 
-We will use the BERT model from KerasNLP to establish a baseline for our semantic similarity 
-task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT 
-Backbone, mapping the backbone outputs to a logit output suitable for a classification task. 
+We will use the BERT model from KerasNLP to establish a baseline for our semantic similarity
+task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT
+Backbone, mapping the backbone outputs to a logit output suitable for a classification task.
 This significantly reduces the need for custom code.
 
 KerasNLP models have built-in tokenization capabilities that handle tokenization by default
-based on the selected model. However, users can also use custom preprocessing techniques 
-as per their specific needs. If we pass a tuple as input, the model will tokenize all the 
+based on the selected model. However, users can also use custom preprocessing techniques
+as per their specific needs. If we pass a tuple as input, the model will tokenize all the
 strings and concatenate them with a `"[SEP]"` separator.
 
-We will use this model with pre-trained weights, and we can use the `from_preset()` method 
+We will use this model with pre-trained weights, and we can use the `from_preset()` method
 to use our own preprocessor. For the SNLI dataset, we will set num_classes as 3.
 """
 
@@ -137,17 +137,16 @@ bert_classifier = keras_nlp.models.BertClassifier.from_preset(
 )
 
 """
-Please note that the BERT Tiny model has only 4,386,307 trainable parameters. 
+Please note that the BERT Tiny model has only 4,386,307 trainable parameters.
 
-KerasNLP task models come with compilation defaults. We can now train the model we just 
+KerasNLP task models come with compilation defaults. We can now train the model we just
 instantiated by calling the `fit()` method.
 """
 
 bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 
 """
-
-Our BERT classifier achieved an accuracy of around 65% on the validation split. Now, 
+Our BERT classifier achieved an accuracy of around 65% on the validation split. Now,
 let's evaluate its performance on the test split.
 
 ### Evaluate the performance of the trained model on test data.
@@ -155,8 +154,8 @@ let's evaluate its performance on the test split.
 bert_classifier.evaluate(test_ds)
 
 """
-Our baseline BERT model achieved almost similar accuracy of around 68% on the test split. 
-Now, let's try to improve its performance by recompiling the model with a different 
+Our baseline BERT model achieved almost similar accuracy of around 68% on the test split.
+Now, let's try to improve its performance by recompiling the model with a different
 learning rate and observe its performance.
 """
 bert_classifier = keras_nlp.models.BertClassifier.from_preset(
@@ -174,8 +173,8 @@ bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 bert_classifier.evaluate(test_ds)
 
 """
-This time, we achieved around 72% validation accuracy on both validation and test 
-splits with just one epoch, which is quite impressive! Let's save our model for now 
+This time, we achieved around 72% validation accuracy on both validation and test
+splits with just one epoch, which is quite impressive! Let's save our model for now
 and move on to learning how to perform inference with it.
 
 Now, let's see if we can further improve the model by using a learning rate scheduler.
@@ -220,7 +219,7 @@ bert_classifier.compile(
 bert_classifier.fit(train_ds, validation_data=val_ds, epochs=3)
 
 """
-Great! With the learning rate scheduler and the AdamW optimizer, our validation 
+Great! With the learning rate scheduler and the AdamW optimizer, our validation
 accuracy improved to around 79%.
 
 Now, let's evaluate our final model on the test set and see how it performs.
@@ -229,11 +228,11 @@ Now, let's evaluate our final model on the test set and see how it performs.
 bert_classifier.evaluate(test_ds)
 
 """
-Our Tiny BERT model achieved an accuracy of approximately 79% on the test set 
-with the use of a learning rate scheduler. This is a significant improvement over 
-our previous results. It's important to note that fine-tuning a pre-trained BERT 
-model can be a powerful tool in natural language processing tasks, and even a 
-small model like Tiny BERT can achieve impressive results. 
+Our Tiny BERT model achieved an accuracy of approximately 79% on the test set
+with the use of a learning rate scheduler. This is a significant improvement over
+our previous results. It's important to note that fine-tuning a pre-trained BERT
+model can be a powerful tool in natural language processing tasks, and even a
+small model like Tiny BERT can achieve impressive results.
 
 
 ## Save and Reload the model
@@ -253,7 +252,7 @@ sample = (sample["hypothesis"], sample["premise"])
 sample
 
 """
-The default preprocessor in KerasNLP models handles input tokenization automatically, 
+The default preprocessor in KerasNLP models handles input tokenization automatically,
 so we don't need to perform tokenization explicitly.
 """
 predictions = bert_classifier.predict(sample)
@@ -269,8 +268,8 @@ predictions = softmax(predictions)
 """
 ## Improving accuracy with RoBERTa
 
-Now that we have established a baseline, we can attempt to improve our results 
-by experimenting with different models. Thanks to KerasNLP, fine-tuning a RoBERTa 
+Now that we have established a baseline, we can attempt to improve our results
+by experimenting with different models. Thanks to KerasNLP, fine-tuning a RoBERTa
 checkpoint on the same dataset is easy with just a few lines of code.
 """
 
@@ -284,14 +283,14 @@ roberta_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 roberta_classifier.evaluate(test_ds)
 
 """
-The RoBERTa base model has significantly more trainable parameters than the BERT 
-Tiny model, with almost 30 times as many at 124,645,635. As a result, it took 
-approximately 1.5 hours to train on a Kaggle P100 GPU. However, the performance 
-improvement was substantial, with accuracy increasing to 88% on both the validation 
-and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on 
+The RoBERTa base model has significantly more trainable parameters than the BERT
+Tiny model, with almost 30 times as many at 124,645,635. As a result, it took
+approximately 1.5 hours to train on a Kaggle P100 GPU. However, the performance
+improvement was substantial, with accuracy increasing to 88% on both the validation
+and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on
 our Kaggle P100 GPU.
 
-Despite using a different model, the steps to perform inference with RoBERTa are 
+Despite using a different model, the steps to perform inference with RoBERTa are
 the same as with BERT!
 """
 
@@ -299,15 +298,15 @@ predictions = roberta_classifier.predict(sample)
 print(tf.math.argmax(predictions, axis=1).numpy())
 
 """
-We hope this tutorial has been helpful in demonstrating the ease and effectiveness 
+We hope this tutorial has been helpful in demonstrating the ease and effectiveness
 of using KerasNLP and BERT for semantic similarity tasks.
 
-Throughout this tutorial, we demonstrated how to use a pre-trained BERT model to 
-establish a baseline and improve performance by training a larger RoBERTa model 
+Throughout this tutorial, we demonstrated how to use a pre-trained BERT model to
+establish a baseline and improve performance by training a larger RoBERTa model
 using just a few lines of code.
 
-The KerasNLP toolbox provides a range of modular building blocks for preprocessing 
-text, including pretrained state-of-the-art models and low-level Transformer Encoder 
-layers. We believe that this makes experimenting with natural language solutions 
+The KerasNLP toolbox provides a range of modular building blocks for preprocessing
+text, including pretrained state-of-the-art models and low-level Transformer Encoder
+layers. We believe that this makes experimenting with natural language solutions
 more accessible and efficient.
 """

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -189,8 +189,7 @@ class TriangularSchedule(keras.optimizers.schedules.LearningRateSchedule):
         self.total = tf.cast(total, dtype="float32")
 
     def get_config(self):
-        config = super().get_config()
-        config.update({"rate": self.rate, "warmup": self.warmup, "total": self.total})
+        config = {"rate": self.rate, "warmup": self.warmup, "total": self.total}
         return config
 
     def __call__(self, step):

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -1,0 +1,313 @@
+"""
+Title: Semantic Similarity with KerasNLP
+Author: [Anshuman Mishra](https://github.com/shivance/)
+Date created: 2023/02/25
+Last modified: 2023/02/25
+Description: Use pretrained models from KerasNLP for the Semantic Similarity Task
+Accelerator: GPU
+"""
+
+"""
+## Introduction
+
+Semantic similarity refers to the task of determining the degree of similarity between two 
+sentences in terms of their meaning. We already saw in [this](https://keras.io/examples/nlp/semantic_similarity_with_bert/) 
+example how to use SNLI (Stanford Natural Language Inference) corpus to predict sentence 
+semantic similarity with the HuggingFace Transformers library. In this tutorial we will 
+learn how to use [KerasNLP](https://keras.io/keras_nlp/), an extension of the core Keras API, 
+for the same task. Furthermore, we will discover how KerasNLP effectively reduces boilerplate 
+code and simplifies the process of building and utilizing models. For more information on KerasNLP, 
+please refer to [KerasNLP's official documentation](https://keras.io/keras_nlp/).
+
+This guide is broken down into following parts:
+
+1. *Setup*, task definition, and establishing a baseline.
+2. *Establishing baseline* with BERT.
+3. *Saving and Reloading* the model.
+4. *Performing inference* with the model.
+5  *Improving accuracy* with RoBERTa
+
+## Setup
+
+To begin, we can import `keras_nlp`, `keras` and `tensorflow`.
+
+"""
+
+"""shell
+pip install -q keras-nlp
+"""
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+import keras_nlp
+import tensorflow_datasets as tfds
+
+"""
+To load the SNLI dataset, we will utilize the tensorflow-datasets library, which 
+contains over 550,000 samples in total. However, to ensure that this example runs 
+quickly, we will only use 20% of the training samples.
+
+## Overview of SNLI Dataset:
+
+Every sample in the dataset contains three components: `hypothesis`, `premise`, 
+and `label`. epresents the original caption provided to the author of the pair, 
+while the hypothesis refers to the hypothesis caption created by the author of 
+the pair. The label is assigned by annotators to indicate the similarity between 
+the two sentences.
+
+The dataset contains three possible similarity label values: Contradiction, Entailment, 
+and Neutral. Contradiction represents completely dissimilar sentences, while Entailment 
+denotes similar meaning sentences. Lastly, Neutral refers to sentences where no clear 
+similarity or dissimilarity can be established between them.
+"""
+
+snli_train = tfds.load("snli", split="train[:20%]")
+snli_val = tfds.load("snli", split="validation")
+snli_test = tfds.load("snli", split="test")
+
+# Here's an example of how our training samples look like, where we randomly select
+# four samples:
+sample = snli_test.batch(4).take(1).get_single_element()
+sample
+
+"""
+### Preprocessing
+
+In our dataset, we have identified that some samples have missing or incorrectly labeled 
+data, which is denoted by a value of -1. To ensure the accuracy and reliability of our model, 
+we will simply filter out these samples from our dataset.
+"""
+
+
+def filter_labels(sample):
+    return sample["label"] >= 0
+
+
+"""
+Here's a utility function that splits the example into an `(x, y)` tuple that is suitable 
+for `model.fit()`. By default, `keras_nlp.models.BertClassifier` will tokenize and pack 
+together raw strings using a `"[SEP]"` token during training. Therefore, this label 
+splitting is all the data preparation that we need to perform.
+"""
+
+
+def split_labels(sample):
+    x = (sample["hypothesis"], sample["premise"])
+    y = sample["label"]
+    return x, y
+
+
+train_ds = (
+    snli_train.filter(filter_labels)
+    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)
+    .batch(16)
+)
+val_ds = (
+    snli_train.filter(filter_labels)
+    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)
+    .batch(16)
+)
+test_ds = (
+    snli_train.filter(filter_labels)
+    .map(split_labels, num_parallel_calls=tf.data.AUTOTUNE)
+    .batch(16)
+)
+
+
+"""
+## Establishing baseline with BERT.
+
+We will use the BERT model from KerasNLP to establish a baseline for our semantic similarity 
+task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT 
+Backbone, mapping the backbone outputs to a logit output suitable for a classification task. 
+This significantly reduces the need for custom code.
+
+KerasNLP models have built-in tokenization capabilities that handle tokenization by default
+based on the selected model. However, users can also use custom preprocessing techniques 
+as per their specific needs. If we pass a tuple as input, the model will tokenize all the 
+strings and concatenate them with a `"[SEP]"` separator.
+
+We will use this model with pre-trained weights, and we can use the `from_preset()` method 
+to use our own preprocessor. For the SNLI dataset, we will set num_classes as 3.
+"""
+
+bert_classifier = keras_nlp.models.BertClassifier.from_preset(
+    "bert_tiny_en_uncased", num_classes=3
+)
+
+"""
+Please note that the BERT Tiny model has only 4,386,307 trainable parameters. 
+
+KerasNLP task models come with compilation defaults. We can now train the model we just 
+instantiated by calling the `fit()` method.
+"""
+
+bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
+
+"""
+
+Our BERT classifier achieved an accuracy of around 65% on the validation split. Now, 
+let's evaluate its performance on the test split.
+
+### Evaluate the performance of the trained model on test data.
+"""
+bert_classifier.evaluate(test_ds)
+
+"""
+Our baseline BERT model achieved almost similar accuracy of around 68% on the test split. 
+Now, let's try to improve its performance by recompiling the model with a different 
+learning rate and observe its performance.
+"""
+bert_classifier = keras_nlp.models.BertClassifier.from_preset(
+    "bert_tiny_en_uncased", num_classes=3
+)
+
+bert_classifier.compile(
+    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    optimizer=tf.keras.optimizers.Adam(1e-4),
+    metrics=["accuracy"],
+)
+
+bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
+
+bert_classifier.evaluate(test_ds)
+
+"""
+This time, we achieved around 72% validation accuracy on both validation and test 
+splits with just one epoch, which is quite impressive! Let's save our model for now 
+and move on to learning how to perform inference with it.
+
+Now, let's see if we can further improve the model by using a learning rate scheduler.
+"""
+
+
+class TriangularSchedule(keras.optimizers.schedules.LearningRateSchedule):
+    """Linear ramp up for `warmup` steps, then linear decay to zero at `total` steps."""
+
+    def __init__(self, rate, warmup, total):
+        self.rate = tf.cast(rate, dtype="float32")
+        self.warmup = tf.cast(warmup, dtype="float32")
+        self.total = tf.cast(total, dtype="float32")
+
+    def __call__(self, step):
+        step = tf.cast(step, dtype="float32")
+        multiplier = tf.cond(
+            step < self.warmup,
+            lambda: step / self.warmup,
+            lambda: (self.total - step) / (self.total - self.warmup),
+        )
+        return tf.maximum(self.rate * multiplier, 0.0)
+
+
+bert_classifier = keras_nlp.models.BertClassifier.from_preset(
+    "bert_tiny_en_uncased", num_classes=3
+)
+
+# Get the total count of training batches.
+# This requires walking the dataset to filter all -1 labels.
+total_steps = sum(1 for _ in train_ds.as_numpy_iterator())
+warmup_steps = int(total_steps * 0.2)
+
+bert_classifier.compile(
+    loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    optimizer=tf.keras.optimizers.experimental.AdamW(
+        TriangularSchedule(0.001, warmup_steps, total_steps)
+    ),
+    metrics=["accuracy"],
+)
+
+bert_classifier.fit(train_ds, validation_data=val_ds, epochs=3)
+
+"""
+Great! With the learning rate scheduler and the AdamW optimizer, our validation 
+accuracy improved to around 79%.
+
+Now, let's evaluate our final model on the test set and see how it performs.
+"""
+
+bert_classifier.evaluate(test_ds)
+
+"""
+Our Tiny BERT model achieved an accuracy of approximately 79% on the test set 
+with the use of a learning rate scheduler. This is a significant improvement over 
+our previous results. It's important to note that fine-tuning a pre-trained BERT 
+model can be a powerful tool in natural language processing tasks, and even a 
+small model like Tiny BERT can achieve impressive results. 
+
+
+## Save and Reload the model
+"""
+bert_classifier.save("bert_classifier")
+restored_model = keras.models.load_model("bert_classifier")
+restored_model.evaluate(test_ds)
+
+"""
+## Performing inference with the model.
+
+Let's see how to perform inference with KerasNLP models
+"""
+
+# Convert to Hypothesis-Premise pair, for forward pass through model
+sample = (sample["hypothesis"], sample["premise"])
+sample
+
+"""
+The default preprocessor in KerasNLP models handles input tokenization automatically, 
+so we don't need to perform tokenization explicitly.
+"""
+predictions = bert_classifier.predict(sample)
+
+
+def softmax(x):
+    return np.exp(x) / np.exp(x).sum(axis=0)
+
+
+# Get the class predictions with maximum probabilities
+predictions = softmax(predictions)
+
+"""
+## Improving accuracy with RoBERTa
+
+Now that we have established a baseline, we can attempt to improve our results 
+by experimenting with different models. Thanks to KerasNLP, fine-tuning a RoBERTa 
+checkpoint on the same dataset is easy with just a few lines of code.
+"""
+
+# Inittializing a RoBERTa from preset
+roberta_classifier = keras_nlp.models.RobertaClassifier.from_preset(
+    "roberta_base_en", num_classes=3
+)
+
+roberta_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
+
+roberta_classifier.evaluate(test_ds)
+
+"""
+The RoBERTa base model has significantly more trainable parameters than the BERT 
+Tiny model, with almost 30 times as many at 124,645,635. As a result, it took 
+approximately 1.5 hours to train on a Kaggle P100 GPU. However, the performance 
+improvement was substantial, with accuracy increasing to 88% on both the validation 
+and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on 
+our Kaggle P100 GPU.
+
+Despite using a different model, the steps to perform inference with RoBERTa are 
+the same as with BERT!
+"""
+
+predictions = roberta_classifier.predict(sample)
+print(tf.math.argmax(predictions, axis=1).numpy())
+
+"""
+We hope this tutorial has been helpful in demonstrating the ease and effectiveness 
+of using KerasNLP and BERT for semantic similarity tasks.
+
+Throughout this tutorial, we demonstrated how to use a pre-trained BERT model to 
+establish a baseline and improve performance by training a larger RoBERTa model 
+using just a few lines of code.
+
+The KerasNLP toolbox provides a range of modular building blocks for preprocessing 
+text, including pretrained state-of-the-art models and low-level Transformer Encoder 
+layers. We believe that this makes experimenting with natural language solutions 
+more accessible and efficient.
+"""

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -44,8 +44,8 @@ import keras_nlp
 import tensorflow_datasets as tfds
 
 """
-To load the SNLI dataset, we use the tensorflow-datasets library, which 
-contains over 550,000 samples in total. However, to ensure that this example runs 
+To load the SNLI dataset, we use the tensorflow-datasets library, which
+contains over 550,000 samples in total. However, to ensure that this example runs
 quickly, we use only 20% of the training samples.
 
 ## Overview of SNLI Dataset
@@ -118,9 +118,9 @@ test_ds = (
 """
 ## Establishing baseline with BERT.
 
-We use the BERT model from KerasNLP to establish a baseline for our semantic similarity 
-task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT 
-Backbone, mapping the backbone outputs to a logit output suitable for a classification task. 
+We use the BERT model from KerasNLP to establish a baseline for our semantic similarity
+task. The `keras_nlp.models.BertClassifier` class attaches a classification head to the BERT
+Backbone, mapping the backbone outputs to a logit output suitable for a classification task.
 This significantly reduces the need for custom code.
 
 KerasNLP models have built-in tokenization capabilities that handle tokenization by default
@@ -128,7 +128,7 @@ based on the selected model. However, users can also use custom preprocessing te
 as per their specific needs. If we pass a tuple as input, the model will tokenize all the
 strings and concatenate them with a `"[SEP]"` separator.
 
-We use this model with pretrained weights, and we can use the `from_preset()` method 
+We use this model with pretrained weights, and we can use the `from_preset()` method
 to use our own preprocessor. For the SNLI dataset, we set `num_classes` to 3.
 """
 
@@ -155,8 +155,8 @@ let's evaluate its performance on the test split.
 bert_classifier.evaluate(test_ds)
 
 """
-Our baseline BERT model achieved a similar accuracy of around 68% on the test split. 
-Now, let's try to improve its performance by recompiling the model with a different 
+Our baseline BERT model achieved a similar accuracy of around 68% on the test split.
+Now, let's try to improve its performance by recompiling the model with a different
 learning rate.
 """
 
@@ -173,11 +173,12 @@ bert_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 bert_classifier.evaluate(test_ds)
 
 """
-This time, we achieve around 72% validation accuracy on both the validation and test 
+This time, we achieve around 72% validation accuracy on both the validation and test
 splits after just one epoch, which is quite impressive!
 
 Now, let's see if we can further improve the model by using a learning rate scheduler.
 """
+
 
 class TriangularSchedule(keras.optimizers.schedules.LearningRateSchedule):
     """Linear ramp up for `warmup` steps, then linear decay to zero at `total` steps."""
@@ -218,7 +219,7 @@ bert_classifier.compile(
 bert_classifier.fit(train_ds, validation_data=val_ds, epochs=epochs)
 
 """
-Great! With the learning rate scheduler and the `AdamW` optimizer, our validation 
+Great! With the learning rate scheduler and the `AdamW` optimizer, our validation
 accuracy improved to around 79% within one epoch, and it hiked to 86% in three
 epochs.
 
@@ -228,13 +229,13 @@ Now, let's evaluate our final model on the test set and see how it performs.
 bert_classifier.evaluate(test_ds)
 
 """
-Our Tiny BERT model achieved an accuracy of approximately 79% on the test set 
-with the use of a learning rate scheduler. This is a significant improvement over 
-our previous results. Fine-tuning a pretrained BERT 
-model can be a powerful tool in natural language processing tasks, and even a 
+Our Tiny BERT model achieved an accuracy of approximately 79% on the test set
+with the use of a learning rate scheduler. This is a significant improvement over
+our previous results. Fine-tuning a pretrained BERT
+model can be a powerful tool in natural language processing tasks, and even a
 small model like Tiny BERT can achieve impressive results.
 
-Let's save our model for now 
+Let's save our model for now
 and move on to learning how to perform inference with it.
 
 ## Save and Reload the model
@@ -285,11 +286,11 @@ roberta_classifier.fit(train_ds, validation_data=val_ds, epochs=1)
 roberta_classifier.evaluate(test_ds)
 
 """
-The RoBERTa base model has significantly more trainable parameters than the BERT 
-Tiny model, with almost 30 times as many at 124,645,635 parameters. As a result, it took 
-approximately 1.5 hours to train on a P100 GPU. However, the performance 
-improvement was substantial, with accuracy increasing to 88% on both the validation 
-and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on 
+The RoBERTa base model has significantly more trainable parameters than the BERT
+Tiny model, with almost 30 times as many at 124,645,635 parameters. As a result, it took
+approximately 1.5 hours to train on a P100 GPU. However, the performance
+improvement was substantial, with accuracy increasing to 88% on both the validation
+and test splits. With RoBERTa, we were able to fit a maximum batch size of 16 on
 our P100 GPU.
 
 Despite using a different model, the steps to perform inference with RoBERTa are
@@ -303,8 +304,8 @@ print(tf.math.argmax(predictions, axis=1).numpy())
 We hope this tutorial has been helpful in demonstrating the ease and effectiveness
 of using KerasNLP and BERT for semantic similarity tasks.
 
-Throughout this tutorial, we demonstrated how to use a pretrained BERT model to 
-establish a baseline and improve performance by training a larger RoBERTa model 
+Throughout this tutorial, we demonstrated how to use a pretrained BERT model to
+establish a baseline and improve performance by training a larger RoBERTa model
 using just a few lines of code.
 
 The KerasNLP toolbox provides a range of modular building blocks for preprocessing

--- a/examples/nlp/semantic_similarity_with_keras_nlp.py
+++ b/examples/nlp/semantic_similarity_with_keras_nlp.py
@@ -188,6 +188,11 @@ class TriangularSchedule(keras.optimizers.schedules.LearningRateSchedule):
         self.warmup = tf.cast(warmup, dtype="float32")
         self.total = tf.cast(total, dtype="float32")
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({"rate": self.rate, "warmup": self.warmup, "total": self.total})
+        return config
+
     def __call__(self, step):
         step = tf.cast(step, dtype="float32")
         multiplier = tf.cond(


### PR DESCRIPTION
Issue : https://github.com/keras-team/keras-nlp/issues/726
Kaggle Tutorial [Link](https://www.kaggle.com/code/shivanshuman/kerasnlp-semantic-similarity-with-bert/notebook)

This PR continues the previous PR #1253 

This PR ports Keras-io's existing [Semantic Similarity with BERT](https://keras.io/examples/nlp/semantic_similarity_with_bert/) to KerasNLP. Now the tutorial is pure Keras + tensorflow. It doesn't depend on Tensorflow at all.