### PR TITLE
fixed typos - 'contratsive', 'reprentations', 'uncertanity', 'appearence' 👍 

### DIFF
--- a/examples/audio/ipynb/wav2vec2_audiocls.ipynb
+++ b/examples/audio/ipynb/wav2vec2_audiocls.ipynb
@@ -15,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"
@@ -39,7 +40,7 @@
     "high-level information, such as acoustic and linguistic content, including phonemes,\n",
     "words, semantic meanings, tone, speaker characteristics from speech signals available to\n",
     "solve the downstream task. [Wav2Vec 2.0](https://arxiv.org/abs/2006.11477), which solves a\n",
-    "self-supervised contratsive learning task to learn high-level speech reprentations,\n",
+    "self-supervised contrastive learning task to learn high-level speech representations,\n",
     "provides a great alternative to traditional low-level features for training deep learning\n",
     "models for KWS.\n",
     "\n",

--- a/examples/audio/md/wav2vec2_audiocls.md
+++ b/examples/audio/md/wav2vec2_audiocls.md
@@ -30,7 +30,7 @@ task.  This makes it is essential for any system to learn speech representations
 high-level information, such as acoustic and linguistic content, including phonemes,
 words, semantic meanings, tone, speaker characteristics from speech signals available to
 solve the downstream task. [Wav2Vec 2.0](https://arxiv.org/abs/2006.11477), which solves a
-self-supervised contratsive learning task to learn high-level speech reprentations,
+self-supervised contrastive learning task to learn high-level speech representations,
 provides a great alternative to traditional low-level features for training deep learning
 models for KWS.
 

--- a/examples/audio/wav2vec2_audiocls.py
+++ b/examples/audio/wav2vec2_audiocls.py
@@ -27,7 +27,7 @@ task.  This makes it is essential for any system to learn speech representations
 high-level information, such as acoustic and linguistic content, including phonemes,
 words, semantic meanings, tone, speaker characteristics from speech signals available to
 solve the downstream task. [Wav2Vec 2.0](https://arxiv.org/abs/2006.11477), which solves a
-self-supervised contratsive learning task to learn high-level speech reprentations,
+self-supervised contrastive learning task to learn high-level speech representations,
 provides a great alternative to traditional low-level features for training deep learning
 models for KWS.
 

--- a/examples/nlp/active_learning_review_classification.py
+++ b/examples/nlp/active_learning_review_classification.py
@@ -31,8 +31,8 @@ acceptable score is reached or some other business metric is met.
 This tutorial provides a basic demonstration of how Active Learning works by
 demonstrating a ratio-based (least confidence) sampling strategy that results in lower
 overall false positive and negative rates when compared to a model trained on the entire
-dataset. This sampling falls under the domain of *uncertanity sampling*, in which new
-datasets are sampled based on the uncertanity that the model outputs for the
+dataset. This sampling falls under the domain of *uncertainty sampling*, in which new
+datasets are sampled based on the uncertainty that the model outputs for the
 corresponding label. In our example, we compare our model's false positive and false
 negative rates and annotate the new data based on their ratio.
 

--- a/examples/nlp/ipynb/active_learning_review_classification.ipynb
+++ b/examples/nlp/ipynb/active_learning_review_classification.ipynb
@@ -15,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"
@@ -33,7 +34,7 @@
     "ensure consistency in labeling of new data.\n",
     "\n",
     "The process starts with annotating a small subset of the full dataset and training an\n",
-    "initial model. The best model checkpoint is saved and then tested on\u00a0a balanced test\n",
+    "initial model. The best model checkpoint is saved and then tested on a balanced test\n",
     "set. The test set must be carefully sampled because the full training process will be\n",
     "dependent on it. Once we have the initial evaluation scores, the oracle is tasked with\n",
     "labeling more samples; the number of data points to be sampled is usually determined by\n",
@@ -44,8 +45,8 @@
     "This tutorial provides a basic demonstration of how Active Learning works by\n",
     "demonstrating a ratio-based (least confidence) sampling strategy that results in lower\n",
     "overall false positive and negative rates when compared to a model trained on the entire\n",
-    "dataset. This sampling falls under the domain of *uncertanity sampling*, in which new\n",
-    "datasets are sampled based on the uncertanity that the model outputs for the\n",
+    "dataset. This sampling falls under the domain of *uncertainty sampling*, in which new\n",
+    "datasets are sampled based on the uncertainty that the model outputs for the\n",
     "corresponding label. In our example, we compare our model's false positive and false\n",
     "negative rates and annotate the new data based on their ratio.\n",
     "\n",
@@ -70,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -133,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -229,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -283,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -312,8 +313,7 @@
     "    plt.legend([\"train_accuracy\", \"val_accuracy\"])\n",
     "    plt.xlabel(\"Epochs\")\n",
     "    plt.ylabel(\"Accuracy\")\n",
-    "    plt.show()\n",
-    ""
+    "    plt.show()\n"
    ]
   },
   {
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -352,8 +352,7 @@
     "        ]\n",
     "    )\n",
     "    model.summary()\n",
-    "    return model\n",
-    ""
+    "    return model\n"
    ]
   },
   {
@@ -370,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -476,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/nlp/md/active_learning_review_classification.md
+++ b/examples/nlp/md/active_learning_review_classification.md
@@ -35,8 +35,8 @@ acceptable score is reached or some other business metric is met.
 This tutorial provides a basic demonstration of how Active Learning works by
 demonstrating a ratio-based (least confidence) sampling strategy that results in lower
 overall false positive and negative rates when compared to a model trained on the entire
-dataset. This sampling falls under the domain of *uncertanity sampling*, in which new
-datasets are sampled based on the uncertanity that the model outputs for the
+dataset. This sampling falls under the domain of *uncertainty sampling*, in which new
+datasets are sampled based on the uncertainty that the model outputs for the
 corresponding label. In our example, we compare our model's false positive and false
 negative rates and annotate the new data based on their ratio.
 

--- a/examples/vision/adamatch.py
+++ b/examples/vision/adamatch.py
@@ -47,7 +47,7 @@ The following figure provides an illustration of this idea. In the present examp
 [MNIST dataset](http://yann.lecun.com/exdb/mnist/) as the source dataset, while the target dataset is
 [SVHN](http://ufldl.stanford.edu/housenumbers/), which consists of images of house
 numbers. Both datasets have various varying factors in terms of texture, viewpoint,
-appearence, etc.: their domains, or distributions, are different from one
+appearance, etc.: their domains, or distributions, are different from one
 another.
 
 ![](https://i.imgur.com/dJFSJuT.png)

--- a/examples/vision/ipynb/adamatch.ipynb
+++ b/examples/vision/ipynb/adamatch.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -55,6 +55,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"
@@ -77,7 +78,7 @@
     "[MNIST dataset](http://yann.lecun.com/exdb/mnist/) as the source dataset, while the target dataset is\n",
     "[SVHN](http://ufldl.stanford.edu/housenumbers/), which consists of images of house\n",
     "numbers. Both datasets have various varying factors in terms of texture, viewpoint,\n",
-    "appearence, etc.: their domains, or distributions, are different from one\n",
+    "appearance, etc.: their domains, or distributions, are different from one\n",
     "another.\n",
     "\n",
     "![](https://i.imgur.com/dJFSJuT.png)\n",
@@ -98,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -131,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -167,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -206,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -239,8 +240,7 @@
     "        image = tf.image.resize_with_pad(image, RESIZE_TO, RESIZE_TO)\n",
     "        image = tf.tile(image, [1, 1, 3])\n",
     "    image = augmenter(image)\n",
-    "    return image\n",
-    ""
+    "    return image\n"
    ]
   },
   {
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -276,8 +276,7 @@
     "        ds = ds.map(lambda x, y: (aug_func(x, False), y), num_parallel_calls=AUTO)\n",
     "\n",
     "    ds = ds.batch(batch_size).prefetch(AUTO)\n",
-    "    return ds\n",
-    ""
+    "    return ds\n"
    ]
   },
   {
@@ -291,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -329,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -357,8 +356,7 @@
     "    # More on `mask` later.\n",
     "    mask = tf.cast(mask, target_loss.dtype)\n",
     "    target_loss *= mask\n",
-    "    return tf.reduce_mean(target_loss, 0)\n",
-    ""
+    "    return tf.reduce_mean(target_loss, 0)\n"
    ]
   },
   {
@@ -395,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -495,8 +493,7 @@
     "        self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))\n",
     "\n",
     "        self.loss_tracker.update_state(total_loss)\n",
-    "        return {\"loss\": self.loss_tracker.result()}\n",
-    ""
+    "        return {\"loss\": self.loss_tracker.result()}\n"
    ]
   },
   {
@@ -559,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -685,8 +682,7 @@
     "        num_classes, kernel_regularizer=regularizers.l2(WEIGHT_DECAY)\n",
     "    )(trunk_outputs)\n",
     "\n",
-    "    return keras.Model(inputs, outputs)\n",
-    ""
+    "    return keras.Model(inputs, outputs)\n"
    ]
   },
   {
@@ -702,7 +698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -723,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -747,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -768,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -799,7 +795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/vision/md/adamatch.md
+++ b/examples/vision/md/adamatch.md
@@ -49,7 +49,7 @@ The following figure provides an illustration of this idea. In the present examp
 [MNIST dataset](http://yann.lecun.com/exdb/mnist/) as the source dataset, while the target dataset is
 [SVHN](http://ufldl.stanford.edu/housenumbers/), which consists of images of house
 numbers. Both datasets have various varying factors in terms of texture, viewpoint,
-appearence, etc.: their domains, or distributions, are different from one
+appearance, etc.: their domains, or distributions, are different from one
 another.
 
 ![](https://i.imgur.com/dJFSJuT.png)


### PR DESCRIPTION
fixed typos - 'contratsive', 'reprentations', 'uncertanity', 'appearence' in .py, .ipynb and .md files.