### PR TITLE
Keras 3 ner_transformers

### DIFF
--- a/examples/nlp/ipynb/ner_transformers.ipynb
+++ b/examples/nlp/ipynb/ner_transformers.ipynb
@@ -40,7 +40,9 @@
     "colab_type": "text"
    },
    "source": [
-    "## Install the open source datasets library from HuggingFace"
+    "## Install the open source datasets library from HuggingFace\n",
+    "\n",
+    "We also download the script used to evaluate NER models."
    ]
   },
   {
@@ -64,10 +66,14 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
+    "os.environ[\"KERAS_BACKEND\"] = \"tensorflow\"\n",
+    "\n",
+    "import os\n",
+    "import keras\n",
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "from tensorflow import keras\n",
-    "from tensorflow.keras import layers\n",
+    "from keras import layers\n",
     "from datasets import load_dataset\n",
     "from collections import Counter\n",
     "from conlleval import evaluate"
@@ -328,9 +334,7 @@
     "vocabulary = [token for token, count in counter.most_common(vocab_size - 2)]\n",
     "\n",
     "# The StringLook class will convert tokens to token IDs\n",
-    "lookup_layer = keras.layers.StringLookup(\n",
-    "    vocabulary=vocabulary\n",
-    ")"
+    "lookup_layer = keras.layers.StringLookup(vocabulary=vocabulary)"
    ]
   },
   {
@@ -449,7 +453,7 @@
     "\n",
     "    def call(self, y_true, y_pred):\n",
     "        loss_fn = keras.losses.SparseCategoricalCrossentropy(\n",
-    "            from_logits=True, reduction=keras.losses.Reduction.NONE\n",
+    "            from_logits=False, reduction=None\n",
     "        )\n",
     "        loss = loss_fn(y_true, y_pred)\n",
     "        mask = tf.cast((y_true > 0), dtype=tf.float32)\n",
@@ -526,7 +530,7 @@
     "    all_true_tag_ids, all_predicted_tag_ids = [], []\n",
     "\n",
     "    for x, y in dataset:\n",
-    "        output = ner_model.predict(x)\n",
+    "        output = ner_model.predict(x, verbose=0)\n",
     "        predictions = np.argmax(output, axis=-1)\n",
     "        predictions = np.reshape(predictions, [-1])\n",
     "\n",
@@ -565,8 +569,8 @@
     "get much higher F1 score -between 90-95% on this dataset owing to the inherent knowledge\n",
     "of words as part of the pretraining process and the usage of subword tokenization.\n",
     "\n",
-    "You can use the trained model hosted on [Hugging Face Hub](https://huggingface.co/keras-io/ner-with-transformers) ",
-    "and try the demo on [Hugging Face Spaces](https://huggingface.co/spaces/keras-io/ner_with_transformers)."
+    "You can use the trained model hosted on [Hugging Face Hub](https://huggingface.co/keras-io/ner-with-transformers)\n",
+    "and try the demo on [Hugging Face Spaces](https://huggingface.co/spaces/keras-io/ner_with_transformers).\"\"\""
    ]
   }
  ],

--- a/examples/nlp/ner_transformers.py
+++ b/examples/nlp/ner_transformers.py
@@ -33,10 +33,14 @@ wget https://raw.githubusercontent.com/sighsmile/conlleval/master/conlleval.py
 """
 
 import os
+
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
+import os
+import keras
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 from datasets import load_dataset
 from collections import Counter
 from conlleval import evaluate
@@ -209,7 +213,7 @@ train_data = tf.data.TextLineDataset("./data/conll_train.txt")
 val_data = tf.data.TextLineDataset("./data/conll_val.txt")
 
 """
-Print out one line to make sure it looks good. The first record in the line is the number of tokens. 
+Print out one line to make sure it looks good. The first record in the line is the number of tokens.
 After that we will have all the tokens followed by all the ner tags.
 """
 
@@ -262,7 +266,7 @@ class CustomNonPaddingTokenLoss(keras.losses.Loss):
 
     def call(self, y_true, y_pred):
         loss_fn = keras.losses.SparseCategoricalCrossentropy(
-            from_logits=True, reduction=keras.losses.Reduction.NONE
+            from_logits=False, reduction=None
         )
         loss = loss_fn(y_true, y_pred)
         mask = tf.cast((y_true > 0), dtype=tf.float32)
@@ -311,7 +315,7 @@ def calculate_metrics(dataset):
     all_true_tag_ids, all_predicted_tag_ids = [], []
 
     for x, y in dataset:
-        output = ner_model.predict(x)
+        output = ner_model.predict(x, verbose=0)
         predictions = np.argmax(output, axis=-1)
         predictions = np.reshape(predictions, [-1])
 


### PR DESCRIPTION
Tensorflow only with preprocessing and some modeling ops in tf, but it should not be too hard to port this to multi backend with tf-only preprocessing in the future.

I believe there was a bad bug in this examples, where it computed a loss of softmax outputs with from_logits=True. Fixed.