### PR TITLE
Fix deprecated parameter `lr`

### DIFF
--- a/examples/nlp/text_extraction_with_bert.py
+++ b/examples/nlp/text_extraction_with_bert.py
@@ -245,7 +245,7 @@ def create_model():
         outputs=[start_probs, end_probs],
     )
     loss = keras.losses.SparseCategoricalCrossentropy(from_logits=False)
-    optimizer = keras.optimizers.Adam(lr=5e-5)
+    optimizer = keras.optimizers.Adam(learning_rate=5e-5)
     model.compile(optimizer=optimizer, loss=[loss, loss])
     return model
 


### PR DESCRIPTION
if you use `lr`, model fails to learn
https://github.com/keras-team/keras-io/issues/1441

This is error message.
WARNING:absl:`lr` is deprecated in Keras optimizer, please use `learning_rate` or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.Adam.

