### PR TITLE
Fixes for Input Image Normalization and Optimizer Reference

### DIFF
--- a/examples/generative/stylegan.py
+++ b/examples/generative/stylegan.py
@@ -81,7 +81,7 @@ with ZipFile("celeba_gan/data.zip", "r") as zipobj:
 ds_train = keras.utils.image_dataset_from_directory(
     "celeba_gan", label_mode=None, image_size=(64, 64), batch_size=32
 )
-ds_train = ds_train.map(lambda x: x / 255.0)
+
 
 
 def resize_image(res, image):
@@ -698,8 +698,8 @@ def train(
             steps = int(train_step_ratio[res_log2] * steps_per_epoch)
 
             style_gan.compile(
-                d_optimizer=tf.keras.optimizers.Adam(**opt_cfg),
-                g_optimizer=tf.keras.optimizers.Adam(**opt_cfg),
+                d_optimizer=tf.keras.optimizers.legacy.Adam(**opt_cfg),
+                g_optimizer=tf.keras.optimizers.legacy.Adam(**opt_cfg),
                 loss_weights={"gradient_penalty": 10, "drift": 0.001},
                 steps_per_epoch=steps,
                 res=res,


### PR DESCRIPTION
There are a couple of fixes recommended to run `Face image generation with StyleGAN` tutorial with the latest Tensorflow version (2.12).

1) The input images are `normalized` twice, so it generates black images. To fix this, we should exclude  `ds_train = ds_train.map(lambda x: x / 255.0)`

2) Since we are trying to restore a checkpoint from a legacy keras optimizer into latest version, we should update the optimizer reference as shown below

```
d_optimizer=tf.keras.optimizers.legacy.Adam(**opt_cfg),
g_optimizer=tf.keras.optimizers.legacy.Adam(**opt_cfg),
```
Thank you!