### PR TITLE
Update faq.md

### DIFF
--- a/templates/getting_started/faq.md
+++ b/templates/getting_started/faq.md
@@ -52,7 +52,7 @@ In most cases, what you need is most likely data parallelism.
 
 Data parallelism consists in replicating the target model once on each device, and using each replica to process a different fraction of the input data.
 
-The best way to do data parallelism with Keras models is to use the `tf.distribute` API. Make sure to read our [guide about using `tf.distribute` with Keras](/guides/distributed_training/).
+The best way to do data parallelism with Keras models is to use the `tf.distribute` API. Make sure to read our [guide about using `tf.distribute` with Keras](https://github.com/keras-team/keras-io/blob/master/guides/md/distributed_training.md).
 
 The gist of it is the following:
 
@@ -289,7 +289,7 @@ It contains the following fields:
 - The default float data type.
 - The default backend. This is legacy; nowadays there is only TensorFlow.
 
-Likewise, cached dataset files, such as those downloaded with [`get_file()`](/utils/#get_file), are stored by default in `$HOME/.keras/datasets/`,
+Likewise, cached dataset files, such as those downloaded with [`get_file()`](https://github.com/keras-team/keras/blob/v2.14.0/keras/utils/data_utils.py#L193), are stored by default in `$HOME/.keras/datasets/`,
 and cached model weights files from Keras Applications are stored by default in `$HOME/.keras/models/`.
 
 
@@ -617,7 +617,7 @@ except RuntimeError:
             callbacks=[backup_callback])
 ```
 
-Find out more in the [callbacks documentation](/api/callbacks/).
+Find out more in the [callbacks documentation](https://keras.io/guides/writing_your_own_callbacks/).
 
 
 ---
@@ -634,7 +634,7 @@ early_stopping = EarlyStopping(monitor='val_loss', patience=2)
 model.fit(x, y, validation_split=0.2, callbacks=[early_stopping])
 ```
 
-Find out more in the [callbacks documentation](/api/callbacks/).
+Find out more in the [callbacks documentation](https://keras.io/guides/writing_your_own_callbacks/).
 
 ---
 
@@ -859,7 +859,7 @@ However, staring at changing ascii numbers in a console is not an optimal metric
 We recommend the use of [TensorBoard](https://www.tensorflow.org/tensorboard), which will display nice-looking graphs of your training and validation metrics, regularly
 updated during training, which you can access from your browser.
 
-You can use TensorBoard with `fit()` via the [`TensorBoard` callback](/api/callbacks/tensorboard/).
+You can use TensorBoard with `fit()` via the [`TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/).
 
 ---
 

--- a/templates/getting_started/faq.md
+++ b/templates/getting_started/faq.md
@@ -52,7 +52,7 @@ In most cases, what you need is most likely data parallelism.
 
 Data parallelism consists in replicating the target model once on each device, and using each replica to process a different fraction of the input data.
 
-The best way to do data parallelism with Keras models is to use the `tf.distribute` API. Make sure to read our [guide about using `tf.distribute` with Keras](https://github.com/keras-team/keras-io/blob/master/guides/md/distributed_training.md).
+The best way to do data parallelism with Keras models is to use the `tf.distribute` API. Make sure to read our [guide about using `tf.distribute` with Keras](/guides/distributed_training/).
 
 The gist of it is the following:
 
@@ -289,7 +289,7 @@ It contains the following fields:
 - The default float data type.
 - The default backend. This is legacy; nowadays there is only TensorFlow.
 
-Likewise, cached dataset files, such as those downloaded with [`get_file()`](https://github.com/keras-team/keras/blob/v2.14.0/keras/utils/data_utils.py#L193), are stored by default in `$HOME/.keras/datasets/`,
+Likewise, cached dataset files, such as those downloaded with [`get_file()`](/api/utils/python_utils/#get_file-function), are stored by default in `$HOME/.keras/datasets/`,
 and cached model weights files from Keras Applications are stored by default in `$HOME/.keras/models/`.
 
 
@@ -617,7 +617,7 @@ except RuntimeError:
             callbacks=[backup_callback])
 ```
 
-Find out more in the [callbacks documentation](https://keras.io/guides/writing_your_own_callbacks/).
+Find out more in the [callbacks documentation](/api/callbacks/).
 
 
 ---
@@ -634,7 +634,7 @@ early_stopping = EarlyStopping(monitor='val_loss', patience=2)
 model.fit(x, y, validation_split=0.2, callbacks=[early_stopping])
 ```
 
-Find out more in the [callbacks documentation](https://keras.io/guides/writing_your_own_callbacks/).
+Find out more in the [callbacks documentation](/api/callbacks/).
 
 ---
 
@@ -859,7 +859,7 @@ However, staring at changing ascii numbers in a console is not an optimal metric
 We recommend the use of [TensorBoard](https://www.tensorflow.org/tensorboard), which will display nice-looking graphs of your training and validation metrics, regularly
 updated during training, which you can access from your browser.
 
-You can use TensorBoard with `fit()` via the [`TensorBoard` callback](https://keras.io/api/callbacks/tensorboard/).
+You can use TensorBoard with `fit()` via the [`TensorBoard` callback](/api/callbacks/tensorboard/).
 
 ---
 


### PR DESCRIPTION
Fixed broken links on this page : 

https://keras.io/getting_started/faq/

1.  Fixed the broken link in the faq.md file (https://github.com/keras-team/keras-io/blob/master/templates/getting_started/faq.md) guide about using tf.distribute with Keras (correct link : https://github.com/keras-team/keras-io/blob/master/guides/md/distributed_training.md)
2. Fixed the broken link for : “Multi-GPU and distributed training” in the same page . The fixed link is the same as above.
3. Fixed the broken link for get_file() on the same page . The corrected link (https://github.com/keras-team/keras/blob/v2.14.0/keras/utils/data_utils.py#L193) is taken from the Source Code mentioned in the get_file() documentation on Keras website on this page (https://keras.io/api/utils/python_utils/#getfile-function) 
4. Fixed the broken link for Callbacks Documentation on the faq.md page . The corrected link suggested (https://keras.io/guides/writing_your_own_callbacks/) under the following headers : 
 “How can I interrupt training when the validation loss isn't decreasing anymore?”  
and
 “How can I ensure my training run can recover from program interruptions?”