### PR TITLE
Increase number of operations

### DIFF
--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -11,8 +11,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Awaiting response issues
-        uses: actions/stale@v5
+        uses: actions/stale@v7
         with:
+          #Limit the No. of API calls in one run default value is 30.
+          operations-per-run: 500
           days-before-issue-stale: 14
           days-before-issue-close: 14
           stale-issue-label: "stale"
@@ -30,8 +32,10 @@ jobs:
           close-pr-message: "This PR was closed because it has been inactive for 28 days. Please reopen if you'd like to work on this further."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Contribution issues
-        uses: actions/stale@v5
+        uses: actions/stale@v7
         with:
+          #Limit the No. of API calls in one run default value is 30.
+          operations-per-run: 500
           days-before-issue-stale: 180
           days-before-issue-close: 365
           stale-issue-label: "stale"


### PR DESCRIPTION
Increased the number of operations per run from default 30 value to 500. With 30 operations it is not going through all the issues and PR.