### PR TITLE
Fix API doc generation when version number contains a "v"

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -132,7 +132,7 @@ def make_source_link(cls, project_url):
     base_module = cls.__module__.split(".")[0]
     project_url = project_url[base_module]
     assert project_url.endswith("/"), f"{base_module} not found"
-    project_url_version = project_url.split("/")[-2].replace("v", "")
+    project_url_version = project_url.split("/")[-2].removeprefix("v")
     module_version = importlib.import_module(base_module).__version__
     if module_version != project_url_version:
         raise RuntimeError(


### PR DESCRIPTION
Silly bug, we would string all "v" characters from a github version tag when matching it against a library version, instead of stripping the first "v".

This makes our rendering scripts blow up when run against a "dev" release.