### PR TITLE
Token permissions

### DIFF
--- a/.github/workflows/auto-assignment.yaml
+++ b/.github/workflows/auto-assignment.yaml
@@ -8,12 +8,13 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,6 +2,9 @@ name: Continuous integration
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   black:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-io/issues/1579.

This PR adds read-only permissions to continuous_integration.yml.

It also adds some future-proofing to the other workflows by moving write permissions to job-level instead of top-level, keeping only read-only top-level permissions. This way the added permissions aren't available to other jobs potentially added to the workflows in the future.