### PR TITLE
Update model.to_json() method in serialization_and_saving.py

### DIFF
--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -304,7 +304,7 @@ information).
 
 - `keras.models.clone_model`
 - `get_config()` and `from_config()`
-- `keras.models.model_to_json()` and `keras.models.model_from_json()`
+- `keras.model.to_json()` and `keras.models.model_from_json()`
 """
 
 """


### PR DESCRIPTION
The given api `tf.keras.models.model_to_json()` api is not available and not working as well. I have replcaed this with `model.to_json()` working method of `tf.keras.model` api. Please find the replicated [gist](https://colab.sandbox.google.com/gist/RenuPatelGoogle/8d7fcf558a1f6276a6243619929f801b/model-to_json.ipynb) for your reference.