### PR TITLE
Display test image

### DIFF
--- a/examples/vision/image_classification_from_scratch.py
+++ b/examples/vision/image_classification_from_scratch.py
@@ -330,6 +330,8 @@ Note that data augmentation and dropout are inactive at inference time.
 """
 
 img = keras.utils.load_img("PetImages/Cat/6779.jpg", target_size=image_size)
+plt.imshow(img)
+
 img_array = keras.utils.img_to_array(img)
 img_array = tf.expand_dims(img_array, 0)  # Create batch axis
 

--- a/examples/vision/ipynb/image_classification_from_scratch.ipynb
+++ b/examples/vision/ipynb/image_classification_from_scratch.ipynb
@@ -510,6 +510,8 @@
     "img = keras.utils.load_img(\n",
     "    \"PetImages/Cat/6779.jpg\", target_size=image_size\n",
     ")\n",
+    "plt.imshow(img)\n",
+    "\n",
     "img_array = keras.utils.img_to_array(img)\n",
     "img_array = tf.expand_dims(img_array, 0)  # Create batch axis\n",
     "\n",

--- a/examples/vision/md/image_classification_from_scratch.md
+++ b/examples/vision/md/image_classification_from_scratch.md
@@ -428,6 +428,8 @@ We get to >90% validation accuracy after training for 25 epochs on the full data
 img = keras.utils.load_img(
     "PetImages/Cat/6779.jpg", target_size=image_size
 )
+plt.imshow(img)
+
 img_array = keras.utils.img_to_array(img)
 img_array = tf.expand_dims(img_array, 0)  # Create batch axis
 


### PR DESCRIPTION
Adding a line to display the test image used for prediction. The reason is to provide a better understanding of how the predictions are linked with image being tested.

Original PRs - #1091 , #1075 