### PR TITLE
Fix deprecated parameter `lr`

### DIFF
--- a/examples/nlp/ipynb/text_extraction_with_bert.ipynb
+++ b/examples/nlp/ipynb/text_extraction_with_bert.ipynb
@@ -331,7 +331,7 @@
     "        outputs=[start_probs, end_probs],\n",
     "    )\n",
     "    loss = keras.losses.SparseCategoricalCrossentropy(from_logits=False)\n",
-    "    optimizer = keras.optimizers.Adam(lr=5e-5)\n",
+    "    optimizer = keras.optimizers.Adam(learning_rate=5e-5)\n",
     "    model.compile(optimizer=optimizer, loss=[loss, loss])\n",
     "    return model\n",
     "\n"

--- a/examples/nlp/md/text_extraction_with_bert.md
+++ b/examples/nlp/md/text_extraction_with_bert.md
@@ -275,7 +275,7 @@ def create_model():
         outputs=[start_probs, end_probs],
     )
     loss = keras.losses.SparseCategoricalCrossentropy(from_logits=False)
-    optimizer = keras.optimizers.Adam(lr=5e-5)
+    optimizer = keras.optimizers.Adam(learning_rate=5e-5)
     model.compile(optimizer=optimizer, loss=[loss, loss])
     return model
 

--- a/examples/nlp/text_extraction_with_bert.py
+++ b/examples/nlp/text_extraction_with_bert.py
@@ -245,7 +245,7 @@ def create_model():
         outputs=[start_probs, end_probs],
     )
     loss = keras.losses.SparseCategoricalCrossentropy(from_logits=False)
-    optimizer = keras.optimizers.Adam(lr=5e-5)
+    optimizer = keras.optimizers.Adam(learning_rate=5e-5)
     model.compile(optimizer=optimizer, loss=[loss, loss])
     return model
 


### PR DESCRIPTION
if you use lr, model fails to learn
https://github.com/keras-team/keras-io/issues/1441

This is error message.
WARNING:absl:lr is deprecated in Keras optimizer, please use learning_rate or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.Adam.