### PR TITLE
Changes to support multiple residual blocks for learnable_resizer

### DIFF
--- a/examples/vision/learnable_resizer.py
+++ b/examples/vision/learnable_resizer.py
@@ -132,7 +132,7 @@ def res_block(x):
     x = conv_block(x, 16, 3, 1, activation=None)
     return layers.Add()([inputs, x])
 
-
+#Note: user can change num_res_blocks to >1 also if needed
 def get_learnable_resizer(filters=16, num_res_blocks=1, interpolation=INTERPOLATION):
     inputs = layers.Input(shape=[None, None, 3])
 
@@ -152,8 +152,11 @@ def get_learnable_resizer(filters=16, num_res_blocks=1, interpolation=INTERPOLAT
     bottleneck = layers.Resizing(*TARGET_SIZE, interpolation=interpolation)(x)
 
     # Residual passes.
-    for _ in range(num_res_blocks):
-        x = res_block(bottleneck)
+    #first res_block will get bottleneck output as input
+    x = res_block(bottleneck)
+    #remaining res_blocks will get first res_block output as input
+    for _ in range(num_res_blocks-1):
+        x = res_block(x)
 
     # Projection.
     x = layers.Conv2D(

--- a/examples/vision/learnable_resizer.py
+++ b/examples/vision/learnable_resizer.py
@@ -154,7 +154,7 @@ def get_learnable_resizer(filters=16, num_res_blocks=1, interpolation=INTERPOLAT
     # Residual passes.
     #first res_block will get bottleneck output as input
     x = res_block(bottleneck)
-    #remaining res_blocks will get first res_block output as input
+    #remaining res_blocks will get previous res_block output as input
     for _ in range(num_res_blocks-1):
         x = res_block(x)
 


### PR DESCRIPTION

In the current implementation of learnable_resizer author used no of residual blocks=1 and accordingly code was implemented.

Consider the code below at line no.155

for _ in range(num_res_blocks):
        x = res_block(bottleneck)
Author used num_res_blocks=1 for this example but he intends to extend support to num_res_blocks>1 also hence considered for loop otherwise the above code can be replaced by just x = res_block(bottleneck).

However as per the Architecture the each res_block should get input from its previous res_block. But with current implementation each res_block is getting bottle_neck layer output as input which breaks the implementation if num_res_blocks>1.

Hence I proposed the changes and added notes so that user can able to change the num_res_blocks to >1 also and able to get correct output as expected which lacks in current implementation.

The issue was highlighted in issue https://github.com/keras-team/keras-io/issues/1328 by the issue author.

The proposed changes will make learnable_resizer more generalized.

Thanks!