### PR TITLE
fix typos in KerasCV guide using RetinaNet

### DIFF
--- a/guides/ipynb/keras_cv/retina_net_overview.ipynb
+++ b/guides/ipynb/keras_cv/retina_net_overview.ipynb
@@ -68,7 +68,7 @@
     "## Data loading\n",
     "\n",
     "KerasCV has a predefined specificication for bounding boxes.  To comply with this, you\n",
-    "should package your bounding boxes into a dictionary matching the speciciation below:\n",
+    "should package your bounding boxes into a dictionary matching the specification below:\n",
     "\n",
     "```\n",
     "bounding_boxes = {\n",
@@ -102,7 +102,7 @@
     "Clearly yields bounding boxes in the format `xywh`.  You can read more about\n",
     "KerasCV bounding box formats [in the API docs](https://keras.io/api/keras_cv/bounding_box/formats/).\n",
     "\n",
-    "Our data comesloaded into the format\n",
+    "Our loaded data comes into the format\n",
     "`{\"images\": images, \"bounding_boxes\": bounding_boxes}`.  This format is supported in all\n",
     "KerasCV preprocessing components.\n",
     "\n",
@@ -152,7 +152,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Next, lets batch our data.  In KerasCV object detection tasks it is recommended that\n",
+    "Next, let's batch our data.  In KerasCV object detection tasks, it is recommended that\n",
     "users use ragged batches.  This is due to the fact that images may be of different\n",
     "sizes in PascalVOC and that there may be different numbers of bounding boxes per image.\n",
     "\n",
@@ -389,7 +389,7 @@
    "source": [
     "## Model creation\n",
     "\n",
-    "We'll use the KerasCV API to construct a RetinaNet model.  In this tutorial we use\n",
+    "We'll use the KerasCV API to construct a RetinaNet model. In this tutorial we use\n",
     "a pretrained ResNet50 backbone, initializing the weights to weights produced by training\n",
     "on the imagenet dataset.  In order to perform fine-tuning, we\n",
     "freeze the backbone before training.  When `include_rescaling=True` is set, inputs to\n",
@@ -426,7 +426,7 @@
    },
    "source": [
     "That is all it takes to construct a KerasCV RetinaNet.  The RetinaNet accepts tuples of\n",
-    "dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`\n",
+    "dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`.\n",
     "This matches what we have constructed in our input pipeline above."
    ]
   },

--- a/guides/ipynb/keras_cv/retina_net_overview.ipynb
+++ b/guides/ipynb/keras_cv/retina_net_overview.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [lukewood](https://twitter.com/luke_wood_ml)<br>\n",
     "**Date created:** 2022/08/22<br>\n",
-    "**Last modified:** 2022/08/22<br>\n",
+    "**Last modified:** 2023/03/30<br>\n",
     "**Description:** Use KerasCV to train a RetinaNet on Pascal VOC 2007."
    ]
   },

--- a/guides/keras_cv/retina_net_overview.py
+++ b/guides/keras_cv/retina_net_overview.py
@@ -2,7 +2,7 @@
 Title: Train an Object Detection Model on Pascal VOC 2007 using KerasCV
 Author: [lukewood](https://twitter.com/luke_wood_ml)
 Date created: 2022/08/22
-Last modified: 2022/08/22
+Last modified: 2023/03/30
 Description: Use KerasCV to train a RetinaNet on Pascal VOC 2007.
 Accelerator: GPU
 """

--- a/guides/md/keras_cv/retina_net_overview.md
+++ b/guides/md/keras_cv/retina_net_overview.md
@@ -2,7 +2,7 @@
 
 **Author:** [lukewood](https://twitter.com/luke_wood_ml)<br>
 **Date created:** 2022/08/22<br>
-**Last modified:** 2022/08/22<br>
+**Last modified:** 2023/03/30<br>
 **Description:** Use KerasCV to train a RetinaNet on Pascal VOC 2007.
 
 
@@ -47,7 +47,7 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 ## Data loading
 
 KerasCV has a predefined specificication for bounding boxes.  To comply with this, you
-should package your bounding boxes into a dictionary matching the speciciation below:
+should package your bounding boxes into a dictionary matching the specification below:
 
 ```
 bounding_boxes = {
@@ -81,7 +81,7 @@ train_ds, ds_info = your_data_loader.load(
 Clearly yields bounding boxes in the format `xywh`.  You can read more about
 KerasCV bounding box formats [in the API docs](https://keras.io/api/keras_cv/bounding_box/formats/).
 
-Our data comesloaded into the format
+Our loaded data comes into the format
 `{"images": images, "bounding_boxes": bounding_boxes}`.  This format is supported in all
 KerasCV preprocessing components.
 
@@ -118,7 +118,7 @@ train_ds = train_ds.map(unpackage_tfds_inputs, num_parallel_calls=tf.data.AUTOTU
 eval_ds = eval_ds.map(unpackage_tfds_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 ```
 
-Next, lets batch our data.  In KerasCV object detection tasks it is recommended that
+Next, let's batch our data.  In KerasCV object detection tasks, it is recommended that
 users use ragged batches.  This is due to the fact that images may be of different
 sizes in PascalVOC and that there may be different numbers of bounding boxes per image.
 
@@ -325,7 +325,7 @@ model.backbone.trainable = False
 ```
 
 That is all it takes to construct a KerasCV RetinaNet.  The RetinaNet accepts tuples of
-dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`
+dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`.
 This matches what we have constructed in our input pipeline above.
 
 


### PR DESCRIPTION
- found some misspellings and punctuation errors in KerasCV guide, so I fixed them.

Comment down below if there are any other parts to change. I will update .ipynb and .md files accordingly if all things are set!