### PR TITLE
Update custom_object documentation and __init__() arg serialization_and_saving.py

### DIFF
--- a/guides/serialization_and_saving.py
+++ b/guides/serialization_and_saving.py
@@ -133,8 +133,8 @@ When saving a model that includes custom objects, such as a subclassed Layer,
 you **must** define a `get_config()` method on the object class.
 If the arguments passed to the constructor (`__init__()` method) of the custom object
 aren't Python objects (anything other than base types like ints, strings,
-etc.), then you **must** also explicitly deserialize these arguments in the `from_config()`
-class method.
+etc.), then you **must** serialize these arguments in `get_config()` method and
+also explicitly deserialize these arguments in the `from_config()` class method.
 
 Like this:
 
@@ -142,7 +142,7 @@ Like this:
 class CustomLayer(keras.layers.Layer):
     def __init__(self, sublayer, **kwargs):
         super().__init__(**kwargs)
-        self.sublayer = layer
+        self.sublayer = sublayer
 
     def call(self, x):
         return self.sublayer(x)


### PR DESCRIPTION
In the example of a `CustomLayer` class its `__init__` method passed argument `sublayer` whereas while assigning to self it is using the variable `layer` instead of `sublayer`. Hence corrected the same.

Also please check the documentation below.

> If the arguments passed to the constructor (`__init__()` method) of the custom object aren't Python objects (anything other than base types like ints, strings, etc.), then you **must** also explicitly deserialize these arguments in the `from_config()` class method.

Actually we need to also add the statement like you must explicitly serialize the `non_python arguments` in `get_config()` method also so that it can be deserialized in `from_config()` method. As it is explicitly mentioned for `from_config()` it should be explicitly mentioned for `get_config()` also which is missing now.

This makes users well aware of this. Because without serializing `non_python` object in `get_config()` , it is not possible to reload that back into model.