### PR TITLE
Update import statement in mobilevit tutorial for TF>=2.13v

### DIFF
--- a/examples/vision/ipynb/mobilevit.ipynb
+++ b/examples/vision/ipynb/mobilevit.ipynb
@@ -34,7 +34,8 @@
     "MobileViT as a general-purpose mobile-friendly backbone for different image recognition\n",
     "tasks. Their findings suggest that, performance-wise, MobileViT is better than other\n",
     "models with the same or higher complexity ([MobileNetV3](https://arxiv.org/abs/1905.02244),\n",
-    "for example), while being efficient on mobile devices."
+    "for example), while being efficient on mobile devices.\n",
+    "Note: This example should be run with Tensorflow 2.13 and higher."
    ]
   },
   {
@@ -56,7 +57,9 @@
    "source": [
     "import tensorflow as tf\n",
     "\n",
-    "from keras.applications import imagenet_utils\n",
+    "from keras.src.applications import imagenet_utils\n",
+    "# For versions <TF2.13 change the above import to:\n",
+    "# from keras.applications import imagenet_utils\n",
     "from tensorflow.keras import layers\n",
     "from tensorflow import keras\n",
     "\n",

--- a/examples/vision/ipynb/mobilevit.ipynb
+++ b/examples/vision/ipynb/mobilevit.ipynb
@@ -35,6 +35,7 @@
     "tasks. Their findings suggest that, performance-wise, MobileViT is better than other\n",
     "models with the same or higher complexity ([MobileNetV3](https://arxiv.org/abs/1905.02244),\n",
     "for example), while being efficient on mobile devices.\n",
+    "\n",
     "Note: This example should be run with Tensorflow 2.13 and higher."
    ]
   },

--- a/examples/vision/md/mobilevit.md
+++ b/examples/vision/md/mobilevit.md
@@ -27,6 +27,8 @@ tasks. Their findings suggest that, performance-wise, MobileViT is better than o
 models with the same or higher complexity ([MobileNetV3](https://arxiv.org/abs/1905.02244),
 for example), while being efficient on mobile devices.
 
+Note: This example should be run with Tensorflow 2.13 and higher.
+
 ---
 ## Imports
 
@@ -34,7 +36,10 @@ for example), while being efficient on mobile devices.
 ```python
 import tensorflow as tf
 
-from keras.applications import imagenet_utils
+from keras.src.applications import imagenet_utils
+# For versions <TF2.13 change the above import to:
+# from keras.applications import imagenet_utils
+
 from tensorflow.keras import layers
 from tensorflow import keras
 

--- a/examples/vision/mobilevit.py
+++ b/examples/vision/mobilevit.py
@@ -22,6 +22,8 @@ MobileViT as a general-purpose mobile-friendly backbone for different image reco
 tasks. Their findings suggest that, performance-wise, MobileViT is better than other
 models with the same or higher complexity ([MobileNetV3](https://arxiv.org/abs/1905.02244),
 for example), while being efficient on mobile devices.
+
+Note: This example should be run with Tensorflow 2.13 and higher.
 """
 
 """
@@ -30,7 +32,9 @@ for example), while being efficient on mobile devices.
 
 import tensorflow as tf
 
-from keras.applications import imagenet_utils
+from keras.src.applications import imagenet_utils
+#For veriosns <TF2.13 change the above import to:
+#from keras.applications import imagenet_utils
 from tensorflow.keras import layers
 from tensorflow import keras
 

--- a/examples/vision/mobilevit.py
+++ b/examples/vision/mobilevit.py
@@ -33,8 +33,9 @@ Note: This example should be run with Tensorflow 2.13 and higher.
 import tensorflow as tf
 
 from keras.src.applications import imagenet_utils
-#For versions <TF2.13 change the above import to:
-#from keras.applications import imagenet_utils
+
+# For versions <TF2.13 change the above import to:
+# from keras.applications import imagenet_utils
 from tensorflow.keras import layers
 from tensorflow import keras
 

--- a/examples/vision/mobilevit.py
+++ b/examples/vision/mobilevit.py
@@ -33,7 +33,7 @@ Note: This example should be run with Tensorflow 2.13 and higher.
 import tensorflow as tf
 
 from keras.src.applications import imagenet_utils
-#For veriosns <TF2.13 change the above import to:
+#For versions <TF2.13 change the above import to:
 #from keras.applications import imagenet_utils
 from tensorflow.keras import layers
 from tensorflow import keras


### PR DESCRIPTION
The mobile vit tutorial will break due to import statement which was changed from Tf2.13V onwards.This works fine upto Tf2.12 versions.

Hence I changed the import statement to make it work for Tf2.13 and higher versions. Also added a note regarding this to make users aware of how to change the import for TF<=2.12 versions.

Also attached gist for same. Refer [gist-2.13vS](https://colab.sandbox.google.com/gist/SuryanarayanaY/bae80ee6e340f279637c2fe64fe6e49e/mobilevit-kerasio-1530_fixed-tf2-13v.ipynb) that is executed fine with the above change and [gist-2.13vF](https://colab.sandbox.google.com/gist/SuryanarayanaY/359a68752c4bd5d9b7c919ff67560ad1/mobilevit-kerasio-1530.ipynb) that failed without the proposed change.

Fixes #1530 