### PR TITLE
remove unused variable in deep_neural_decision_forests.py

### DIFF
--- a/examples/structured_data/deep_neural_decision_forests.py
+++ b/examples/structured_data/deep_neural_decision_forests.py
@@ -348,7 +348,6 @@ Finally, let's set up the code that will train and evaluate the model.
 learning_rate = 0.01
 batch_size = 265
 num_epochs = 10
-hidden_units = [64, 64]
 
 
 def run_experiment(model):

--- a/examples/structured_data/ipynb/deep_neural_decision_forests.ipynb
+++ b/examples/structured_data/ipynb/deep_neural_decision_forests.ipynb
@@ -508,7 +508,6 @@
     "learning_rate = 0.01\n",
     "batch_size = 265\n",
     "num_epochs = 10\n",
-    "hidden_units = [64, 64]\n",
     "\n",
     "\n",
     "def run_experiment(model):\n",

--- a/examples/structured_data/md/deep_neural_decision_forests.md
+++ b/examples/structured_data/md/deep_neural_decision_forests.md
@@ -376,7 +376,6 @@ Finally, let's set up the code that will train and evaluate the model.
 learning_rate = 0.01
 batch_size = 265
 num_epochs = 10
-hidden_units = [64, 64]
 
 
 def run_experiment(model):


### PR DESCRIPTION
In this file, `hidden_units = [64, 64]` initiated but not used anywhere. It's better to remove this line to avoid unwanted confusions for users.

Also Fixes #536 . 