### PR TITLE
Fix import error

### DIFF
--- a/examples/generative/finetune_stable_diffusion.py
+++ b/examples/generative/finetune_stable_diffusion.py
@@ -33,8 +33,9 @@ at least TensorFlow 2.11 in order to use AdamW with mixed precision.
 """
 
 """shell
-pip install keras-cv==0.4.0 -q
+pip install keras-cv==0.6.0 -q
 pip install -U tensorflow -q
+pip install keras-core -q
 """
 
 """
@@ -375,7 +376,7 @@ USE_MP = True
 if USE_MP:
     keras.mixed_precision.set_global_policy("mixed_float16")
 
-image_encoder = ImageEncoder(RESOLUTION, RESOLUTION)
+image_encoder = ImageEncoder()
 diffusion_ft_trainer = Trainer(
     diffusion_model=DiffusionModel(RESOLUTION, RESOLUTION, MAX_PROMPT_LENGTH),
     # Remove the top layer from the encoder, which cuts off the variance and only

--- a/examples/generative/ipynb/finetune_stable_diffusion.ipynb
+++ b/examples/generative/ipynb/finetune_stable_diffusion.ipynb
@@ -53,8 +53,9 @@
    },
    "outputs": [],
    "source": [
-    "!pip install keras-cv==0.4.0 -q\n",
-    "!pip install -U tensorflow -q"
+    "!pip install keras-cv==0.6.0 -q\n",
+    "!pip install -U tensorflow -q\n",
+    "!pip install keras-core -q"
    ]
   },
   {
@@ -513,7 +514,7 @@
     "if USE_MP:\n",
     "    keras.mixed_precision.set_global_policy(\"mixed_float16\")\n",
     "\n",
-    "image_encoder = ImageEncoder(RESOLUTION, RESOLUTION)\n",
+    "image_encoder = ImageEncoder()\n",
     "diffusion_ft_trainer = Trainer(\n",
     "    diffusion_model=DiffusionModel(RESOLUTION, RESOLUTION, MAX_PROMPT_LENGTH),\n",
     "    # Remove the top layer from the encoder, which cuts off the variance and only\n",

--- a/examples/generative/md/finetune_stable_diffusion.md
+++ b/examples/generative/md/finetune_stable_diffusion.md
@@ -37,8 +37,9 @@ at least TensorFlow 2.11 in order to use AdamW with mixed precision.
 
 
 ```python
-!pip install keras-cv==0.4.0 -q
+!pip install keras-cv==0.6.0 -q
 !pip install -U tensorflow -q
+!pip install keras-core -q
 ```
 
 ---
@@ -459,7 +460,7 @@ USE_MP = True
 if USE_MP:
     keras.mixed_precision.set_global_policy("mixed_float16")
 
-image_encoder = ImageEncoder(RESOLUTION, RESOLUTION)
+image_encoder = ImageEncoder()
 diffusion_ft_trainer = Trainer(
     diffusion_model=DiffusionModel(RESOLUTION, RESOLUTION, MAX_PROMPT_LENGTH),
     # Remove the top layer from the encoder, which cuts off the variance and only


### PR DESCRIPTION
Fix import error by upgrading the version of `keras-cv` and add installation internal dependency keras-core.

As per the updated keras-cv, there is no need to provide image input shape in `StableDiffusion` for `ImageEncoder` Ref Commit # https://github.com/keras-team/keras-cv/commit/67efa6152ee0a513d79d25ef68cf2128b26a5e04
Closes: https://github.com/keras-team/keras-io/issues/1555
