### PR TITLE
remove unwanted code from transformer_asr.py

### DIFF
--- a/examples/audio/ipynb/transformer_asr.ipynb
+++ b/examples/audio/ipynb/transformer_asr.ipynb
@@ -110,7 +110,6 @@
     "        self.conv3 = tf.keras.layers.Conv1D(\n",
     "            num_hid, 11, strides=2, padding=\"same\", activation=\"relu\"\n",
     "        )\n",
-    "        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)\n",
     "\n",
     "    def call(self, x):\n",
     "        x = self.conv1(x)\n",

--- a/examples/audio/md/transformer_asr.md
+++ b/examples/audio/md/transformer_asr.md
@@ -82,7 +82,6 @@ class SpeechFeatureEmbedding(layers.Layer):
         self.conv3 = tf.keras.layers.Conv1D(
             num_hid, 11, strides=2, padding="same", activation="relu"
         )
-        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)
 
     def call(self, x):
         x = self.conv1(x)

--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -75,7 +75,6 @@ class SpeechFeatureEmbedding(layers.Layer):
         self.conv3 = tf.keras.layers.Conv1D(
             num_hid, 11, strides=2, padding="same", activation="relu"
         )
-        self.pos_emb = layers.Embedding(input_dim=maxlen, output_dim=num_hid)
 
     def call(self, x):
         x = self.conv1(x)


### PR DESCRIPTION
In the example tutorial of `Automatic Speech Recognition with Transformer`, positional embedding `self.pos_emb` in the class `SpeechFeatureEmbedding` has initialised but not used anywhere.

Hence I am proposing to remove this line of code to avoid unnecessary confusion.

Fixes #1394 

Thanks