### PR TITLE
Added missing .self to unit_2 in "Custom cell that supports nested input/output"

### DIFF
--- a/guides/ipynb/working_with_rnns.ipynb
+++ b/guides/ipynb/working_with_rnns.ipynb
@@ -759,7 +759,7 @@
     "        return output, new_states\n",
     "\n",
     "    def get_config(self):\n",
-    "        return {\"unit_1\": self.unit_1, \"unit_2\": unit_2, \"unit_3\": self.unit_3}\n",
+    "        return {\"unit_1\": self.unit_1, \"unit_2\": self.unit_2, \"unit_3\": self.unit_3}\n",
     ""
    ]
   },

--- a/guides/ipynb/working_with_rnns.ipynb
+++ b/guides/ipynb/working_with_rnns.ipynb
@@ -717,7 +717,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "@keras.saving.register_keras_serializable()\n",
+    "@keras.utils.register_keras_serializable()\n",
     "class NestedCell(keras.layers.Layer):\n",
     "    def __init__(self, unit_1, unit_2, unit_3, **kwargs):\n",
     "        self.unit_1 = unit_1\n",

--- a/guides/ipynb/working_with_rnns.ipynb
+++ b/guides/ipynb/working_with_rnns.ipynb
@@ -717,7 +717,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "@keras.utils.register_keras_serializable()\n",
+    "@keras.saving.register_keras_serializable()\n",
     "class NestedCell(keras.layers.Layer):\n",
     "    def __init__(self, unit_1, unit_2, unit_3, **kwargs):\n",
     "        self.unit_1 = unit_1\n",

--- a/guides/md/working_with_rnns.md
+++ b/guides/md/working_with_rnns.md
@@ -655,7 +655,7 @@ class NestedCell(keras.layers.Layer):
         return output, new_states
 
     def get_config(self):
-        return {"unit_1": self.unit_1, "unit_2": unit_2, "unit_3": self.unit_3}
+        return {"unit_1": self.unit_1, "unit_2": self.unit_2, "unit_3": self.unit_3}
 
 ```
 

--- a/guides/md/working_with_rnns.md
+++ b/guides/md/working_with_rnns.md
@@ -613,7 +613,7 @@ for details on writing your own layers.
 
 ```python
 
-@keras.saving.register_keras_serializable()
+@keras.utils.register_keras_serializable()
 class NestedCell(keras.layers.Layer):
     def __init__(self, unit_1, unit_2, unit_3, **kwargs):
         self.unit_1 = unit_1

--- a/guides/md/working_with_rnns.md
+++ b/guides/md/working_with_rnns.md
@@ -613,7 +613,7 @@ for details on writing your own layers.
 
 ```python
 
-@keras.utils.register_keras_serializable()
+@keras.saving.register_keras_serializable()
 class NestedCell(keras.layers.Layer):
     def __init__(self, unit_1, unit_2, unit_3, **kwargs):
         self.unit_1 = unit_1

--- a/guides/working_with_rnns.py
+++ b/guides/working_with_rnns.py
@@ -490,7 +490,7 @@ for details on writing your own layers.
 """
 
 
-@keras.utils.register_keras_serializable()
+@keras.saving.register_keras_serializable()
 class NestedCell(keras.layers.Layer):
     def __init__(self, unit_1, unit_2, unit_3, **kwargs):
         self.unit_1 = unit_1

--- a/guides/working_with_rnns.py
+++ b/guides/working_with_rnns.py
@@ -490,7 +490,7 @@ for details on writing your own layers.
 """
 
 
-@keras.saving.register_keras_serializable()
+@keras.utils.register_keras_serializable()
 class NestedCell(keras.layers.Layer):
     def __init__(self, unit_1, unit_2, unit_3, **kwargs):
         self.unit_1 = unit_1

--- a/guides/working_with_rnns.py
+++ b/guides/working_with_rnns.py
@@ -532,7 +532,7 @@ class NestedCell(keras.layers.Layer):
         return output, new_states
 
     def get_config(self):
-        return {"unit_1": self.unit_1, "unit_2": unit_2, "unit_3": self.unit_3}
+        return {"unit_1": self.unit_1, "unit_2": self.unit_2, "unit_3": self.unit_3}
 
 
 """


### PR DESCRIPTION
A quick fix for a "typo" that I found in: [Define a custom cell that supports nested input/output](https://www.tensorflow.org/guide/keras/working_with_rnns#define_a_custom_cell_that_supports_nested_inputoutput).

I think there is a `self.` missing for `unit_2` in `return {"unit_1": self.unit_1, "unit_2": unit_2, "unit_3": self.unit_3}`