### PR TITLE
Remove `src/` from source path in keras docstrings

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -142,7 +142,7 @@ def make_source_link(cls, project_url):
             f"current imported package version {module_version}"
         )
     path = cls.__module__.replace(".", "/")
-    if base_module == "keras_nlp":
+    if base_module in {"keras_nlp", "keras"}:
         path = path.replace("src/", "")
     line = inspect.getsourcelines(cls)[-1]
     return (


### PR DESCRIPTION
Currently, all `[source]` links incorrectly contain `src/` resulting in the wrong links.

This fixes that issue.