### PR TITLE
Update keras-core version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas
 jupyter
 tensorflow~=2.13.0
 tensorflow_datasets
-keras-core==0.1.3
+keras-core==0.1.5
 keras-tuner==1.3.5
 keras-cv==0.6.1
 keras-nlp==0.6.1


### PR DESCRIPTION
Updated keras-core version which is blocking docker build process of CI activity.

![image](https://github.com/keras-team/keras-io/assets/73069040/ad2973ce-009c-427f-ada0-70a237aa5f93)
