### PR TITLE
Update image_captioning.py

### DIFF
--- a/examples/vision/image_captioning.py
+++ b/examples/vision/image_captioning.py
@@ -618,7 +618,7 @@ def generate_caption():
         )
         sampled_token_index = np.argmax(predictions[0, i, :])
         sampled_token = index_lookup[sampled_token_index]
-        if sampled_token == " <end>":
+        if sampled_token == "<end>":
             break
         decoded_caption += " " + sampled_token
 


### PR DESCRIPTION
The " <end>" token had a leading space which never matches with the vocabulary token "<end>" leading to bad inference.