### PR TITLE
Remove extra activation layer in image_classification_from_scratch.py

### DIFF
--- a/examples/vision/image_classification_from_scratch.py
+++ b/examples/vision/image_classification_from_scratch.py
@@ -235,11 +235,11 @@ def make_model(input_shape, num_classes):
     x = layers.Rescaling(1.0 / 255)(inputs)
     x = layers.Conv2D(128, 3, strides=2, padding="same")(x)
     x = layers.BatchNormalization()(x)
-    x = layers.Activation("relu")(x)
 
     previous_block_activation = x  # Set aside residual
 
     for size in [256, 512, 728]:
+        x = layers.Activation("relu")(x)
         x = layers.SeparableConv2D(size, 3, padding="same")(x)
         x = layers.BatchNormalization()(x)
 

--- a/examples/vision/image_classification_from_scratch.py
+++ b/examples/vision/image_classification_from_scratch.py
@@ -240,7 +240,6 @@ def make_model(input_shape, num_classes):
     previous_block_activation = x  # Set aside residual
 
     for size in [256, 512, 728]:
-        x = layers.Activation("relu")(x)
         x = layers.SeparableConv2D(size, 3, padding="same")(x)
         x = layers.BatchNormalization()(x)
 

--- a/examples/vision/ipynb/image_classification_from_scratch.ipynb
+++ b/examples/vision/ipynb/image_classification_from_scratch.ipynb
@@ -400,7 +400,6 @@
     "    x = layers.Rescaling(1.0 / 255)(inputs)\n",
     "    x = layers.Conv2D(128, 3, strides=2, padding=\"same\")(x)\n",
     "    x = layers.BatchNormalization()(x)\n",
-    "    x = layers.Activation(\"relu\")(x)\n",
     "\n",
     "    previous_block_activation = x  # Set aside residual\n",
     "\n",

--- a/examples/vision/md/image_classification_from_scratch.md
+++ b/examples/vision/md/image_classification_from_scratch.md
@@ -292,7 +292,6 @@ def make_model(input_shape, num_classes):
     x = layers.Rescaling(1.0 / 255)(inputs)
     x = layers.Conv2D(128, 3, strides=2, padding="same")(x)
     x = layers.BatchNormalization()(x)
-    x = layers.Activation("relu")(x)
 
     previous_block_activation = x  # Set aside residual
 


### PR DESCRIPTION
The `image_classification_from_scratch.py` tutorial has one extra `relu activation layer` which is being applied on the layer that already gone through relu activation which makes one code of line redundant. Though it may not affect output it unnecessarily creates confusion for the users and also consumes some resources if used for training.Hence I am proposing to remove the unwanted line of code.

Fixes #1119 