### PR TITLE
Adding header Accelerator field details

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Author: (could be `Authors`: as well, and may contain markdown links)
 Date created: (date in yyyy/mm/dd format)
 Last modified: (date in yyyy/mm/dd format)
 Description: (one-line text description)
+Accelerator: (could be GPU, TPU, or None)
 ```
 
 To see examples of tutobooks, you can check out any `.py` file in `examples/` or `guides/`.

--- a/scripts/tutobooks.py
+++ b/scripts/tutobooks.py
@@ -303,6 +303,8 @@ def validate(py):
         raise ValueError("Missing `Last modified:` field.")
     if not lines[5].startswith("Description: "):
         raise ValueError("Missing `Description:` field.")
+    if not lines[6].startswith("Accelerator: "):
+        raise ValueError("Missing `Accelerator:` field.")
     description = lines[5][len("Description: ") :]
     if not description:
         raise ValueError("Missing `Description:` field content.")
@@ -312,6 +314,12 @@ def validate(py):
         raise ValueError("Description field content must end with a period.")
     if len(description) > 100:
         raise ValueError("Description field content must be less than 100 chars.")
+    accelerator = lines[6][len("Accelerator: "):]
+    accelerator_options = ["GPU", "TPU", "None"]
+    if accelerator not in accelerator_options:
+        raise ValueError(
+            f"Accelerator field content must be one of: {accelerator_options}"
+        )
     for i, line in enumerate(lines):
         if line.startswith('"""') and line.endswith('"""') and len(line) > 3:
             raise ValueError(


### PR DESCRIPTION
Every example header needs to have 6 rows. This condition is implemented in the code, but the 6th line should contain info about `Accelerator`, this thing was missing.

So I added additional checks with existing header conditions to verify two things

1. 6th row contains info about `Accelerator`
2. Its value is one of the possible values `GPU`, `TPU`, or `None`

Info about `Accelerator` and its possible values is also added in `README`.

