### PR TITLE
Fix broken link and typos in functional_api.py

### DIFF
--- a/guides/functional_api.py
+++ b/guides/functional_api.py
@@ -186,8 +186,7 @@ del model
 model = keras.models.load_model("path_to_my_model.keras")
 
 """
-For details, read the model [serialization & saving](
-    /guides/serialization_and_saving/) guide.
+For details, read the model [serialization & saving](/guides/serialization_and_saving/) guide.
 """
 
 """
@@ -813,7 +812,7 @@ Where `inputs` is a tensor or a nested structure of tensors (e.g. a list of tens
 and where `**kwargs` are non-tensor arguments (non-inputs).
 - `call(self, inputs, training=None, **kwargs)` --
 Where `training` is a boolean indicating whether the layer should behave
-in training mode and inference mode.
+in training mode or inference mode.
 - `call(self, inputs, mask=None, **kwargs)` --
 Where `mask` is a boolean mask tensor (useful for RNNs, for instance).
 - `call(self, inputs, training=None, mask=None, **kwargs)` --


### PR DESCRIPTION
In the functional_api guide the link for serialization & saving at lin no.189 is not working due to formatting issues.The link has been introduced with new space like below. 

```
For details, read the model [serialization & saving](
    /guides/serialization_and_saving/) guide.
```

Same link at line no 816 works fine which is mentioned below.

`See the [serialization & saving guide (/guides/serialization_and_saving/)`

I believe the formatting(White spaces) in first case causing the link to fail.I think there is no need to mention complete URL here as it is auto generated which needs correct formatting.Correct me if I am wrong.



Also corrected **typo** in line no 816.

```
Where `training` is a boolean indicating whether the layer should behave
in training mode and inference mode.
```
 
to 

```
Where `training` is a boolean indicating whether the layer should behave
in training mode or inference mode.
```
