### PR TITLE
Update encoding in movielens_recommendations_transformers.py

### DIFF
--- a/examples/structured_data/ipynb/movielens_recommendations_transformers.ipynb
+++ b/examples/structured_data/ipynb/movielens_recommendations_transformers.ipynb
@@ -151,6 +151,7 @@
     "\n",
     "movies = pd.read_csv(\n",
     "    \"ml-1m/movies.dat\", sep=\"::\", names=[\"movie_id\", \"title\", \"genres\"]\n",
+    "    encoding='latin-1'\n",
     ")"
    ]
   },

--- a/examples/structured_data/md/movielens_recommendations_transformers.md
+++ b/examples/structured_data/md/movielens_recommendations_transformers.md
@@ -97,7 +97,8 @@ ratings = pd.read_csv(
 )
 
 movies = pd.read_csv(
-    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"]
+    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"],
+    encoding='latin-1'
 )
 ```
 

--- a/examples/structured_data/movielens_recommendations_transformers.py
+++ b/examples/structured_data/movielens_recommendations_transformers.py
@@ -92,7 +92,8 @@ ratings = pd.read_csv(
 )
 
 movies = pd.read_csv(
-    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"],encoding='latin-1'
+    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"],
+    encoding='latin-1'
 )
 
 """

--- a/examples/structured_data/movielens_recommendations_transformers.py
+++ b/examples/structured_data/movielens_recommendations_transformers.py
@@ -92,7 +92,9 @@ ratings = pd.read_csv(
 )
 
 movies = pd.read_csv(
-    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"],
+    "ml-1m/movies.dat", 
+    sep="::", 
+    names=["movie_id", "title", "genres"],
     encoding='latin-1'
 )
 

--- a/examples/structured_data/movielens_recommendations_transformers.py
+++ b/examples/structured_data/movielens_recommendations_transformers.py
@@ -92,10 +92,10 @@ ratings = pd.read_csv(
 )
 
 movies = pd.read_csv(
-    "ml-1m/movies.dat", 
-    sep="::", 
+    "ml-1m/movies.dat",
+    sep="::",
     names=["movie_id", "title", "genres"],
-    encoding="latin-1"
+    encoding="latin-1",
 )
 
 """

--- a/examples/structured_data/movielens_recommendations_transformers.py
+++ b/examples/structured_data/movielens_recommendations_transformers.py
@@ -95,7 +95,7 @@ movies = pd.read_csv(
     "ml-1m/movies.dat", 
     sep="::", 
     names=["movie_id", "title", "genres"],
-    encoding='latin-1'
+    encoding="latin-1"
 )
 
 """

--- a/examples/structured_data/movielens_recommendations_transformers.py
+++ b/examples/structured_data/movielens_recommendations_transformers.py
@@ -92,7 +92,7 @@ ratings = pd.read_csv(
 )
 
 movies = pd.read_csv(
-    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"]
+    "ml-1m/movies.dat", sep="::", names=["movie_id", "title", "genres"],encoding='latin-1'
 )
 
 """


### PR DESCRIPTION
At present the example tutorial raising the UnicodeDecodeError at ` movies=pd.read_csv()`

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 3114: invalid continuation byte`

Hence adding the `encoding='latin-1'` to the `movies=pd.read_csv(...,encoding='latin-1')` will get rid of this error.

Hence I proposed this code change for review and approval.

Attaching [gist](https://colab.research.google.com/gist/SuryanarayanaY/d88cf842ed112232a49a6946f439336e/movielens_recommendations_transformers.ipynb#scrollTo=k0iuqIp8CHJN) for reference to check the error and solution that works fine.