### PR TITLE
Adding "FeatureSpace advanced use cases" example

### DIFF
--- a/examples/structured_data/feature_space_advanced.py
+++ b/examples/structured_data/feature_space_advanced.py
@@ -1,0 +1,526 @@
+"""
+Title: FeatureSpace avanced use cases
+Author: [Dimitre Oliveira](https://www.linkedin.com/in/dimitre-oliveira-7a1a0113a/)
+Date created: 2023/06/27
+Last modified: 2023/06/27
+Description: How to use FeatureSpace for advanced preprocessing use cases.
+Accelerator: None
+"""
+"""
+## Introduction
+
+This example is an extension of the [Structured data classification with
+FeatureSpace](https://keras.io/examples/structured_data/structured_data_classification_wit
+h_feature_space/) code example, and here we will extend it to cover more complex use
+cases of the [`keras.utils.FeatureSpace`](https://keras.io/api/utils/feature_space/)
+preprocessing utility, like feature hashing, feature crosses, handling missing values and
+integrating [Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/)
+with FeatureSpace.
+
+The general task still is structured data classification (also known as tabular data
+classification) using a data that includes numerical features, integer categorical
+features, and string categorical features.
+"""
+
+"""
+### The dataset
+
+[Our dataset](https://archive.ics.uci.edu/ml/datasets/heart+Disease) is provided by the
+Cleveland Clinic Foundation for Heart Disease.
+It's a CSV file with 303 rows. Each row contains information about a patient (a
+**sample**), and each column describes an attribute of the patient (a **feature**). We
+use the features to predict whether a patient has a heart disease
+(**binary classification**).
+
+Here's the description of each feature:
+
+Column| Description| Feature Type
+------------|--------------------|----------------------
+Age | Age in years | Numerical
+Sex | (1 = male; 0 = female) | Categorical
+CP | Chest pain type (0, 1, 2, 3, 4) | Categorical
+Trestbpd | Resting blood pressure (in mm Hg on admission) | Numerical
+Chol | Serum cholesterol in mg/dl | Numerical
+FBS | fasting blood sugar in 120 mg/dl (1 = true; 0 = false) | Categorical
+RestECG | Resting electrocardiogram results (0, 1, 2) | Categorical
+Thalach | Maximum heart rate achieved | Numerical
+Exang | Exercise induced angina (1 = yes; 0 = no) | Categorical
+Oldpeak | ST depression induced by exercise relative to rest | Numerical
+Slope | Slope of the peak exercise ST segment | Numerical
+CA | Number of major vessels (0-3) colored by fluoroscopy | Both numerical & categorical
+Thal | 3 = normal; 6 = fixed defect; 7 = reversible defect | Categorical
+Target | Diagnosis of heart disease (1 = true; 0 = false) | Target
+"""
+
+"""
+## Setup
+"""
+
+import pandas as pd
+import tensorflow as tf
+from tensorflow.keras.utils import FeatureSpace
+
+"""
+## Load the data
+
+Let's download the data and load it into a Pandas dataframe:
+"""
+
+data_url = "http://storage.googleapis.com/download.tensorflow.org/data/heart.csv"
+dataframe = pd.read_csv(data_url)
+
+"""
+The dataset includes 303 samples with 14 columns per sample (13 features, plus the target
+label), here's a preview of a few samples:
+"""
+
+print(f"Dataframe shape: {dataframe.shape}")
+display(dataframe.head())
+
+"""
+The last column, "target", indicates whether the patient has a heart disease (1) or not
+(0).
+"""
+
+"""
+## Train/validation split
+
+Let's split the data into a training and validation set:
+"""
+
+valid_dataframe = dataframe.sample(frac=0.2, random_state=42)
+train_dataframe = dataframe.drop(valid_dataframe.index)
+
+print(
+    f"Using {len(train_dataframe)} samples for training and {len(valid_dataframe)} for validation"
+)
+
+"""
+## Generating TF datasets
+
+Let's generate
+[`tf.data.Dataset`](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) objects
+for each dataframe:
+"""
+
+
+def dataframe_to_dataset(dataframe):
+    dataframe = dataframe.copy()
+    labels = dataframe.pop("target")
+    ds = tf.data.Dataset.from_tensor_slices((dict(dataframe), labels))
+    ds = ds.shuffle(buffer_size=len(dataframe))
+    return ds
+
+
+train_ds = dataframe_to_dataset(train_dataframe)
+valid_ds = dataframe_to_dataset(valid_dataframe)
+
+"""
+Each `Dataset` yields a tuple `(input, target)` where `input` is a dictionary of features
+and `target` is the value `0` or `1`:
+"""
+
+for x, y in dataframe_to_dataset(train_dataframe).take(1):
+    print(f"Input: {x}")
+    print(f"Target: {y}")
+
+"""
+## Preprocessing
+
+Usually our data is not on the proper or best format for modeling, this is why most of
+the time we need to do some kind of preprocessing on the features to make them compatible
+with the model or to extract the most of them for the task. We need to do this
+preprocessing step for training but but at inference we also need to make sure that the
+data goes through the same process, this where a utility like `FeatureSpace` shines, we
+can define all the preprocessing once and re-use it at different stages of our system.
+
+Here we will see how to use `FeatureSpace` to perform more complex transformations and
+its flexibility, then combine everything together into a single component to preprocess
+data for our model.
+"""
+
+"""
+The `FeatureSpace` utility learns how to process the data by using the `adapt()` function
+to learn from it, this requires a dataset containing only feature, so let's create it
+together with a utility function to show the preprocessing example in practice:
+"""
+
+train_ds_with_no_labels = train_ds.map(lambda x, _: x)
+
+
+def example_feature_space(dataset, feature_space, feature_names):
+    feature_space.adapt(dataset)
+    for x in dataset.take(1):
+        inputs = {feature_name: x[feature_name] for feature_name in feature_names}
+        preprocessed_x = feature_space(inputs)
+        print(f"Input: {[{k:v.numpy()} for k, v in inputs.items()]}")
+        print(
+            f"Preprocessed output: {[{k:v.numpy()} for k, v in preprocessed_x.items()]}"
+        )
+
+
+"""
+### Feature hashing
+"""
+
+"""
+**Feature hashing** means hashing or encoding a set of values into a defined number of
+bins, in this case we have `thalach` (Maximum heart rate achieved) which is a numerical
+feature that can assume a varying range of values and we will hash it into 4 bins, this
+means that any possible value of the original feature will be placed into one of those
+possible 5 bins. The output here can be a one-hot encoded vector or a single number.
+"""
+
+feature_space = FeatureSpace(
+    features={
+        "thalach": FeatureSpace.integer_hashed(num_bins=4, output_mode="one_hot")
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["thalach"])
+
+"""
+**Feature hashing** can also be used for string features.
+"""
+
+feature_space = FeatureSpace(
+    features={"thal": FeatureSpace.string_hashed(num_bins=2, output_mode="one_hot")},
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+
+"""
+For numerical features we can get a similar behavior by using the `float_discretized`
+option, the main difference between this and `integer_hashed` is that with the former we
+bin the values while keeping some numerical relationship (close values will likely be
+placed at the same bin) while the later (hashing) we cannot guarantee that those numbers
+will be hashed into the same bin, it depends on the hashing function.
+"""
+
+feature_space = FeatureSpace(
+    features={"age": FeatureSpace.float_discretized(num_bins=3, output_mode="one_hot")},
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["age"])
+
+"""
+### Feature indexing
+"""
+
+"""
+**Indexing** a string feature essentially means creating a discrete numerical
+representation for it, this is especially important for string features since most models
+only accept numerical features. This transformation will place the string values into
+different categories. The output here can be a one-hot encoded vector or a single number.
+
+Note that by specifying `num_oov_indices=1` we leave one spot at our output vector for
+OOV (out of vocabulary) values this is an important tool to handle missing or unseen
+values after the training (values that were not seen during the `adapt()` step)
+"""
+
+feature_space = FeatureSpace(
+    features={
+        "thal": FeatureSpace.string_categorical(
+            num_oov_indices=1, output_mode="one_hot"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+
+"""
+We also can do **feature indexing** for integer features, this is quite important for
+features like `sex` where values like (`1 and 0`) do not have a numerical relationship
+between them, they are just different categories, this behavior can be perfectly captured
+by this transformation.
+
+For this case we want to explicitly set `num_oov_indices=0` for the feature `sex` the
+reason is that we only expect two possible values for this feature anything else would
+either wrong input or and issue with the data creation, for this reason we would probably
+just want the code to throw an error so that we can be aware of the issue and fix it.
+"""
+
+feature_space = FeatureSpace(
+    features={
+        "sex": FeatureSpace.integer_categorical(
+            num_oov_indices=0, output_mode="one_hot"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["sex"])
+
+"""
+### Feature crosses (mixing features of diverse types)
+
+With **crosses** we can do feature interactions between an arbitrary number of features
+of mixed types as long as they are categorical features, you can think of instead of
+having a feature {'age': 20} and another {'sex': 0} we can have {'age_X_sex': 20_0}, but
+with `FeatureSpace` and **crosses** we can apply specific preprocessing to each
+individual feature and to the feature cross itself. This option can be very powerful for
+specific use cases, here might be a good option since age combined with gender can have
+different meanings for the health domain.
+
+We will cross `age` and `sex` and hash the combination output of them into a vector
+representation of size 8. The output here can be a one-hot encoded vector or a single
+number.
+
+Sometimes the combination of multiple features can result into on a super large feature
+space, think about crossing someone's ZIP code with its last name, the possibilities
+would be in the thousands, that is why the `crossing_dim` parameter is so important it
+limits the output dimension of the cross feature.
+
+Note that the combination of possible values of the 6 bins of `age` and the 2 values of
+`sex` would be 12, so by choosing `crossing_dim` we are choosing to constrain a little
+bit the output vector.
+"""
+
+feature_space = FeatureSpace(
+    features={
+        "age": FeatureSpace.integer_hashed(num_bins=6, output_mode="one_hot"),
+        "sex": FeatureSpace.integer_categorical(
+            num_oov_indices=0, output_mode="one_hot"
+        ),
+    },
+    crosses=[
+        FeatureSpace.cross(
+            feature_names=("age", "sex"),
+            crossing_dim=8,
+            output_mode="one_hot",
+        )
+    ],
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["age", "sex"])
+
+"""
+### FeatureSpace using a Keras preprocessing layer
+
+To be a really flexible and extensible feature we cannot only rely on those pre-defined
+transformation, we must be able to re-use other transformations from the Keras/TensorFlow
+ecosystem and customize our own, this is why `FeatureSpace` is also designed to work with
+[Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/), this way we
+can use sophisticated data transformations provided by the framework, you can even create
+your own custom Keras preprocessing layers and use it in the same way.
+
+Here we are going to use the
+[`tf.keras.layers.TextVectorization`](https://keras.io/api/layers/preprocessing_layers/tex
+t/text_vectorization/#textvectorization-class) preprocessing layer to create a TF-IDF
+feature from our data.
+"""
+
+custom_layer = tf.keras.layers.TextVectorization(output_mode="tf_idf")
+
+feature_space = FeatureSpace(
+    features={
+        "thal": FeatureSpace.feature(
+            preprocessor=custom_layer, dtype="string", output_mode="float"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+
+"""
+## Configuring the final `FeatureSpace`
+
+Now that we know how to use `FeatureSpace` for more complex use cases let's pick the ones
+that looks more useful for this task and create the final `FeatureSpace` component.
+
+To configure how each feature should be preprocessed,
+we instantiate a `keras.utils.FeatureSpace`, and we
+pass to it a dictionary that maps the name of our features
+to the feature transformation function.
+
+"""
+
+feature_space = FeatureSpace(
+    features={
+        # Categorical features encoded as integers
+        "sex": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "cp": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "fbs": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "restecg": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "exang": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "ca": FeatureSpace.integer_categorical(num_oov_indices=0),
+        # Categorical features encoded as string
+        "thal": FeatureSpace.string_categorical(num_oov_indices=1),
+        # Numerical features to hash and bin
+        "age": FeatureSpace.integer_hashed(num_bins=6),
+        "thalach": FeatureSpace.integer_hashed(num_bins=4),
+        # Numerical features to normalize
+        "trestbps": FeatureSpace.float_normalized(),
+        "chol": FeatureSpace.float_normalized(),
+        "oldpeak": FeatureSpace.float_normalized(),
+        "slope": FeatureSpace.float_normalized(),
+    },
+    # Specify feature cross with a custom crossing dim.
+    crosses=[
+        FeatureSpace.cross(
+            feature_names=("age", "sex"),
+            crossing_dim=8,
+            output_mode="one_hot",
+        )
+    ],
+    output_mode="concat",
+)
+
+"""
+## Adapt the `FeatureSpace` to the training data
+
+Before we start using the `FeatureSpace` to build a model, we have
+to adapt it to the training data. During `adapt()`, the `FeatureSpace` will:
+
+- Index the set of possible values for categorical features.
+- Compute the mean and variance for numerical features to normalize.
+- Compute the value boundaries for the different bins for numerical features to
+discretize.
+- Any other kind of preprocessing required by custom layers.
+
+Note that `adapt()` should be called on a `tf.data.Dataset` which yields dicts
+of feature values -- no labels.
+
+But first let's batch the datasets
+"""
+
+train_ds = train_ds.batch(32)
+valid_ds = valid_ds.batch(32)
+
+train_ds_with_no_labels = train_ds.map(lambda x, _: x)
+feature_space.adapt(train_ds_with_no_labels)
+
+"""
+At this point, the `FeatureSpace` can be called on a dict of raw feature values, and
+because we set `output_mode="concat"` it will return a single concatenate vector for each
+sample, combining encoded features and feature crosses.
+"""
+
+for x, _ in train_ds.take(1):
+    preprocessed_x = feature_space(x)
+    print(f"preprocessed_x shape: {preprocessed_x.shape}")
+    print(f"preprocessed_x sample: \n{preprocessed_x[0]}")
+
+"""
+## Saving the `FeatureSpace`
+
+At this point we can choose to save our `FeatureSpace` component, this have many
+advantages like re-using it on different experiments that use the same model, saving time
+if you need to re-run the preprocessing step, and mainly for model deployment, where by
+loading it you can be sure that you will be applying the same preprocessing steps don't
+matter the device or environment, this is a great way to reduce [training/serving
+skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
+skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
+"""
+
+feature_space.save("myfeaturespace.keras")
+
+"""
+## Preprocessing with `FeatureSpace` as part of the tf.data pipeline
+
+We will opt to use our component asynchronously by making it part of the tf.data
+pipeline, as noted at the [previous
+guide](https://keras.io/examples/structured_data/structured_data_classification_with_featu
+re_space/) This enables asynchronous parallel preprocessing of the data on CPU before it
+hits the model. Usually, this is always the right thing to do during training.
+
+Let's create a training and validation dataset of preprocessed batches:
+"""
+
+preprocessed_train_ds = train_ds.map(
+    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE
+).prefetch(tf.data.AUTOTUNE)
+
+preprocessed_valid_ds = valid_ds.map(
+    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE
+).prefetch(tf.data.AUTOTUNE)
+
+"""
+## Model
+
+We will take advantage of our `FeatureSpace` component to build the model, as we want the
+model to be compatible with our preprocessing function, let's use the the `FeatureSpace`
+feature map as the input of our model.
+"""
+
+encoded_features = feature_space.get_encoded_features()
+print(encoded_features)
+
+"""
+This model is quite trivial only for demonstration purposes so don't pay too much
+attention to the architecture.
+"""
+
+x = tf.keras.layers.Dense(32, activation="relu")(encoded_features)
+x = tf.keras.layers.Dropout(0.5)(x)
+output = tf.keras.layers.Dense(1, activation="sigmoid")(x)
+
+model = tf.keras.Model(inputs=encoded_features, outputs=output)
+model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+
+"""
+## Training
+
+Let's train our model for 50 epochs. Note that feature preprocessing is happening as part
+of the tf.data pipeline, not as part of the model.
+"""
+
+model.fit(
+    preprocessed_train_ds, validation_data=preprocessed_valid_ds, epochs=20, verbose=2
+)
+
+"""
+## Inference on new data with the end-to-end model
+
+Now, we can build our inference model (which includes the `FeatureSpace`) to make
+predictions based on dicts of raw features values, as follows:
+"""
+
+"""
+### Loading the `FeatureSpace`
+
+First let's load the `FeatureSpace` that we saved a few moment ago, this can be quite
+handy if you train a model but want to do inference at different time, possibly using a
+different device or environment.
+"""
+
+loaded_feature_space = tf.keras.models.load_model("myfeaturespace.keras")
+
+"""
+### Building the inference end-to-end model
+
+To build the inference model we need both the feature input map and the preprocessing
+encoded Keras tensors.
+"""
+
+dict_inputs = loaded_feature_space.get_inputs()
+encoded_features = loaded_feature_space.get_encoded_features()
+print(encoded_features)
+
+dict_inputs
+
+outputs = model(encoded_features)
+inference_model = tf.keras.Model(inputs=dict_inputs, outputs=outputs)
+
+sample = {
+    "age": 60,
+    "sex": 1,
+    "cp": 1,
+    "trestbps": 145,
+    "chol": 233,
+    "fbs": 1,
+    "restecg": 2,
+    "thalach": 150,
+    "exang": 0,
+    "oldpeak": 2.3,
+    "slope": 3,
+    "ca": 0,
+    "thal": "fixed",
+}
+
+input_dict = {name: tf.convert_to_tensor([value]) for name, value in sample.items()}
+predictions = inference_model.predict(input_dict)
+
+print(
+    f"This particular patient had a {100 * predictions[0][0]:.2f}% probability "
+    "of having a heart disease, as evaluated by our model."
+)

--- a/examples/structured_data/feature_space_advanced.py
+++ b/examples/structured_data/feature_space_advanced.py
@@ -1,17 +1,17 @@
 """
 Title: FeatureSpace avanced use cases
 Author: [Dimitre Oliveira](https://www.linkedin.com/in/dimitre-oliveira-7a1a0113a/)
-Date created: 2023/06/27
-Last modified: 2023/06/27
+Date created: 2023/07/01
+Last modified: 2023/07/01
 Description: How to use FeatureSpace for advanced preprocessing use cases.
 Accelerator: None
 """
 """
 ## Introduction
 
-This example is an extension of the [Structured data classification with
-FeatureSpace](https://keras.io/examples/structured_data/structured_data_classification_wit
-h_feature_space/) code example, and here we will extend it to cover more complex use
+This example is an extension of the
+[Structured data classification with FeatureSpace](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)
+code example, and here we will extend it to cover more complex use
 cases of the [`keras.utils.FeatureSpace`](https://keras.io/api/utils/feature_space/)
 preprocessing utility, like feature hashing, feature crosses, handling missing values and
 integrating [Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/)
@@ -25,31 +25,45 @@ features, and string categorical features.
 """
 ### The dataset
 
-[Our dataset](https://archive.ics.uci.edu/ml/datasets/heart+Disease) is provided by the
-Cleveland Clinic Foundation for Heart Disease.
-It's a CSV file with 303 rows. Each row contains information about a patient (a
-**sample**), and each column describes an attribute of the patient (a **feature**). We
-use the features to predict whether a patient has a heart disease
-(**binary classification**).
+[Our dataset](https://archive.ics.uci.edu/dataset/222/bank+marketing) is provided by a
+Portuguese banking institution.
+It's a CSV file with 4119 rows. Each row contains information about marketing campaigns
+based on phone calls, and each column describes an attribute of the client. We use the
+features to predict whether the client subscribed ('yes') or not ('no') to the product
+(bank term deposit).
 
 Here's the description of each feature:
 
 Column| Description| Feature Type
-------------|--------------------|----------------------
-Age | Age in years | Numerical
-Sex | (1 = male; 0 = female) | Categorical
-CP | Chest pain type (0, 1, 2, 3, 4) | Categorical
-Trestbpd | Resting blood pressure (in mm Hg on admission) | Numerical
-Chol | Serum cholesterol in mg/dl | Numerical
-FBS | fasting blood sugar in 120 mg/dl (1 = true; 0 = false) | Categorical
-RestECG | Resting electrocardiogram results (0, 1, 2) | Categorical
-Thalach | Maximum heart rate achieved | Numerical
-Exang | Exercise induced angina (1 = yes; 0 = no) | Categorical
-Oldpeak | ST depression induced by exercise relative to rest | Numerical
-Slope | Slope of the peak exercise ST segment | Numerical
-CA | Number of major vessels (0-3) colored by fluoroscopy | Both numerical & categorical
-Thal | 3 = normal; 6 = fixed defect; 7 = reversible defect | Categorical
-Target | Diagnosis of heart disease (1 = true; 0 = false) | Target
+------|------------|-------------
+Age | Age of the client | Numerical
+Job | Type of job | Categorical
+Marital | Marital status | Categorical
+Education | Education level of the client | Categorical
+Default | Has credit in default? | Categorical
+Housing | Has housing loan? | Categorical
+Loan | Has personal loan? | Categorical
+Contact | Contact communication type | Categorical
+Month | Last contact month of year | Categorical
+Day_of_week | Last contact day of the week | Categorical
+Duration | Last contact duration, in seconds | Numerical
+Campaign | Number of contacts performed during this campaign and for this client | Numerical
+Pdays | Number of days that passed by after the client was last contacted from a previous campaign | Numerical
+Previous | Number of contacts performed before this campaign and for this client | Numerical
+Poutcome | Outcome of the previous marketing campaign | Categorical
+Emp.var.rate | Employment variation rate | Numerical
+Cons.price.idx | Consumer price index | Numerical
+Cons.conf.idx | Consumer confidence index | Numerical
+Euribor3m | Euribor 3 month rate | Numerical
+Nr.employed | Number of employees | Numerical
+Y | Has the client subscribed a term deposit? | Target
+
+**Important note regarding the feature `duration`**:  this attribute highly affects the
+output target (e.g., if duration=0 then y='no'). Yet, the duration is not known before a
+call is performed. Also, after the end of the call y is obviously known. Thus, this input
+should only be included for benchmark purposes and should be discarded if the intention
+is to have a realistic predictive model. For this reason we will drop it.
+
 """
 
 """
@@ -58,6 +72,8 @@ Target | Diagnosis of heart disease (1 = true; 0 = false) | Target
 
 import pandas as pd
 import tensorflow as tf
+from pathlib import Path
+from zipfile import ZipFile
 from tensorflow.keras.utils import FeatureSpace
 
 """
@@ -66,20 +82,41 @@ from tensorflow.keras.utils import FeatureSpace
 Let's download the data and load it into a Pandas dataframe:
 """
 
-data_url = "http://storage.googleapis.com/download.tensorflow.org/data/heart.csv"
-dataframe = pd.read_csv(data_url)
+data_url = "https://archive.ics.uci.edu/static/public/222/bank+marketing.zip"
+data_zipped_path = tf.keras.utils.get_file("bank_marketing.zip", data_url, extract=True)
+keras_datasets_path = Path(data_zipped_path).parents[0]
+with ZipFile(f"{keras_datasets_path}/bank-additional.zip", "r") as zip:
+    # Extract files
+    zip.extractall(path=keras_datasets_path)
+
+dataframe = pd.read_csv(
+    f"{keras_datasets_path}/bank-additional/bank-additional.csv", sep=";"
+)
 
 """
-The dataset includes 303 samples with 14 columns per sample (13 features, plus the target
-label), here's a preview of a few samples:
+We will create a new feature `previously_contacted` to be able to demonstrate some useful
+preprocessing techniques, this feature is based on `pdays`. According to the dataset
+information if `pdays = 999` it means that the client was not previously contacted, so
+let's create a feature to capture that.
+"""
+
+# Droping `duration` to avoid target leak
+dataframe.drop("duration", axis=1, inplace=True)
+# Creating the new feature `previously_contacted`
+dataframe["previously_contacted"] = dataframe["pdays"].map(
+    lambda x: 0 if x == 999 else 1
+)
+
+"""
+The dataset includes 4119 samples with 21 columns per sample (20 features, plus the
+target label), here's a preview of a few samples:
 """
 
 print(f"Dataframe shape: {dataframe.shape}")
 display(dataframe.head())
 
 """
-The last column, "target", indicates whether the patient has a heart disease (1) or not
-(0).
+The column, "y", indicates whether the client has subscribed a term deposit or not.
 """
 
 """
@@ -88,11 +125,12 @@ The last column, "target", indicates whether the patient has a heart disease (1)
 Let's split the data into a training and validation set:
 """
 
-valid_dataframe = dataframe.sample(frac=0.2, random_state=42)
+valid_dataframe = dataframe.sample(frac=0.2, random_state=0)
 train_dataframe = dataframe.drop(valid_dataframe.index)
 
 print(
-    f"Using {len(train_dataframe)} samples for training and {len(valid_dataframe)} for validation"
+    f"Using {len(train_dataframe)} samples for training and "
+    f"{len(valid_dataframe)} for validation"
 )
 
 """
@@ -100,14 +138,29 @@ print(
 
 Let's generate
 [`tf.data.Dataset`](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) objects
-for each dataframe:
+for each dataframe, since our target column `y` is a string we also need to encode it as
+an integer to be able to train our model with it. To achieve this we will create a
+`StringLookup` layer that will map the strings "no" and "yes" into "0" and "1"
+respectively.
 """
+
+label_lookup = tf.keras.layers.StringLookup(
+    # the order here is important since the first index will be encoded as 0
+    vocabulary=["no", "yes"],
+    num_oov_indices=0,
+)
+
+
+def encode_label(x, y):
+    encoded_y = label_lookup(y)
+    return x, encoded_y
 
 
 def dataframe_to_dataset(dataframe):
     dataframe = dataframe.copy()
-    labels = dataframe.pop("target")
+    labels = dataframe.pop("y")
     ds = tf.data.Dataset.from_tensor_slices((dict(dataframe), labels))
+    ds = ds.map(encode_label, num_parallel_calls=tf.data.AUTOTUNE)
     ds = ds.shuffle(buffer_size=len(dataframe))
     return ds
 
@@ -165,29 +218,32 @@ def example_feature_space(dataset, feature_space, feature_names):
 
 """
 **Feature hashing** means hashing or encoding a set of values into a defined number of
-bins, in this case we have `thalach` (Maximum heart rate achieved) which is a numerical
-feature that can assume a varying range of values and we will hash it into 4 bins, this
-means that any possible value of the original feature will be placed into one of those
-possible 5 bins. The output here can be a one-hot encoded vector or a single number.
+bins, in this case we have `campaign` (number of contacts performed during this campaign
+and for a client) which is a numerical feature that can assume a varying range of values
+and we will hash it into 4 bins, this means that any possible value of the original
+feature will be placed into one of those possible 4 bins. The output here can be a
+one-hot encoded vector or a single number.
 """
 
 feature_space = FeatureSpace(
     features={
-        "thalach": FeatureSpace.integer_hashed(num_bins=4, output_mode="one_hot")
+        "campaign": FeatureSpace.integer_hashed(num_bins=4, output_mode="one_hot")
     },
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["thalach"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["campaign"])
 
 """
 **Feature hashing** can also be used for string features.
 """
 
 feature_space = FeatureSpace(
-    features={"thal": FeatureSpace.string_hashed(num_bins=2, output_mode="one_hot")},
+    features={
+        "education": FeatureSpace.string_hashed(num_bins=3, output_mode="one_hot")
+    },
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["education"])
 
 """
 For numerical features we can get a similar behavior by using the `float_discretized`
@@ -220,48 +276,50 @@ values after the training (values that were not seen during the `adapt()` step)
 
 feature_space = FeatureSpace(
     features={
-        "thal": FeatureSpace.string_categorical(
+        "default": FeatureSpace.string_categorical(
             num_oov_indices=1, output_mode="one_hot"
         )
     },
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["default"])
 
 """
-We also can do **feature indexing** for integer features, this is quite important for
-features like `sex` where values like (`1 and 0`) do not have a numerical relationship
+We also can do **feature indexing** for integer features, this can be quite important for
+some datasets where categorical features are replaced by numbers, for instance features
+like `sex` or `gender` where values like (`1 and 0`) do not have a numerical relationship
 between them, they are just different categories, this behavior can be perfectly captured
 by this transformation.
 
-For this case we want to explicitly set `num_oov_indices=0` for the feature `sex` the
-reason is that we only expect two possible values for this feature anything else would
-either wrong input or and issue with the data creation, for this reason we would probably
-just want the code to throw an error so that we can be aware of the issue and fix it.
+On this dataset we can use the feature that we created `previously_contacted`. For this
+case we want to explicitly set `num_oov_indices=0`, the reason is that we only expect two
+possible values for the feature, anything else would be either wrong input or an issue
+with the data creation, for this reason we would probably just want the code to throw an
+error so that we can be aware of the issue and fix it.
 """
 
 feature_space = FeatureSpace(
     features={
-        "sex": FeatureSpace.integer_categorical(
+        "previously_contacted": FeatureSpace.integer_categorical(
             num_oov_indices=0, output_mode="one_hot"
         )
     },
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["sex"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["previously_contacted"])
 
 """
 ### Feature crosses (mixing features of diverse types)
 
 With **crosses** we can do feature interactions between an arbitrary number of features
 of mixed types as long as they are categorical features, you can think of instead of
-having a feature {'age': 20} and another {'sex': 0} we can have {'age_X_sex': 20_0}, but
-with `FeatureSpace` and **crosses** we can apply specific preprocessing to each
-individual feature and to the feature cross itself. This option can be very powerful for
-specific use cases, here might be a good option since age combined with gender can have
-different meanings for the health domain.
+having a feature {'age': 20} and another {'job': 'entrepreneur'} we can have
+{'age_X_job': 20_entrepreneur}, but with `FeatureSpace` and **crosses** we can apply
+specific preprocessing to each individual feature and to the feature cross itself. This
+option can be very powerful for specific use cases, here might be a good option since age
+combined with job can have different meanings for the banking domain.
 
-We will cross `age` and `sex` and hash the combination output of them into a vector
+We will cross `age` and `job` and hash the combination output of them into a vector
 representation of size 8. The output here can be a one-hot encoded vector or a single
 number.
 
@@ -270,28 +328,28 @@ space, think about crossing someone's ZIP code with its last name, the possibili
 would be in the thousands, that is why the `crossing_dim` parameter is so important it
 limits the output dimension of the cross feature.
 
-Note that the combination of possible values of the 6 bins of `age` and the 2 values of
-`sex` would be 12, so by choosing `crossing_dim` we are choosing to constrain a little
-bit the output vector.
+Note that the combination of possible values of the 6 bins of `age` and the 12 values of
+`job` would be 72, so by choosing `crossing_dim = 8` we are choosing to constrain the
+output vector.
 """
 
 feature_space = FeatureSpace(
     features={
         "age": FeatureSpace.integer_hashed(num_bins=6, output_mode="one_hot"),
-        "sex": FeatureSpace.integer_categorical(
+        "job": FeatureSpace.string_categorical(
             num_oov_indices=0, output_mode="one_hot"
         ),
     },
     crosses=[
         FeatureSpace.cross(
-            feature_names=("age", "sex"),
+            feature_names=("age", "job"),
             crossing_dim=8,
             output_mode="one_hot",
         )
     ],
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["age", "sex"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["age", "job"])
 
 """
 ### FeatureSpace using a Keras preprocessing layer
@@ -304,22 +362,23 @@ can use sophisticated data transformations provided by the framework, you can ev
 your own custom Keras preprocessing layers and use it in the same way.
 
 Here we are going to use the
-[`tf.keras.layers.TextVectorization`](https://keras.io/api/layers/preprocessing_layers/tex
-t/text_vectorization/#textvectorization-class) preprocessing layer to create a TF-IDF
-feature from our data.
+[`tf.keras.layers.TextVectorization`](https://keras.io/api/layers/preprocessing_layers/text/text_vectorization/#textvectorization-class)
+preprocessing layer to create a TF-IDF
+feature from our data. Note that this feature is not a really good use case for TF-IDF,
+this is just for demonstration purposes.
 """
 
 custom_layer = tf.keras.layers.TextVectorization(output_mode="tf_idf")
 
 feature_space = FeatureSpace(
     features={
-        "thal": FeatureSpace.feature(
+        "education": FeatureSpace.feature(
             preprocessor=custom_layer, dtype="string", output_mode="float"
         )
     },
     output_mode="dict",
 )
-example_feature_space(train_ds_with_no_labels, feature_space, ["thal"])
+example_feature_space(train_ds_with_no_labels, feature_space, ["education"])
 
 """
 ## Configuring the final `FeatureSpace`
@@ -337,30 +396,41 @@ to the feature transformation function.
 feature_space = FeatureSpace(
     features={
         # Categorical features encoded as integers
-        "sex": FeatureSpace.integer_categorical(num_oov_indices=0),
-        "cp": FeatureSpace.integer_categorical(num_oov_indices=0),
-        "fbs": FeatureSpace.integer_categorical(num_oov_indices=0),
-        "restecg": FeatureSpace.integer_categorical(num_oov_indices=0),
-        "exang": FeatureSpace.integer_categorical(num_oov_indices=0),
-        "ca": FeatureSpace.integer_categorical(num_oov_indices=0),
+        "previously_contacted": FeatureSpace.integer_categorical(num_oov_indices=0),
         # Categorical features encoded as string
-        "thal": FeatureSpace.string_categorical(num_oov_indices=1),
+        "marital": FeatureSpace.string_categorical(num_oov_indices=0),
+        "education": FeatureSpace.string_categorical(num_oov_indices=0),
+        "default": FeatureSpace.string_categorical(num_oov_indices=0),
+        "housing": FeatureSpace.string_categorical(num_oov_indices=0),
+        "loan": FeatureSpace.string_categorical(num_oov_indices=0),
+        "contact": FeatureSpace.string_categorical(num_oov_indices=0),
+        "month": FeatureSpace.string_categorical(num_oov_indices=0),
+        "day_of_week": FeatureSpace.string_categorical(num_oov_indices=0),
+        "poutcome": FeatureSpace.string_categorical(num_oov_indices=0),
+        # Categorical features to hash and bin
+        "job": FeatureSpace.string_hashed(num_bins=3),
         # Numerical features to hash and bin
-        "age": FeatureSpace.integer_hashed(num_bins=6),
-        "thalach": FeatureSpace.integer_hashed(num_bins=4),
+        "pdays": FeatureSpace.integer_hashed(num_bins=4),
+        # Numerical features to normalize and bin
+        "age": FeatureSpace.float_discretized(num_bins=4),
         # Numerical features to normalize
-        "trestbps": FeatureSpace.float_normalized(),
-        "chol": FeatureSpace.float_normalized(),
-        "oldpeak": FeatureSpace.float_normalized(),
-        "slope": FeatureSpace.float_normalized(),
+        "campaign": FeatureSpace.float_normalized(),
+        "previous": FeatureSpace.float_normalized(),
+        "emp.var.rate": FeatureSpace.float_normalized(),
+        "cons.price.idx": FeatureSpace.float_normalized(),
+        "cons.conf.idx": FeatureSpace.float_normalized(),
+        "euribor3m": FeatureSpace.float_normalized(),
+        "nr.employed": FeatureSpace.float_normalized(),
     },
     # Specify feature cross with a custom crossing dim.
     crosses=[
+        FeatureSpace.cross(feature_names=("age", "job"), crossing_dim=8),
         FeatureSpace.cross(
-            feature_names=("age", "sex"),
-            crossing_dim=8,
-            output_mode="one_hot",
-        )
+            feature_names=("default", "housing", "loan"), crossing_dim=6
+        ),
+        FeatureSpace.cross(
+            feature_names=("poutcome", "previously_contacted"), crossing_dim=2
+        ),
     ],
     output_mode="concat",
 )
@@ -407,9 +477,8 @@ At this point we can choose to save our `FeatureSpace` component, this have many
 advantages like re-using it on different experiments that use the same model, saving time
 if you need to re-run the preprocessing step, and mainly for model deployment, where by
 loading it you can be sure that you will be applying the same preprocessing steps don't
-matter the device or environment, this is a great way to reduce [training/serving
-skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
-skew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
+matter the device or environment, this is a great way to reduce
+[training/servingskew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
 """
 
 feature_space.save("myfeaturespace.keras")
@@ -418,9 +487,9 @@ feature_space.save("myfeaturespace.keras")
 ## Preprocessing with `FeatureSpace` as part of the tf.data pipeline
 
 We will opt to use our component asynchronously by making it part of the tf.data
-pipeline, as noted at the [previous
-guide](https://keras.io/examples/structured_data/structured_data_classification_with_featu
-re_space/) This enables asynchronous parallel preprocessing of the data on CPU before it
+pipeline, as noted at the
+[previous guide](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)
+This enables asynchronous parallel preprocessing of the data on CPU before it
 hits the model. Usually, this is always the right thing to do during training.
 
 Let's create a training and validation dataset of preprocessed batches:
@@ -450,7 +519,7 @@ This model is quite trivial only for demonstration purposes so don't pay too muc
 attention to the architecture.
 """
 
-x = tf.keras.layers.Dense(32, activation="relu")(encoded_features)
+x = tf.keras.layers.Dense(64, activation="relu")(encoded_features)
 x = tf.keras.layers.Dropout(0.5)(x)
 output = tf.keras.layers.Dense(1, activation="sigmoid")(x)
 
@@ -460,7 +529,7 @@ model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"]
 """
 ## Training
 
-Let's train our model for 50 epochs. Note that feature preprocessing is happening as part
+Let's train our model for 20 epochs. Note that feature preprocessing is happening as part
 of the tf.data pipeline, not as part of the model.
 """
 
@@ -496,31 +565,38 @@ dict_inputs = loaded_feature_space.get_inputs()
 encoded_features = loaded_feature_space.get_encoded_features()
 print(encoded_features)
 
-dict_inputs
+print(dict_inputs)
 
 outputs = model(encoded_features)
 inference_model = tf.keras.Model(inputs=dict_inputs, outputs=outputs)
 
 sample = {
-    "age": 60,
-    "sex": 1,
-    "cp": 1,
-    "trestbps": 145,
-    "chol": 233,
-    "fbs": 1,
-    "restecg": 2,
-    "thalach": 150,
-    "exang": 0,
-    "oldpeak": 2.3,
-    "slope": 3,
-    "ca": 0,
-    "thal": "fixed",
+    "age": 30,
+    "job": "blue-collar",
+    "marital": "married",
+    "education": "basic.9y",
+    "default": "no",
+    "housing": "yes",
+    "loan": "no",
+    "contact": "cellular",
+    "month": "may",
+    "day_of_week": "fri",
+    "campaign": 2,
+    "pdays": 999,
+    "previous": 0,
+    "poutcome": "nonexistent",
+    "emp.var.rate": -1.8,
+    "cons.price.idx": 92.893,
+    "cons.conf.idx": -46.2,
+    "euribor3m": 1.313,
+    "nr.employed": 5099.1,
+    "previously_contacted": 0,
 }
 
 input_dict = {name: tf.convert_to_tensor([value]) for name, value in sample.items()}
 predictions = inference_model.predict(input_dict)
 
 print(
-    f"This particular patient had a {100 * predictions[0][0]:.2f}% probability "
-    "of having a heart disease, as evaluated by our model."
+    f"This particular client has a {100 * predictions[0][0]:.2f}% probability "
+    "of subscribing a term deposit, as evaluated by our model."
 )

--- a/examples/structured_data/ipynb/feature_space_advanced.ipynb
+++ b/examples/structured_data/ipynb/feature_space_advanced.ipynb
@@ -1,0 +1,1025 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# FeatureSpace avanced use cases\n",
+    "\n",
+    "**Author:** [Dimitre Oliveira](https://www.linkedin.com/in/dimitre-oliveira-7a1a0113a/)<br>\n",
+    "**Date created:** 2023/07/01<br>\n",
+    "**Last modified:** 2023/07/01<br>\n",
+    "**Description:** How to use FeatureSpace for advanced preprocessing use cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This example is an extension of the\n",
+    "[Structured data classification with FeatureSpace](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)\n",
+    "code example, and here we will extend it to cover more complex use\n",
+    "cases of the [`keras.utils.FeatureSpace`](https://keras.io/api/utils/feature_space/)\n",
+    "preprocessing utility, like feature hashing, feature crosses, handling missing values and\n",
+    "integrating [Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/)\n",
+    "with FeatureSpace.\n",
+    "\n",
+    "The general task still is structured data classification (also known as tabular data\n",
+    "classification) using a data that includes numerical features, integer categorical\n",
+    "features, and string categorical features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### The dataset\n",
+    "\n",
+    "[Our dataset](https://archive.ics.uci.edu/dataset/222/bank+marketing) is provided by a\n",
+    "Portuguese banking institution.\n",
+    "It's a CSV file with 4119 rows. Each row contains information about marketing campaigns\n",
+    "based on phone calls, and each column describes an attribute of the client. We use the\n",
+    "features to predict whether the client subscribed ('yes') or not ('no') to the product\n",
+    "(bank term deposit).\n",
+    "\n",
+    "Here's the description of each feature:\n",
+    "\n",
+    "Column| Description| Feature Type\n",
+    "------|------------|-------------\n",
+    "Age | Age of the client | Numerical\n",
+    "Job | Type of job | Categorical\n",
+    "Marital | Marital status | Categorical\n",
+    "Education | Education level of the client | Categorical\n",
+    "Default | Has credit in default? | Categorical\n",
+    "Housing | Has housing loan? | Categorical\n",
+    "Loan | Has personal loan? | Categorical\n",
+    "Contact | Contact communication type | Categorical\n",
+    "Month | Last contact month of year | Categorical\n",
+    "Day_of_week | Last contact day of the week | Categorical\n",
+    "Duration | Last contact duration, in seconds | Numerical\n",
+    "Campaign | Number of contacts performed during this campaign and for this client | Numerical\n",
+    "Pdays | Number of days that passed by after the client was last contacted from a previous campaign | Numerical\n",
+    "Previous | Number of contacts performed before this campaign and for this client | Numerical\n",
+    "Poutcome | Outcome of the previous marketing campaign | Categorical\n",
+    "Emp.var.rate | Employment variation rate | Numerical\n",
+    "Cons.price.idx | Consumer price index | Numerical\n",
+    "Cons.conf.idx | Consumer confidence index | Numerical\n",
+    "Euribor3m | Euribor 3 month rate | Numerical\n",
+    "Nr.employed | Number of employees | Numerical\n",
+    "Y | Has the client subscribed a term deposit? | Target\n",
+    "\n",
+    "**Important note regarding the feature `duration`**:  this attribute highly affects the\n",
+    "output target (e.g., if duration=0 then y='no'). Yet, the duration is not known before a\n",
+    "call is performed. Also, after the end of the call y is obviously known. Thus, this input\n",
+    "should only be included for benchmark purposes and should be discarded if the intention\n",
+    "is to have a realistic predictive model. For this reason we will drop it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import tensorflow as tf\n",
+    "from pathlib import Path\n",
+    "from zipfile import ZipFile\n",
+    "from tensorflow.keras.utils import FeatureSpace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Load the data\n",
+    "\n",
+    "Let's download the data and load it into a Pandas dataframe:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "data_url = \"https://archive.ics.uci.edu/static/public/222/bank+marketing.zip\"\n",
+    "data_zipped_path = tf.keras.utils.get_file(\"bank_marketing.zip\", data_url, extract=True)\n",
+    "keras_datasets_path = Path(data_zipped_path).parents[0]\n",
+    "with ZipFile(f\"{keras_datasets_path}/bank-additional.zip\", \"r\") as zip:\n",
+    "    # Extract files\n",
+    "    zip.extractall(path=keras_datasets_path)\n",
+    "\n",
+    "dataframe = pd.read_csv(\n",
+    "    f\"{keras_datasets_path}/bank-additional/bank-additional.csv\", sep=\";\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We will create a new feature `previously_contacted` to be able to demonstrate some useful\n",
+    "preprocessing techniques, this feature is based on `pdays`. According to the dataset\n",
+    "information if `pdays = 999` it means that the client was not previously contacted, so\n",
+    "let's create a feature to capture that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "# Droping `duration` to avoid target leak\n",
+    "dataframe.drop(\"duration\", axis=1, inplace=True)\n",
+    "# Creating the new feature `previously_contacted`\n",
+    "dataframe[\"previously_contacted\"] = dataframe[\"pdays\"].map(\n",
+    "    lambda x: 0 if x == 999 else 1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The dataset includes 4119 samples with 21 columns per sample (20 features, plus the\n",
+    "target label), here's a preview of a few samples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"Dataframe shape: {dataframe.shape}\")\n",
+    "display(dataframe.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The column, \"y\", indicates whether the client has subscribed a term deposit or not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Train/validation split\n",
+    "\n",
+    "Let's split the data into a training and validation set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "valid_dataframe = dataframe.sample(frac=0.2, random_state=0)\n",
+    "train_dataframe = dataframe.drop(valid_dataframe.index)\n",
+    "\n",
+    "print(\n",
+    "    f\"Using {len(train_dataframe)} samples for training and \"\n",
+    "    f\"{len(valid_dataframe)} for validation\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Generating TF datasets\n",
+    "\n",
+    "Let's generate\n",
+    "[`tf.data.Dataset`](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) objects\n",
+    "for each dataframe, since our target column `y` is a string we also need to encode it as\n",
+    "an integer to be able to train our model with it. To achieve this we will create a\n",
+    "`StringLookup` layer that will map the strings \"no\" and \"yes\" into \"0\" and \"1\"\n",
+    "respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "label_lookup = tf.keras.layers.StringLookup(\n",
+    "    # the order here is important since the first index will be encoded as 0\n",
+    "    vocabulary=[\"no\", \"yes\"],\n",
+    "    num_oov_indices=0,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def encode_label(x, y):\n",
+    "    encoded_y = label_lookup(y)\n",
+    "    return x, encoded_y\n",
+    "\n",
+    "\n",
+    "def dataframe_to_dataset(dataframe):\n",
+    "    dataframe = dataframe.copy()\n",
+    "    labels = dataframe.pop(\"y\")\n",
+    "    ds = tf.data.Dataset.from_tensor_slices((dict(dataframe), labels))\n",
+    "    ds = ds.map(encode_label, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "    ds = ds.shuffle(buffer_size=len(dataframe))\n",
+    "    return ds\n",
+    "\n",
+    "\n",
+    "train_ds = dataframe_to_dataset(train_dataframe)\n",
+    "valid_ds = dataframe_to_dataset(valid_dataframe)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Each `Dataset` yields a tuple `(input, target)` where `input` is a dictionary of features\n",
+    "and `target` is the value `0` or `1`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "for x, y in dataframe_to_dataset(train_dataframe).take(1):\n",
+    "    print(f\"Input: {x}\")\n",
+    "    print(f\"Target: {y}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Preprocessing\n",
+    "\n",
+    "Usually our data is not on the proper or best format for modeling, this is why most of\n",
+    "the time we need to do some kind of preprocessing on the features to make them compatible\n",
+    "with the model or to extract the most of them for the task. We need to do this\n",
+    "preprocessing step for training but but at inference we also need to make sure that the\n",
+    "data goes through the same process, this where a utility like `FeatureSpace` shines, we\n",
+    "can define all the preprocessing once and re-use it at different stages of our system.\n",
+    "\n",
+    "Here we will see how to use `FeatureSpace` to perform more complex transformations and\n",
+    "its flexibility, then combine everything together into a single component to preprocess\n",
+    "data for our model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The `FeatureSpace` utility learns how to process the data by using the `adapt()` function\n",
+    "to learn from it, this requires a dataset containing only feature, so let's create it\n",
+    "together with a utility function to show the preprocessing example in practice:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "train_ds_with_no_labels = train_ds.map(lambda x, _: x)\n",
+    "\n",
+    "\n",
+    "def example_feature_space(dataset, feature_space, feature_names):\n",
+    "    feature_space.adapt(dataset)\n",
+    "    for x in dataset.take(1):\n",
+    "        inputs = {feature_name: x[feature_name] for feature_name in feature_names}\n",
+    "        preprocessed_x = feature_space(inputs)\n",
+    "        print(f\"Input: {[{k:v.numpy()} for k, v in inputs.items()]}\")\n",
+    "        print(\n",
+    "            f\"Preprocessed output: {[{k:v.numpy()} for k, v in preprocessed_x.items()]}\"\n",
+    "        )\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Feature hashing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "**Feature hashing** means hashing or encoding a set of values into a defined number of\n",
+    "bins, in this case we have `campaign` (number of contacts performed during this campaign\n",
+    "and for a client) which is a numerical feature that can assume a varying range of values\n",
+    "and we will hash it into 4 bins, this means that any possible value of the original\n",
+    "feature will be placed into one of those possible 4 bins. The output here can be a\n",
+    "one-hot encoded vector or a single number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"campaign\": FeatureSpace.integer_hashed(num_bins=4, output_mode=\"one_hot\")\n",
+    "    },\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"campaign\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "**Feature hashing** can also be used for string features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"education\": FeatureSpace.string_hashed(num_bins=3, output_mode=\"one_hot\")\n",
+    "    },\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"education\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "For numerical features we can get a similar behavior by using the `float_discretized`\n",
+    "option, the main difference between this and `integer_hashed` is that with the former we\n",
+    "bin the values while keeping some numerical relationship (close values will likely be\n",
+    "placed at the same bin) while the later (hashing) we cannot guarantee that those numbers\n",
+    "will be hashed into the same bin, it depends on the hashing function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\"age\": FeatureSpace.float_discretized(num_bins=3, output_mode=\"one_hot\")},\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"age\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Feature indexing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "**Indexing** a string feature essentially means creating a discrete numerical\n",
+    "representation for it, this is especially important for string features since most models\n",
+    "only accept numerical features. This transformation will place the string values into\n",
+    "different categories. The output here can be a one-hot encoded vector or a single number.\n",
+    "\n",
+    "Note that by specifying `num_oov_indices=1` we leave one spot at our output vector for\n",
+    "OOV (out of vocabulary) values this is an important tool to handle missing or unseen\n",
+    "values after the training (values that were not seen during the `adapt()` step)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"default\": FeatureSpace.string_categorical(\n",
+    "            num_oov_indices=1, output_mode=\"one_hot\"\n",
+    "        )\n",
+    "    },\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"default\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "We also can do **feature indexing** for integer features, this can be quite important for\n",
+    "some datasets where categorical features are replaced by numbers, for instance features\n",
+    "like `sex` or `gender` where values like (`1 and 0`) do not have a numerical relationship\n",
+    "between them, they are just different categories, this behavior can be perfectly captured\n",
+    "by this transformation.\n",
+    "\n",
+    "On this dataset we can use the feature that we created `previously_contacted`. For this\n",
+    "case we want to explicitly set `num_oov_indices=0`, the reason is that we only expect two\n",
+    "possible values for the feature, anything else would be either wrong input or an issue\n",
+    "with the data creation, for this reason we would probably just want the code to throw an\n",
+    "error so that we can be aware of the issue and fix it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"previously_contacted\": FeatureSpace.integer_categorical(\n",
+    "            num_oov_indices=0, output_mode=\"one_hot\"\n",
+    "        )\n",
+    "    },\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"previously_contacted\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Feature crosses (mixing features of diverse types)\n",
+    "\n",
+    "With **crosses** we can do feature interactions between an arbitrary number of features\n",
+    "of mixed types as long as they are categorical features, you can think of instead of\n",
+    "having a feature {'age': 20} and another {'job': 'entrepreneur'} we can have\n",
+    "{'age_X_job': 20_entrepreneur}, but with `FeatureSpace` and **crosses** we can apply\n",
+    "specific preprocessing to each individual feature and to the feature cross itself. This\n",
+    "option can be very powerful for specific use cases, here might be a good option since age\n",
+    "combined with job can have different meanings for the banking domain.\n",
+    "\n",
+    "We will cross `age` and `job` and hash the combination output of them into a vector\n",
+    "representation of size 8. The output here can be a one-hot encoded vector or a single\n",
+    "number.\n",
+    "\n",
+    "Sometimes the combination of multiple features can result into on a super large feature\n",
+    "space, think about crossing someone's ZIP code with its last name, the possibilities\n",
+    "would be in the thousands, that is why the `crossing_dim` parameter is so important it\n",
+    "limits the output dimension of the cross feature.\n",
+    "\n",
+    "Note that the combination of possible values of the 6 bins of `age` and the 12 values of\n",
+    "`job` would be 72, so by choosing `crossing_dim = 8` we are choosing to constrain the\n",
+    "output vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"age\": FeatureSpace.integer_hashed(num_bins=6, output_mode=\"one_hot\"),\n",
+    "        \"job\": FeatureSpace.string_categorical(\n",
+    "            num_oov_indices=0, output_mode=\"one_hot\"\n",
+    "        ),\n",
+    "    },\n",
+    "    crosses=[\n",
+    "        FeatureSpace.cross(\n",
+    "            feature_names=(\"age\", \"job\"),\n",
+    "            crossing_dim=8,\n",
+    "            output_mode=\"one_hot\",\n",
+    "        )\n",
+    "    ],\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"age\", \"job\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### FeatureSpace using a Keras preprocessing layer\n",
+    "\n",
+    "To be a really flexible and extensible feature we cannot only rely on those pre-defined\n",
+    "transformation, we must be able to re-use other transformations from the Keras/TensorFlow\n",
+    "ecosystem and customize our own, this is why `FeatureSpace` is also designed to work with\n",
+    "[Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/), this way we\n",
+    "can use sophisticated data transformations provided by the framework, you can even create\n",
+    "your own custom Keras preprocessing layers and use it in the same way.\n",
+    "\n",
+    "Here we are going to use the\n",
+    "[`tf.keras.layers.TextVectorization`](https://keras.io/api/layers/preprocessing_layers/text/text_vectorization/#textvectorization-class)\n",
+    "preprocessing layer to create a TF-IDF\n",
+    "feature from our data. Note that this feature is not a really good use case for TF-IDF,\n",
+    "this is just for demonstration purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "custom_layer = tf.keras.layers.TextVectorization(output_mode=\"tf_idf\")\n",
+    "\n",
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        \"education\": FeatureSpace.feature(\n",
+    "            preprocessor=custom_layer, dtype=\"string\", output_mode=\"float\"\n",
+    "        )\n",
+    "    },\n",
+    "    output_mode=\"dict\",\n",
+    ")\n",
+    "example_feature_space(train_ds_with_no_labels, feature_space, [\"education\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Configuring the final `FeatureSpace`\n",
+    "\n",
+    "Now that we know how to use `FeatureSpace` for more complex use cases let's pick the ones\n",
+    "that looks more useful for this task and create the final `FeatureSpace` component.\n",
+    "\n",
+    "To configure how each feature should be preprocessed,\n",
+    "we instantiate a `keras.utils.FeatureSpace`, and we\n",
+    "pass to it a dictionary that maps the name of our features\n",
+    "to the feature transformation function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space = FeatureSpace(\n",
+    "    features={\n",
+    "        # Categorical features encoded as integers\n",
+    "        \"previously_contacted\": FeatureSpace.integer_categorical(num_oov_indices=0),\n",
+    "        # Categorical features encoded as string\n",
+    "        \"marital\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"education\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"default\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"housing\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"loan\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"contact\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"month\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"day_of_week\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        \"poutcome\": FeatureSpace.string_categorical(num_oov_indices=0),\n",
+    "        # Categorical features to hash and bin\n",
+    "        \"job\": FeatureSpace.string_hashed(num_bins=3),\n",
+    "        # Numerical features to hash and bin\n",
+    "        \"pdays\": FeatureSpace.integer_hashed(num_bins=4),\n",
+    "        # Numerical features to normalize and bin\n",
+    "        \"age\": FeatureSpace.float_discretized(num_bins=4),\n",
+    "        # Numerical features to normalize\n",
+    "        \"campaign\": FeatureSpace.float_normalized(),\n",
+    "        \"previous\": FeatureSpace.float_normalized(),\n",
+    "        \"emp.var.rate\": FeatureSpace.float_normalized(),\n",
+    "        \"cons.price.idx\": FeatureSpace.float_normalized(),\n",
+    "        \"cons.conf.idx\": FeatureSpace.float_normalized(),\n",
+    "        \"euribor3m\": FeatureSpace.float_normalized(),\n",
+    "        \"nr.employed\": FeatureSpace.float_normalized(),\n",
+    "    },\n",
+    "    # Specify feature cross with a custom crossing dim.\n",
+    "    crosses=[\n",
+    "        FeatureSpace.cross(feature_names=(\"age\", \"job\"), crossing_dim=8),\n",
+    "        FeatureSpace.cross(\n",
+    "            feature_names=(\"default\", \"housing\", \"loan\"), crossing_dim=6\n",
+    "        ),\n",
+    "        FeatureSpace.cross(\n",
+    "            feature_names=(\"poutcome\", \"previously_contacted\"), crossing_dim=2\n",
+    "        ),\n",
+    "    ],\n",
+    "    output_mode=\"concat\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Adapt the `FeatureSpace` to the training data\n",
+    "\n",
+    "Before we start using the `FeatureSpace` to build a model, we have\n",
+    "to adapt it to the training data. During `adapt()`, the `FeatureSpace` will:\n",
+    "\n",
+    "- Index the set of possible values for categorical features.\n",
+    "- Compute the mean and variance for numerical features to normalize.\n",
+    "- Compute the value boundaries for the different bins for numerical features to\n",
+    "discretize.\n",
+    "- Any other kind of preprocessing required by custom layers.\n",
+    "\n",
+    "Note that `adapt()` should be called on a `tf.data.Dataset` which yields dicts\n",
+    "of feature values -- no labels.\n",
+    "\n",
+    "But first let's batch the datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "train_ds = train_ds.batch(32)\n",
+    "valid_ds = valid_ds.batch(32)\n",
+    "\n",
+    "train_ds_with_no_labels = train_ds.map(lambda x, _: x)\n",
+    "feature_space.adapt(train_ds_with_no_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "At this point, the `FeatureSpace` can be called on a dict of raw feature values, and\n",
+    "because we set `output_mode=\"concat\"` it will return a single concatenate vector for each\n",
+    "sample, combining encoded features and feature crosses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "for x, _ in train_ds.take(1):\n",
+    "    preprocessed_x = feature_space(x)\n",
+    "    print(f\"preprocessed_x shape: {preprocessed_x.shape}\")\n",
+    "    print(f\"preprocessed_x sample: \\n{preprocessed_x[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Saving the `FeatureSpace`\n",
+    "\n",
+    "At this point we can choose to save our `FeatureSpace` component, this have many\n",
+    "advantages like re-using it on different experiments that use the same model, saving time\n",
+    "if you need to re-run the preprocessing step, and mainly for model deployment, where by\n",
+    "loading it you can be sure that you will be applying the same preprocessing steps don't\n",
+    "matter the device or environment, this is a great way to reduce\n",
+    "[training/servingskew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "feature_space.save(\"myfeaturespace.keras\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Preprocessing with `FeatureSpace` as part of the tf.data pipeline\n",
+    "\n",
+    "We will opt to use our component asynchronously by making it part of the tf.data\n",
+    "pipeline, as noted at the\n",
+    "[previous guide](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)\n",
+    "This enables asynchronous parallel preprocessing of the data on CPU before it\n",
+    "hits the model. Usually, this is always the right thing to do during training.\n",
+    "\n",
+    "Let's create a training and validation dataset of preprocessed batches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "preprocessed_train_ds = train_ds.map(\n",
+    "    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE\n",
+    ").prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "preprocessed_valid_ds = valid_ds.map(\n",
+    "    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE\n",
+    ").prefetch(tf.data.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Model\n",
+    "\n",
+    "We will take advantage of our `FeatureSpace` component to build the model, as we want the\n",
+    "model to be compatible with our preprocessing function, let's use the the `FeatureSpace`\n",
+    "feature map as the input of our model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "encoded_features = feature_space.get_encoded_features()\n",
+    "print(encoded_features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "This model is quite trivial only for demonstration purposes so don't pay too much\n",
+    "attention to the architecture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "x = tf.keras.layers.Dense(64, activation=\"relu\")(encoded_features)\n",
+    "x = tf.keras.layers.Dropout(0.5)(x)\n",
+    "output = tf.keras.layers.Dense(1, activation=\"sigmoid\")(x)\n",
+    "\n",
+    "model = tf.keras.Model(inputs=encoded_features, outputs=output)\n",
+    "model.compile(optimizer=\"adam\", loss=\"binary_crossentropy\", metrics=[\"accuracy\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Training\n",
+    "\n",
+    "Let's train our model for 20 epochs. Note that feature preprocessing is happening as part\n",
+    "of the tf.data pipeline, not as part of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "model.fit(\n",
+    "    preprocessed_train_ds, validation_data=preprocessed_valid_ds, epochs=20, verbose=2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Inference on new data with the end-to-end model\n",
+    "\n",
+    "Now, we can build our inference model (which includes the `FeatureSpace`) to make\n",
+    "predictions based on dicts of raw features values, as follows:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Loading the `FeatureSpace`\n",
+    "\n",
+    "First let's load the `FeatureSpace` that we saved a few moment ago, this can be quite\n",
+    "handy if you train a model but want to do inference at different time, possibly using a\n",
+    "different device or environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "loaded_feature_space = tf.keras.models.load_model(\"myfeaturespace.keras\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "### Building the inference end-to-end model\n",
+    "\n",
+    "To build the inference model we need both the feature input map and the preprocessing\n",
+    "encoded Keras tensors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "dict_inputs = loaded_feature_space.get_inputs()\n",
+    "encoded_features = loaded_feature_space.get_encoded_features()\n",
+    "print(encoded_features)\n",
+    "\n",
+    "print(dict_inputs)\n",
+    "\n",
+    "outputs = model(encoded_features)\n",
+    "inference_model = tf.keras.Model(inputs=dict_inputs, outputs=outputs)\n",
+    "\n",
+    "sample = {\n",
+    "    \"age\": 30,\n",
+    "    \"job\": \"blue-collar\",\n",
+    "    \"marital\": \"married\",\n",
+    "    \"education\": \"basic.9y\",\n",
+    "    \"default\": \"no\",\n",
+    "    \"housing\": \"yes\",\n",
+    "    \"loan\": \"no\",\n",
+    "    \"contact\": \"cellular\",\n",
+    "    \"month\": \"may\",\n",
+    "    \"day_of_week\": \"fri\",\n",
+    "    \"campaign\": 2,\n",
+    "    \"pdays\": 999,\n",
+    "    \"previous\": 0,\n",
+    "    \"poutcome\": \"nonexistent\",\n",
+    "    \"emp.var.rate\": -1.8,\n",
+    "    \"cons.price.idx\": 92.893,\n",
+    "    \"cons.conf.idx\": -46.2,\n",
+    "    \"euribor3m\": 1.313,\n",
+    "    \"nr.employed\": 5099.1,\n",
+    "    \"previously_contacted\": 0,\n",
+    "}\n",
+    "\n",
+    "input_dict = {name: tf.convert_to_tensor([value]) for name, value in sample.items()}\n",
+    "predictions = inference_model.predict(input_dict)\n",
+    "\n",
+    "print(\n",
+    "    f\"This particular client has a {100 * predictions[0][0]:.2f}% probability \"\n",
+    "    \"of subscribing a term deposit, as evaluated by our model.\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "None",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "feature_space_advanced",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/structured_data/md/feature_space_advanced.md
+++ b/examples/structured_data/md/feature_space_advanced.md
@@ -1,0 +1,973 @@
+# FeatureSpace avanced use cases
+
+**Author:** [Dimitre Oliveira](https://www.linkedin.com/in/dimitre-oliveira-7a1a0113a/)<br>
+**Date created:** 2023/07/01<br>
+**Last modified:** 2023/07/01<br>
+**Description:** How to use FeatureSpace for advanced preprocessing use cases.
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/structured_data/ipynb/feature_space_advanced.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/structured_data/feature_space_advanced.py)
+
+
+
+---
+## Introduction
+
+This example is an extension of the
+[Structured data classification with FeatureSpace](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)
+code example, and here we will extend it to cover more complex use
+cases of the [`keras.utils.FeatureSpace`](https://keras.io/api/utils/feature_space/)
+preprocessing utility, like feature hashing, feature crosses, handling missing values and
+integrating [Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/)
+with FeatureSpace.
+
+The general task still is structured data classification (also known as tabular data
+classification) using a data that includes numerical features, integer categorical
+features, and string categorical features.
+
+### The dataset
+
+[Our dataset](https://archive.ics.uci.edu/dataset/222/bank+marketing) is provided by a
+Portuguese banking institution.
+It's a CSV file with 4119 rows. Each row contains information about marketing campaigns
+based on phone calls, and each column describes an attribute of the client. We use the
+features to predict whether the client subscribed ('yes') or not ('no') to the product
+(bank term deposit).
+
+Here's the description of each feature:
+
+Column| Description| Feature Type
+------|------------|-------------
+Age | Age of the client | Numerical
+Job | Type of job | Categorical
+Marital | Marital status | Categorical
+Education | Education level of the client | Categorical
+Default | Has credit in default? | Categorical
+Housing | Has housing loan? | Categorical
+Loan | Has personal loan? | Categorical
+Contact | Contact communication type | Categorical
+Month | Last contact month of year | Categorical
+Day_of_week | Last contact day of the week | Categorical
+Duration | Last contact duration, in seconds | Numerical
+Campaign | Number of contacts performed during this campaign and for this client | Numerical
+Pdays | Number of days that passed by after the client was last contacted from a previous campaign | Numerical
+Previous | Number of contacts performed before this campaign and for this client | Numerical
+Poutcome | Outcome of the previous marketing campaign | Categorical
+Emp.var.rate | Employment variation rate | Numerical
+Cons.price.idx | Consumer price index | Numerical
+Cons.conf.idx | Consumer confidence index | Numerical
+Euribor3m | Euribor 3 month rate | Numerical
+Nr.employed | Number of employees | Numerical
+Y | Has the client subscribed a term deposit? | Target
+
+**Important note regarding the feature `duration`**:  this attribute highly affects the
+output target (e.g., if duration=0 then y='no'). Yet, the duration is not known before a
+call is performed. Also, after the end of the call y is obviously known. Thus, this input
+should only be included for benchmark purposes and should be discarded if the intention
+is to have a realistic predictive model. For this reason we will drop it.
+
+---
+## Setup
+
+
+```python
+import pandas as pd
+import tensorflow as tf
+from pathlib import Path
+from zipfile import ZipFile
+from tensorflow.keras.utils import FeatureSpace
+```
+
+---
+## Load the data
+
+Let's download the data and load it into a Pandas dataframe:
+
+
+```python
+data_url = "https://archive.ics.uci.edu/static/public/222/bank+marketing.zip"
+data_zipped_path = tf.keras.utils.get_file("bank_marketing.zip", data_url, extract=True)
+keras_datasets_path = Path(data_zipped_path).parents[0]
+with ZipFile(f"{keras_datasets_path}/bank-additional.zip", "r") as zip:
+    # Extract files
+    zip.extractall(path=keras_datasets_path)
+
+dataframe = pd.read_csv(
+    f"{keras_datasets_path}/bank-additional/bank-additional.csv", sep=";"
+)
+```
+
+<div class="k-default-codeblock">
+```
+Downloading data from https://archive.ics.uci.edu/static/public/222/bank+marketing.zip
+   8192/Unknown - 0s 0us/step
+
+```
+</div>
+We will create a new feature `previously_contacted` to be able to demonstrate some useful
+preprocessing techniques, this feature is based on `pdays`. According to the dataset
+information if `pdays = 999` it means that the client was not previously contacted, so
+let's create a feature to capture that.
+
+
+```python
+# Droping `duration` to avoid target leak
+dataframe.drop("duration", axis=1, inplace=True)
+# Creating the new feature `previously_contacted`
+dataframe["previously_contacted"] = dataframe["pdays"].map(
+    lambda x: 0 if x == 999 else 1
+)
+```
+
+The dataset includes 4119 samples with 21 columns per sample (20 features, plus the
+target label), here's a preview of a few samples:
+
+
+```python
+print(f"Dataframe shape: {dataframe.shape}")
+display(dataframe.head())
+```
+
+<div class="k-default-codeblock">
+```
+Dataframe shape: (4119, 21)
+
+```
+</div>
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+<div class="k-default-codeblock">
+```
+.dataframe tbody tr th {
+    vertical-align: top;
+}
+
+.dataframe thead th {
+    text-align: right;
+}
+```
+</div>
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>age</th>
+      <th>job</th>
+      <th>marital</th>
+      <th>education</th>
+      <th>default</th>
+      <th>housing</th>
+      <th>loan</th>
+      <th>contact</th>
+      <th>month</th>
+      <th>day_of_week</th>
+      <th>...</th>
+      <th>pdays</th>
+      <th>previous</th>
+      <th>poutcome</th>
+      <th>emp.var.rate</th>
+      <th>cons.price.idx</th>
+      <th>cons.conf.idx</th>
+      <th>euribor3m</th>
+      <th>nr.employed</th>
+      <th>y</th>
+      <th>previously_contacted</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>30</td>
+      <td>blue-collar</td>
+      <td>married</td>
+      <td>basic.9y</td>
+      <td>no</td>
+      <td>yes</td>
+      <td>no</td>
+      <td>cellular</td>
+      <td>may</td>
+      <td>fri</td>
+      <td>...</td>
+      <td>999</td>
+      <td>0</td>
+      <td>nonexistent</td>
+      <td>-1.8</td>
+      <td>92.893</td>
+      <td>-46.2</td>
+      <td>1.313</td>
+      <td>5099.1</td>
+      <td>no</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>39</td>
+      <td>services</td>
+      <td>single</td>
+      <td>high.school</td>
+      <td>no</td>
+      <td>no</td>
+      <td>no</td>
+      <td>telephone</td>
+      <td>may</td>
+      <td>fri</td>
+      <td>...</td>
+      <td>999</td>
+      <td>0</td>
+      <td>nonexistent</td>
+      <td>1.1</td>
+      <td>93.994</td>
+      <td>-36.4</td>
+      <td>4.855</td>
+      <td>5191.0</td>
+      <td>no</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>25</td>
+      <td>services</td>
+      <td>married</td>
+      <td>high.school</td>
+      <td>no</td>
+      <td>yes</td>
+      <td>no</td>
+      <td>telephone</td>
+      <td>jun</td>
+      <td>wed</td>
+      <td>...</td>
+      <td>999</td>
+      <td>0</td>
+      <td>nonexistent</td>
+      <td>1.4</td>
+      <td>94.465</td>
+      <td>-41.8</td>
+      <td>4.962</td>
+      <td>5228.1</td>
+      <td>no</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>38</td>
+      <td>services</td>
+      <td>married</td>
+      <td>basic.9y</td>
+      <td>no</td>
+      <td>unknown</td>
+      <td>unknown</td>
+      <td>telephone</td>
+      <td>jun</td>
+      <td>fri</td>
+      <td>...</td>
+      <td>999</td>
+      <td>0</td>
+      <td>nonexistent</td>
+      <td>1.4</td>
+      <td>94.465</td>
+      <td>-41.8</td>
+      <td>4.959</td>
+      <td>5228.1</td>
+      <td>no</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>47</td>
+      <td>admin.</td>
+      <td>married</td>
+      <td>university.degree</td>
+      <td>no</td>
+      <td>yes</td>
+      <td>no</td>
+      <td>cellular</td>
+      <td>nov</td>
+      <td>mon</td>
+      <td>...</td>
+      <td>999</td>
+      <td>0</td>
+      <td>nonexistent</td>
+      <td>-0.1</td>
+      <td>93.200</td>
+      <td>-42.0</td>
+      <td>4.191</td>
+      <td>5195.8</td>
+      <td>no</td>
+      <td>0</td>
+    </tr>
+  </tbody>
+</table>
+<p>5 rows × 21 columns</p>
+</div>
+
+
+The column, "y", indicates whether the client has subscribed a term deposit or not.
+
+---
+## Train/validation split
+
+Let's split the data into a training and validation set:
+
+
+```python
+valid_dataframe = dataframe.sample(frac=0.2, random_state=0)
+train_dataframe = dataframe.drop(valid_dataframe.index)
+
+print(
+    f"Using {len(train_dataframe)} samples for training and "
+    f"{len(valid_dataframe)} for validation"
+)
+```
+
+<div class="k-default-codeblock">
+```
+Using 3295 samples for training and 824 for validation
+
+```
+</div>
+---
+## Generating TF datasets
+
+Let's generate
+[`tf.data.Dataset`](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) objects
+for each dataframe, since our target column `y` is a string we also need to encode it as
+an integer to be able to train our model with it. To achieve this we will create a
+`StringLookup` layer that will map the strings "no" and "yes" into "0" and "1"
+respectively.
+
+
+```python
+label_lookup = tf.keras.layers.StringLookup(
+    # the order here is important since the first index will be encoded as 0
+    vocabulary=["no", "yes"],
+    num_oov_indices=0,
+)
+
+
+def encode_label(x, y):
+    encoded_y = label_lookup(y)
+    return x, encoded_y
+
+
+def dataframe_to_dataset(dataframe):
+    dataframe = dataframe.copy()
+    labels = dataframe.pop("y")
+    ds = tf.data.Dataset.from_tensor_slices((dict(dataframe), labels))
+    ds = ds.map(encode_label, num_parallel_calls=tf.data.AUTOTUNE)
+    ds = ds.shuffle(buffer_size=len(dataframe))
+    return ds
+
+
+train_ds = dataframe_to_dataset(train_dataframe)
+valid_ds = dataframe_to_dataset(valid_dataframe)
+```
+
+<div class="k-default-codeblock">
+```
+/Users/dimitreoliveira/Desktop/keras-io/.venvs/dev/lib/python3.11/site-packages/numpy/core/numeric.py:2463: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
+  return bool(asarray(a1 == a2).all())
+
+```
+</div>
+Each `Dataset` yields a tuple `(input, target)` where `input` is a dictionary of features
+and `target` is the value `0` or `1`:
+
+
+```python
+for x, y in dataframe_to_dataset(train_dataframe).take(1):
+    print(f"Input: {x}")
+    print(f"Target: {y}")
+```
+
+<div class="k-default-codeblock">
+```
+Input: {'age': <tf.Tensor: shape=(), dtype=int64, numpy=57>, 'job': <tf.Tensor: shape=(), dtype=string, numpy=b'housemaid'>, 'marital': <tf.Tensor: shape=(), dtype=string, numpy=b'married'>, 'education': <tf.Tensor: shape=(), dtype=string, numpy=b'basic.4y'>, 'default': <tf.Tensor: shape=(), dtype=string, numpy=b'no'>, 'housing': <tf.Tensor: shape=(), dtype=string, numpy=b'yes'>, 'loan': <tf.Tensor: shape=(), dtype=string, numpy=b'no'>, 'contact': <tf.Tensor: shape=(), dtype=string, numpy=b'telephone'>, 'month': <tf.Tensor: shape=(), dtype=string, numpy=b'jul'>, 'day_of_week': <tf.Tensor: shape=(), dtype=string, numpy=b'thu'>, 'campaign': <tf.Tensor: shape=(), dtype=int64, numpy=3>, 'pdays': <tf.Tensor: shape=(), dtype=int64, numpy=999>, 'previous': <tf.Tensor: shape=(), dtype=int64, numpy=0>, 'poutcome': <tf.Tensor: shape=(), dtype=string, numpy=b'nonexistent'>, 'emp.var.rate': <tf.Tensor: shape=(), dtype=float64, numpy=1.4>, 'cons.price.idx': <tf.Tensor: shape=(), dtype=float64, numpy=93.918>, 'cons.conf.idx': <tf.Tensor: shape=(), dtype=float64, numpy=-42.7>, 'euribor3m': <tf.Tensor: shape=(), dtype=float64, numpy=4.966>, 'nr.employed': <tf.Tensor: shape=(), dtype=float64, numpy=5228.1>, 'previously_contacted': <tf.Tensor: shape=(), dtype=int64, numpy=0>}
+Target: 0
+
+```
+</div>
+---
+## Preprocessing
+
+Usually our data is not on the proper or best format for modeling, this is why most of
+the time we need to do some kind of preprocessing on the features to make them compatible
+with the model or to extract the most of them for the task. We need to do this
+preprocessing step for training but but at inference we also need to make sure that the
+data goes through the same process, this where a utility like `FeatureSpace` shines, we
+can define all the preprocessing once and re-use it at different stages of our system.
+
+Here we will see how to use `FeatureSpace` to perform more complex transformations and
+its flexibility, then combine everything together into a single component to preprocess
+data for our model.
+
+The `FeatureSpace` utility learns how to process the data by using the `adapt()` function
+to learn from it, this requires a dataset containing only feature, so let's create it
+together with a utility function to show the preprocessing example in practice:
+
+
+```python
+train_ds_with_no_labels = train_ds.map(lambda x, _: x)
+
+
+def example_feature_space(dataset, feature_space, feature_names):
+    feature_space.adapt(dataset)
+    for x in dataset.take(1):
+        inputs = {feature_name: x[feature_name] for feature_name in feature_names}
+        preprocessed_x = feature_space(inputs)
+        print(f"Input: {[{k:v.numpy()} for k, v in inputs.items()]}")
+        print(
+            f"Preprocessed output: {[{k:v.numpy()} for k, v in preprocessed_x.items()]}"
+        )
+
+```
+
+### Feature hashing
+
+**Feature hashing** means hashing or encoding a set of values into a defined number of
+bins, in this case we have `campaign` (number of contacts performed during this campaign
+and for a client) which is a numerical feature that can assume a varying range of values
+and we will hash it into 4 bins, this means that any possible value of the original
+feature will be placed into one of those possible 4 bins. The output here can be a
+one-hot encoded vector or a single number.
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        "campaign": FeatureSpace.integer_hashed(num_bins=4, output_mode="one_hot")
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["campaign"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'campaign': 1}]
+Preprocessed output: [{'campaign': array([0., 1., 0., 0.], dtype=float32)}]
+
+```
+</div>
+**Feature hashing** can also be used for string features.
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        "education": FeatureSpace.string_hashed(num_bins=3, output_mode="one_hot")
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["education"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'education': b'high.school'}]
+Preprocessed output: [{'education': array([1., 0., 0.], dtype=float32)}]
+
+```
+</div>
+For numerical features we can get a similar behavior by using the `float_discretized`
+option, the main difference between this and `integer_hashed` is that with the former we
+bin the values while keeping some numerical relationship (close values will likely be
+placed at the same bin) while the later (hashing) we cannot guarantee that those numbers
+will be hashed into the same bin, it depends on the hashing function.
+
+
+```python
+feature_space = FeatureSpace(
+    features={"age": FeatureSpace.float_discretized(num_bins=3, output_mode="one_hot")},
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["age"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'age': 36}]
+Preprocessed output: [{'age': array([0., 1., 0.], dtype=float32)}]
+
+```
+</div>
+### Feature indexing
+
+**Indexing** a string feature essentially means creating a discrete numerical
+representation for it, this is especially important for string features since most models
+only accept numerical features. This transformation will place the string values into
+different categories. The output here can be a one-hot encoded vector or a single number.
+
+Note that by specifying `num_oov_indices=1` we leave one spot at our output vector for
+OOV (out of vocabulary) values this is an important tool to handle missing or unseen
+values after the training (values that were not seen during the `adapt()` step)
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        "default": FeatureSpace.string_categorical(
+            num_oov_indices=1, output_mode="one_hot"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["default"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'default': b'unknown'}]
+Preprocessed output: [{'default': array([0., 0., 1., 0.], dtype=float32)}]
+
+```
+</div>
+We also can do **feature indexing** for integer features, this can be quite important for
+some datasets where categorical features are replaced by numbers, for instance features
+like `sex` or `gender` where values like (`1 and 0`) do not have a numerical relationship
+between them, they are just different categories, this behavior can be perfectly captured
+by this transformation.
+
+On this dataset we can use the feature that we created `previously_contacted`. For this
+case we want to explicitly set `num_oov_indices=0`, the reason is that we only expect two
+possible values for the feature, anything else would be either wrong input or an issue
+with the data creation, for this reason we would probably just want the code to throw an
+error so that we can be aware of the issue and fix it.
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        "previously_contacted": FeatureSpace.integer_categorical(
+            num_oov_indices=0, output_mode="one_hot"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["previously_contacted"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'previously_contacted': 0}]
+Preprocessed output: [{'previously_contacted': array([1., 0.], dtype=float32)}]
+
+```
+</div>
+### Feature crosses (mixing features of diverse types)
+
+With **crosses** we can do feature interactions between an arbitrary number of features
+of mixed types as long as they are categorical features, you can think of instead of
+having a feature {'age': 20} and another {'job': 'entrepreneur'} we can have
+{'age_X_job': 20_entrepreneur}, but with `FeatureSpace` and **crosses** we can apply
+specific preprocessing to each individual feature and to the feature cross itself. This
+option can be very powerful for specific use cases, here might be a good option since age
+combined with job can have different meanings for the banking domain.
+
+We will cross `age` and `job` and hash the combination output of them into a vector
+representation of size 8. The output here can be a one-hot encoded vector or a single
+number.
+
+Sometimes the combination of multiple features can result into on a super large feature
+space, think about crossing someone's ZIP code with its last name, the possibilities
+would be in the thousands, that is why the `crossing_dim` parameter is so important it
+limits the output dimension of the cross feature.
+
+Note that the combination of possible values of the 6 bins of `age` and the 12 values of
+`job` would be 72, so by choosing `crossing_dim = 8` we are choosing to constrain the
+output vector.
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        "age": FeatureSpace.integer_hashed(num_bins=6, output_mode="one_hot"),
+        "job": FeatureSpace.string_categorical(
+            num_oov_indices=0, output_mode="one_hot"
+        ),
+    },
+    crosses=[
+        FeatureSpace.cross(
+            feature_names=("age", "job"),
+            crossing_dim=8,
+            output_mode="one_hot",
+        )
+    ],
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["age", "job"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'age': 43}, {'job': b'management'}]
+Preprocessed output: [{'age': array([1., 0., 0., 0., 0., 0.], dtype=float32)}, {'job': array([0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)}, {'age_X_job': array([0., 0., 0., 0., 0., 0., 1., 0.], dtype=float32)}]
+
+```
+</div>
+### FeatureSpace using a Keras preprocessing layer
+
+To be a really flexible and extensible feature we cannot only rely on those pre-defined
+transformation, we must be able to re-use other transformations from the Keras/TensorFlow
+ecosystem and customize our own, this is why `FeatureSpace` is also designed to work with
+[Keras preprocessing layers](https://keras.io/guides/preprocessing_layers/), this way we
+can use sophisticated data transformations provided by the framework, you can even create
+your own custom Keras preprocessing layers and use it in the same way.
+
+Here we are going to use the
+[`tf.keras.layers.TextVectorization`](https://keras.io/api/layers/preprocessing_layers/text/text_vectorization/#textvectorization-class)
+preprocessing layer to create a TF-IDF
+feature from our data. Note that this feature is not a really good use case for TF-IDF,
+this is just for demonstration purposes.
+
+
+```python
+custom_layer = tf.keras.layers.TextVectorization(output_mode="tf_idf")
+
+feature_space = FeatureSpace(
+    features={
+        "education": FeatureSpace.feature(
+            preprocessor=custom_layer, dtype="string", output_mode="float"
+        )
+    },
+    output_mode="dict",
+)
+example_feature_space(train_ds_with_no_labels, feature_space, ["education"])
+```
+
+<div class="k-default-codeblock">
+```
+Input: [{'education': b'high.school'}]
+Preprocessed output: [{'education': array([0.       , 0.       , 1.6840783, 0.       , 0.       , 0.       ,
+       0.       , 0.       , 0.       ], dtype=float32)}]
+
+```
+</div>
+---
+## Configuring the final `FeatureSpace`
+
+Now that we know how to use `FeatureSpace` for more complex use cases let's pick the ones
+that looks more useful for this task and create the final `FeatureSpace` component.
+
+To configure how each feature should be preprocessed,
+we instantiate a `keras.utils.FeatureSpace`, and we
+pass to it a dictionary that maps the name of our features
+to the feature transformation function.
+
+
+```python
+feature_space = FeatureSpace(
+    features={
+        # Categorical features encoded as integers
+        "previously_contacted": FeatureSpace.integer_categorical(num_oov_indices=0),
+        # Categorical features encoded as string
+        "marital": FeatureSpace.string_categorical(num_oov_indices=0),
+        "education": FeatureSpace.string_categorical(num_oov_indices=0),
+        "default": FeatureSpace.string_categorical(num_oov_indices=0),
+        "housing": FeatureSpace.string_categorical(num_oov_indices=0),
+        "loan": FeatureSpace.string_categorical(num_oov_indices=0),
+        "contact": FeatureSpace.string_categorical(num_oov_indices=0),
+        "month": FeatureSpace.string_categorical(num_oov_indices=0),
+        "day_of_week": FeatureSpace.string_categorical(num_oov_indices=0),
+        "poutcome": FeatureSpace.string_categorical(num_oov_indices=0),
+        # Categorical features to hash and bin
+        "job": FeatureSpace.string_hashed(num_bins=3),
+        # Numerical features to hash and bin
+        "pdays": FeatureSpace.integer_hashed(num_bins=4),
+        # Numerical features to normalize and bin
+        "age": FeatureSpace.float_discretized(num_bins=4),
+        # Numerical features to normalize
+        "campaign": FeatureSpace.float_normalized(),
+        "previous": FeatureSpace.float_normalized(),
+        "emp.var.rate": FeatureSpace.float_normalized(),
+        "cons.price.idx": FeatureSpace.float_normalized(),
+        "cons.conf.idx": FeatureSpace.float_normalized(),
+        "euribor3m": FeatureSpace.float_normalized(),
+        "nr.employed": FeatureSpace.float_normalized(),
+    },
+    # Specify feature cross with a custom crossing dim.
+    crosses=[
+        FeatureSpace.cross(feature_names=("age", "job"), crossing_dim=8),
+        FeatureSpace.cross(
+            feature_names=("default", "housing", "loan"), crossing_dim=6
+        ),
+        FeatureSpace.cross(
+            feature_names=("poutcome", "previously_contacted"), crossing_dim=2
+        ),
+    ],
+    output_mode="concat",
+)
+```
+
+---
+## Adapt the `FeatureSpace` to the training data
+
+Before we start using the `FeatureSpace` to build a model, we have
+to adapt it to the training data. During `adapt()`, the `FeatureSpace` will:
+
+- Index the set of possible values for categorical features.
+- Compute the mean and variance for numerical features to normalize.
+- Compute the value boundaries for the different bins for numerical features to
+discretize.
+- Any other kind of preprocessing required by custom layers.
+
+Note that `adapt()` should be called on a `tf.data.Dataset` which yields dicts
+of feature values -- no labels.
+
+But first let's batch the datasets
+
+
+```python
+train_ds = train_ds.batch(32)
+valid_ds = valid_ds.batch(32)
+
+train_ds_with_no_labels = train_ds.map(lambda x, _: x)
+feature_space.adapt(train_ds_with_no_labels)
+```
+
+At this point, the `FeatureSpace` can be called on a dict of raw feature values, and
+because we set `output_mode="concat"` it will return a single concatenate vector for each
+sample, combining encoded features and feature crosses.
+
+
+```python
+for x, _ in train_ds.take(1):
+    preprocessed_x = feature_space(x)
+    print(f"preprocessed_x shape: {preprocessed_x.shape}")
+    print(f"preprocessed_x sample: \n{preprocessed_x[0]}")
+```
+
+<div class="k-default-codeblock">
+```
+preprocessed_x shape: (32, 77)
+preprocessed_x sample: 
+[ 0.          0.          1.          0.         -0.58789116 -0.47766402
+  0.59354883  1.          0.          1.          0.          0.
+  0.          0.          1.          0.          0.          0.
+  0.          0.          1.          0.          0.          0.
+  0.          0.8486566   0.77920455  1.          0.          0.
+  0.          1.          0.          0.          1.          0.
+  1.          0.          0.          0.          0.          1.
+  0.          0.          0.          0.          0.          0.
+  0.          0.          0.84002995  0.          0.          1.
+  0.          1.          0.          0.         -0.35691866  1.
+  0.          0.          0.          0.          0.          1.
+  0.          0.          0.          0.          1.          0.
+  0.          0.          0.          1.          0.        ]
+
+```
+</div>
+---
+## Saving the `FeatureSpace`
+
+At this point we can choose to save our `FeatureSpace` component, this have many
+advantages like re-using it on different experiments that use the same model, saving time
+if you need to re-run the preprocessing step, and mainly for model deployment, where by
+loading it you can be sure that you will be applying the same preprocessing steps don't
+matter the device or environment, this is a great way to reduce
+[training/servingskew](https://developers.google.com/machine-learning/guides/rules-of-ml#training-serving_skew).
+
+
+```python
+feature_space.save("myfeaturespace.keras")
+```
+
+---
+## Preprocessing with `FeatureSpace` as part of the tf.data pipeline
+
+We will opt to use our component asynchronously by making it part of the tf.data
+pipeline, as noted at the
+[previous guide](https://keras.io/examples/structured_data/structured_data_classification_with_feature_space/)
+This enables asynchronous parallel preprocessing of the data on CPU before it
+hits the model. Usually, this is always the right thing to do during training.
+
+Let's create a training and validation dataset of preprocessed batches:
+
+
+```python
+preprocessed_train_ds = train_ds.map(
+    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE
+).prefetch(tf.data.AUTOTUNE)
+
+preprocessed_valid_ds = valid_ds.map(
+    lambda x, y: (feature_space(x), y), num_parallel_calls=tf.data.AUTOTUNE
+).prefetch(tf.data.AUTOTUNE)
+```
+
+---
+## Model
+
+We will take advantage of our `FeatureSpace` component to build the model, as we want the
+model to be compatible with our preprocessing function, let's use the the `FeatureSpace`
+feature map as the input of our model.
+
+
+```python
+encoded_features = feature_space.get_encoded_features()
+print(encoded_features)
+```
+
+<div class="k-default-codeblock">
+```
+KerasTensor(type_spec=TensorSpec(shape=(None, 77), dtype=tf.float32, name=None), name='concatenate/concat:0', description="created by layer 'concatenate'")
+
+```
+</div>
+This model is quite trivial only for demonstration purposes so don't pay too much
+attention to the architecture.
+
+
+```python
+x = tf.keras.layers.Dense(64, activation="relu")(encoded_features)
+x = tf.keras.layers.Dropout(0.5)(x)
+output = tf.keras.layers.Dense(1, activation="sigmoid")(x)
+
+model = tf.keras.Model(inputs=encoded_features, outputs=output)
+model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+```
+
+---
+## Training
+
+Let's train our model for 20 epochs. Note that feature preprocessing is happening as part
+of the tf.data pipeline, not as part of the model.
+
+
+```python
+model.fit(
+    preprocessed_train_ds, validation_data=preprocessed_valid_ds, epochs=20, verbose=2
+)
+```
+
+<div class="k-default-codeblock">
+```
+Epoch 1/20
+103/103 - 2s - loss: 0.3399 - accuracy: 0.8777 - val_loss: 0.2653 - val_accuracy: 0.9114 - 2s/epoch - 23ms/step
+Epoch 2/20
+103/103 - 1s - loss: 0.3077 - accuracy: 0.8953 - val_loss: 0.2650 - val_accuracy: 0.9114 - 848ms/epoch - 8ms/step
+Epoch 3/20
+103/103 - 1s - loss: 0.3001 - accuracy: 0.8956 - val_loss: 0.2638 - val_accuracy: 0.9114 - 852ms/epoch - 8ms/step
+Epoch 4/20
+103/103 - 1s - loss: 0.2942 - accuracy: 0.8950 - val_loss: 0.2679 - val_accuracy: 0.9029 - 842ms/epoch - 8ms/step
+Epoch 5/20
+103/103 - 1s - loss: 0.2897 - accuracy: 0.8995 - val_loss: 0.2649 - val_accuracy: 0.9078 - 845ms/epoch - 8ms/step
+Epoch 6/20
+103/103 - 1s - loss: 0.2893 - accuracy: 0.8992 - val_loss: 0.2648 - val_accuracy: 0.9078 - 844ms/epoch - 8ms/step
+Epoch 7/20
+103/103 - 1s - loss: 0.2869 - accuracy: 0.8980 - val_loss: 0.2649 - val_accuracy: 0.9090 - 836ms/epoch - 8ms/step
+Epoch 8/20
+103/103 - 1s - loss: 0.2892 - accuracy: 0.8953 - val_loss: 0.2647 - val_accuracy: 0.9066 - 832ms/epoch - 8ms/step
+Epoch 9/20
+103/103 - 1s - loss: 0.2856 - accuracy: 0.9011 - val_loss: 0.2641 - val_accuracy: 0.9102 - 831ms/epoch - 8ms/step
+Epoch 10/20
+103/103 - 1s - loss: 0.2810 - accuracy: 0.8998 - val_loss: 0.2647 - val_accuracy: 0.9090 - 840ms/epoch - 8ms/step
+Epoch 11/20
+103/103 - 1s - loss: 0.2841 - accuracy: 0.8980 - val_loss: 0.2659 - val_accuracy: 0.9041 - 830ms/epoch - 8ms/step
+Epoch 12/20
+103/103 - 1s - loss: 0.2828 - accuracy: 0.8983 - val_loss: 0.2652 - val_accuracy: 0.9053 - 833ms/epoch - 8ms/step
+Epoch 13/20
+103/103 - 1s - loss: 0.2815 - accuracy: 0.9023 - val_loss: 0.2639 - val_accuracy: 0.9126 - 834ms/epoch - 8ms/step
+Epoch 14/20
+103/103 - 1s - loss: 0.2830 - accuracy: 0.8953 - val_loss: 0.2659 - val_accuracy: 0.9053 - 835ms/epoch - 8ms/step
+Epoch 15/20
+103/103 - 1s - loss: 0.2848 - accuracy: 0.8977 - val_loss: 0.2637 - val_accuracy: 0.9090 - 831ms/epoch - 8ms/step
+Epoch 16/20
+103/103 - 1s - loss: 0.2764 - accuracy: 0.8986 - val_loss: 0.2653 - val_accuracy: 0.9053 - 829ms/epoch - 8ms/step
+Epoch 17/20
+103/103 - 1s - loss: 0.2813 - accuracy: 0.8995 - val_loss: 0.2635 - val_accuracy: 0.9078 - 826ms/epoch - 8ms/step
+Epoch 18/20
+103/103 - 1s - loss: 0.2790 - accuracy: 0.9023 - val_loss: 0.2677 - val_accuracy: 0.9017 - 831ms/epoch - 8ms/step
+Epoch 19/20
+103/103 - 1s - loss: 0.2820 - accuracy: 0.8968 - val_loss: 0.2644 - val_accuracy: 0.9066 - 835ms/epoch - 8ms/step
+Epoch 20/20
+103/103 - 1s - loss: 0.2812 - accuracy: 0.9002 - val_loss: 0.2661 - val_accuracy: 0.9029 - 898ms/epoch - 9ms/step
+
+<keras.callbacks.History at 0x2d2ff5090>
+
+```
+</div>
+---
+## Inference on new data with the end-to-end model
+
+Now, we can build our inference model (which includes the `FeatureSpace`) to make
+predictions based on dicts of raw features values, as follows:
+
+### Loading the `FeatureSpace`
+
+First let's load the `FeatureSpace` that we saved a few moment ago, this can be quite
+handy if you train a model but want to do inference at different time, possibly using a
+different device or environment.
+
+
+```python
+loaded_feature_space = tf.keras.models.load_model("myfeaturespace.keras")
+```
+
+<div class="k-default-codeblock">
+```
+/Users/dimitreoliveira/Desktop/keras-io/.venvs/dev/lib/python3.11/site-packages/numpy/core/numeric.py:2463: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
+  return bool(asarray(a1 == a2).all())
+
+```
+</div>
+### Building the inference end-to-end model
+
+To build the inference model we need both the feature input map and the preprocessing
+encoded Keras tensors.
+
+
+```python
+dict_inputs = loaded_feature_space.get_inputs()
+encoded_features = loaded_feature_space.get_encoded_features()
+print(encoded_features)
+
+print(dict_inputs)
+
+outputs = model(encoded_features)
+inference_model = tf.keras.Model(inputs=dict_inputs, outputs=outputs)
+
+sample = {
+    "age": 30,
+    "job": "blue-collar",
+    "marital": "married",
+    "education": "basic.9y",
+    "default": "no",
+    "housing": "yes",
+    "loan": "no",
+    "contact": "cellular",
+    "month": "may",
+    "day_of_week": "fri",
+    "campaign": 2,
+    "pdays": 999,
+    "previous": 0,
+    "poutcome": "nonexistent",
+    "emp.var.rate": -1.8,
+    "cons.price.idx": 92.893,
+    "cons.conf.idx": -46.2,
+    "euribor3m": 1.313,
+    "nr.employed": 5099.1,
+    "previously_contacted": 0,
+}
+
+input_dict = {name: tf.convert_to_tensor([value]) for name, value in sample.items()}
+predictions = inference_model.predict(input_dict)
+
+print(
+    f"This particular client has a {100 * predictions[0][0]:.2f}% probability "
+    "of subscribing a term deposit, as evaluated by our model."
+)
+```
+
+<div class="k-default-codeblock">
+```
+KerasTensor(type_spec=TensorSpec(shape=(None, 77), dtype=tf.float32, name=None), name='concatenate_1/concat:0', description="created by layer 'concatenate_1'")
+{'previously_contacted': <KerasTensor: shape=(None, 1) dtype=int64 (created by layer 'previously_contacted')>, 'marital': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'marital')>, 'education': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'education')>, 'default': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'default')>, 'housing': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'housing')>, 'loan': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'loan')>, 'contact': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'contact')>, 'month': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'month')>, 'day_of_week': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'day_of_week')>, 'poutcome': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'poutcome')>, 'job': <KerasTensor: shape=(None, 1) dtype=string (created by layer 'job')>, 'pdays': <KerasTensor: shape=(None, 1) dtype=int64 (created by layer 'pdays')>, 'age': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'age')>, 'campaign': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'campaign')>, 'previous': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'previous')>, 'emp.var.rate': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'emp.var.rate')>, 'cons.price.idx': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'cons.price.idx')>, 'cons.conf.idx': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'cons.conf.idx')>, 'euribor3m': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'euribor3m')>, 'nr.employed': <KerasTensor: shape=(None, 1) dtype=float32 (created by layer 'nr.employed')>}
+1/1 [==============================] - 1s 568ms/step
+This particular client has a 8.59% probability of subscribing a term deposit, as evaluated by our model.
+
+```
+</div>


### PR DESCRIPTION
This PR adds a code example titled "FeatureSpace advanced use cases".
This work is part of the "Keras Community Sprint 2023" work that I am collaborating with @fchollet , the topic was his suggestion and I built the code, let me know if it is looking good, or if I need to change something here.
If you prefer there is also a [Colab version of this code](https://colab.research.google.com/drive/1RQL3asuAGPNFZ7JwUKHtu9eq3dG7h6lq?usp=sharing)
A few notes:
 - I used the same dataset as the previous guide, I don't think that this is the best one to showcase the complex use cases of FeatureSpace, but I did not like the other options a lot either.
- For Francois, you suggested that the guide should also cover handling missing values, did you mean using `num_oov_indices=1` to cover unseen values or actually handle missing/null values during the `adapt()` method, I could not find examples on the second approach.

During the development of this work I create [this Issue](https://github.com/keras-team/keras/issues/18246) to point to a possible bug with the saving/loading of the `FeatureSpace` component, and I also create [this issue](https://github.com/keras-team/keras/issues/18254) to suggest improvements to use the feature with specific layers.