### PR TITLE
Fixed the broken link in understanding_masking_and_padding.ipynb

### DIFF
--- a/guides/ipynb/understanding_masking_and_padding.ipynb
+++ b/guides/ipynb/understanding_masking_and_padding.ipynb
@@ -418,7 +418,7 @@
    },
    "source": [
     "Note: For more details about format limitations related to masking, see the\n",
-    "[serialization guide](/guides/serialization_and_saving)."
+    "[serialization guide](https://keras.io/guides/serialization_and_saving/)."
    ]
   },
   {


### PR DESCRIPTION
Fixed the broken link of  **serialization** in `understanding_masking_and_padding.ipynb`