### PR TITLE
token_embedding fix depriciation

### DIFF
--- a/guides/ipynb/keras_nlp/transformer_pretraining.ipynb
+++ b/guides/ipynb/keras_nlp/transformer_pretraining.ipynb
@@ -515,7 +515,7 @@
     "# We use the input token embedding to project from our encoded vectors to\n",
     "# vocabulary logits, which has been shown to improve training efficiency.\n",
     "outputs = keras_nlp.layers.MaskedLMHead(\n",
-    "    embedding_weights=embedding_layer.token_embedding.embeddings,\n",
+    "    token_embedding=embedding_layer.token_embedding,\n",
     "    activation=\"softmax\",\n",
     ")(encoded_tokens, mask_positions=inputs[\"mask_positions\"])\n",
     "\n",

--- a/guides/keras_nlp/transformer_pretraining.py
+++ b/guides/keras_nlp/transformer_pretraining.py
@@ -365,7 +365,7 @@ encoded_tokens = encoder_model(inputs["token_ids"])
 # We use the input token embedding to project from our encoded vectors to
 # vocabulary logits, which has been shown to improve training efficiency.
 outputs = keras_nlp.layers.MaskedLMHead(
-    embedding_weights=embedding_layer.token_embedding.embeddings,
+    token_embedding=embedding_layer.token_embedding,
     activation="softmax",
 )(encoded_tokens, mask_positions=inputs["mask_positions"])
 

--- a/guides/md/keras_nlp/transformer_pretraining.md
+++ b/guides/md/keras_nlp/transformer_pretraining.md
@@ -486,7 +486,7 @@ encoded_tokens = encoder_model(inputs["token_ids"])
 # We use the input token embedding to project from our encoded vectors to
 # vocabulary logits, which has been shown to improve training efficiency.
 outputs = keras_nlp.layers.MaskedLMHead(
-    embedding_weights=embedding_layer.token_embedding.embeddings,
+    token_embedding=embedding_layer.token_embedding,
     activation="softmax",
 )(encoded_tokens, mask_positions=inputs["mask_positions"])
 


### PR DESCRIPTION
embedding_weigths is no longer a argument of MaskedLMHead

instead it takes token_embeddings directly

Reference: 
https://keras.io/api/keras_nlp/modeling_layers/masked_lm_head/#:~:text=token_embedding%3A%20Optional.%20A%20keras_nlp.layers.ReversibleEmbedding%20instance.%20If%20passed%2C%20the%20layer%20will%20be%20used%20to%20project%20from%20the%20hidden_dim%20of%20the%20model%20to%20the%20output%20vocabulary_size.