### PR TITLE
Add missing dependency and make pip commands runnable on Google Colab

### DIFF
--- a/examples/nlp/ipynb/t5_hf_summarization.ipynb
+++ b/examples/nlp/ipynb/t5_hf_summarization.ipynb
@@ -68,11 +68,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install transformers==4.20.0\n",
-    "pip install keras_nlp==0.3.0\n",
-    "pip install datasets\n",
-    "pip install huggingface-hub\n",
-    "pip install nltk"
+    "!pip install transformers==4.20.0\n",
+    "!pip install keras_nlp==0.3.0\n",
+    "!pip install datasets\n",
+    "!pip install huggingface-hub\n",
+    "!pip install nltk",
+    "!pip install rouge-score"
    ]
   },
   {

--- a/examples/nlp/md/t5_hf_summarization.md
+++ b/examples/nlp/md/t5_hf_summarization.md
@@ -41,11 +41,12 @@ task using Hugging Face Transformers on the `XSum` dataset loaded from Hugging F
 
 
 ```python
-pip install transformers==4.20.0
-pip install keras_nlp==0.3.0
-pip install datasets
-pip install huggingface-hub
-pip install nltk
+!pip install transformers==4.20.0
+!pip install keras_nlp==0.3.0
+!pip install datasets
+!pip install huggingface-hub
+!pip install nltk
+!pip install rouge-score
 ```
 
 ### Importing the necessary libraries

--- a/examples/nlp/t5_hf_summarization.py
+++ b/examples/nlp/t5_hf_summarization.py
@@ -41,12 +41,12 @@ task using Hugging Face Transformers on the `XSum` dataset loaded from Hugging F
 """
 
 """shell
-pip install transformers==4.20.0
-pip install keras_nlp==0.3.0
-pip install datasets
-pip install huggingface-hub
-pip install nltk
-pip install rouge-score
+!pip install transformers==4.20.0
+!pip install keras_nlp==0.3.0
+!pip install datasets
+!pip install huggingface-hub
+!pip install nltk
+!pip install rouge-score
 """
 
 """

--- a/examples/nlp/t5_hf_summarization.py
+++ b/examples/nlp/t5_hf_summarization.py
@@ -46,6 +46,7 @@ pip install keras_nlp==0.3.0
 pip install datasets
 pip install huggingface-hub
 pip install nltk
+pip install rouge-score
 """
 
 """


### PR DESCRIPTION
Without installing the 'rouge-score' package using 'pip install rouge-score', attempting to run 'rouge_l = keras_nlp.metrics.RougeL()' will result in an error message: 'ImportError: RougeL requires the rouge_score package. Please install it with pip install rouge-score.'