### PR TITLE
Updated the t5_hf_summarization.py

### DIFF
--- a/examples/nlp/ipynb/t5_hf_summarization.ipynb
+++ b/examples/nlp/ipynb/t5_hf_summarization.ipynb
@@ -374,7 +374,7 @@
     "tokenizer, the `from_pretrained` method will download and cache the model for us.\n",
     "\n",
     "The `from_pretrained()` method expects the name of a model from the Hugging Face Model Hub. As\n",
-    "mentioned earlier, we will use the `t5-base` model checkpoint."
+    "mentioned earlier, we will use the `t5-small` model checkpoint."
    ]
   },
   {

--- a/examples/nlp/ipynb/t5_hf_summarization.ipynb
+++ b/examples/nlp/ipynb/t5_hf_summarization.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "The dataset has the following fields:\n",
     "\n",
-    "- **document**: the original BBC article to me summarized\n",
+    "- **document**: the original BBC article to be summarized\n",
     "- **summary**: the single sentence summary of the BBC article\n",
     "- **id**: ID of the document-summary pair"
    ]

--- a/examples/nlp/ipynb/t5_hf_summarization.ipynb
+++ b/examples/nlp/ipynb/t5_hf_summarization.ipynb
@@ -345,7 +345,7 @@
    "source": [
     "To apply this function on all the pairs of sentences in our dataset, we just use the\n",
     "`map` method of our `dataset` object we created earlier. This will apply the function on\n",
-    "all the elements of all the splits in `dataset`, so our training, validation and testing\n",
+    "all the elements of all the splits in `dataset`, so our training and testing\n",
     "data will be preprocessed in one single command."
    ]
   },

--- a/examples/nlp/md/t5_hf_summarization.md
+++ b/examples/nlp/md/t5_hf_summarization.md
@@ -110,7 +110,7 @@ raw_datasets = load_dataset("xsum", split="train")
 
 The dataset has the following fields:
 
-- **document**: the original BBC article to me summarized
+- **document**: the original BBC article to be summarized
 - **summary**: the single sentence summary of the BBC article
 - **id**: ID of the document-summary pair
 

--- a/examples/nlp/md/t5_hf_summarization.md
+++ b/examples/nlp/md/t5_hf_summarization.md
@@ -230,7 +230,7 @@ sequence-to-sequence (both the input and output are text sequences), we use the
 tokenizer, the `from_pretrained` method will download and cache the model for us.
 
 The `from_pretrained()` method expects the name of a model from the Hugging Face Model Hub. As
-mentioned earlier, we will use the `t5-base` model checkpoint.
+mentioned earlier, we will use the `t5-small` model checkpoint.
 
 
 ```python

--- a/examples/nlp/md/t5_hf_summarization.md
+++ b/examples/nlp/md/t5_hf_summarization.md
@@ -213,7 +213,7 @@ def preprocess_function(examples):
 
 To apply this function on all the pairs of sentences in our dataset, we just use the
 `map` method of our `dataset` object we created earlier. This will apply the function on
-all the elements of all the splits in `dataset`, so our training, validation and testing
+all the elements of all the splits in `dataset`, so our training and testing
 data will be preprocessed in one single command.
 
 

--- a/examples/nlp/t5_hf_summarization.py
+++ b/examples/nlp/t5_hf_summarization.py
@@ -106,7 +106,7 @@ raw_datasets = load_dataset("xsum", split="train")
 """
 The dataset has the following fields:
 
-- **document**: the original BBC article to me summarized
+- **document**: the original BBC article to be summarized
 - **summary**: the single sentence summary of the BBC article
 - **id**: ID of the document-summary pair
 """

--- a/examples/nlp/t5_hf_summarization.py
+++ b/examples/nlp/t5_hf_summarization.py
@@ -202,7 +202,7 @@ sequence-to-sequence (both the input and output are text sequences), we use the
 tokenizer, the `from_pretrained` method will download and cache the model for us.
 
 The `from_pretrained()` method expects the name of a model from the Hugging Face Model Hub. As
-mentioned earlier, we will use the `t5-base` model checkpoint.
+mentioned earlier, we will use the `t5-small` model checkpoint.
 """
 
 from transformers import TFAutoModelForSeq2SeqLM, DataCollatorForSeq2Seq

--- a/examples/nlp/t5_hf_summarization.py
+++ b/examples/nlp/t5_hf_summarization.py
@@ -187,7 +187,7 @@ def preprocess_function(examples):
 """
 To apply this function on all the pairs of sentences in our dataset, we just use the
 `map` method of our `dataset` object we created earlier. This will apply the function on
-all the elements of all the splits in `dataset`, so our training, validation and testing
+all the elements of all the splits in `dataset`, so our training and testing
 data will be preprocessed in one single command.
 """
 


### PR DESCRIPTION
made 3 commits:

**commit-1**

Changed 't5-base' to 't5-small'
In 'Define certain variables' section the MODEL_CHECKPOINT is defined as "t5-small" and also based on this console output 'Downloading:   0%|          | 0.00/231M [00:00<?, ?B/s]',  it seems "t5-small" is the right.

**commit-2**

Removed 'validation' text
'''
raw_datasets = raw_datasets.train_test_split(
    train_size=TRAIN_TEST_SPLIT, test_size=TRAIN_TEST_SPLIT
)
'''

Here we divided out raw_datasets in to training and test set with no validation set. So I think removing the word 'validation' here is right.


**commit-3**

fixed spelling error
Changed 'me summarized' to 'be summarized'