### PR TITLE
Correct typo mistake in neural_machine_translation_with_transformer.py

### DIFF
--- a/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
+++ b/examples/nlp/ipynb/neural_machine_translation_with_transformer.ipynb
@@ -257,7 +257,7 @@
     "As such, the training dataset will yield a tuple `(inputs, targets)`, where:\n",
     "\n",
     "- `inputs` is a dictionary with the keys `encoder_inputs` and `decoder_inputs`.\n",
-    "`encoder_inputs` is the vectorized source sentence and `encoder_inputs` is the target sentence \"so far\",\n",
+    "`encoder_inputs` is the vectorized source sentence and `decoder_inputs` is the target sentence \"so far\",\n",
     "that is to say, the words 0 to N used to predict word N+1 (and beyond) in the target sentence.\n",
     "- `target` is the target sentence offset by one step:\n",
     "it provides the next words in the target sentence -- what the model will try to predict."

--- a/examples/nlp/md/neural_machine_translation_with_transformer.md
+++ b/examples/nlp/md/neural_machine_translation_with_transformer.md
@@ -186,7 +186,7 @@ using the source sentence and the target words 0 to N.
 As such, the training dataset will yield a tuple `(inputs, targets)`, where:
 
 - `inputs` is a dictionary with the keys `encoder_inputs` and `decoder_inputs`.
-`encoder_inputs` is the vectorized source sentence and `encoder_inputs` is the target sentence "so far",
+`encoder_inputs` is the vectorized source sentence and `decoder_inputs` is the target sentence "so far",
 that is to say, the words 0 to N used to predict word N+1 (and beyond) in the target sentence.
 - `target` is the target sentence offset by one step:
 it provides the next words in the target sentence -- what the model will try to predict.

--- a/examples/nlp/neural_machine_translation_with_transformer.py
+++ b/examples/nlp/neural_machine_translation_with_transformer.py
@@ -154,7 +154,7 @@ using the source sentence and the target words 0 to N.
 As such, the training dataset will yield a tuple `(inputs, targets)`, where:
 
 - `inputs` is a dictionary with the keys `encoder_inputs` and `decoder_inputs`.
-`encoder_inputs` is the vectorized source sentence and `encoder_inputs` is the target sentence "so far",
+`encoder_inputs` is the vectorized source sentence and `decoder_inputs` is the target sentence "so far",
 that is to say, the words 0 to N used to predict word N+1 (and beyond) in the target sentence.
 - `target` is the target sentence offset by one step:
 it provides the next words in the target sentence -- what the model will try to predict.


### PR DESCRIPTION
At Line No.157 in neural_machine_translation_with_transformer.py, it was mentioned: 

> `encoder_inputs` is the vectorized source sentence and `encoder_inputs` is the target sentence "so far",

Actually `the target sentence "so far" `, should be `decoder_inputs`  instead of `encoder_inputs`

Corrected the same.

Shall fix #1002 