### PR TITLE
Bump KerasNLP version to 0.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ tensorflow_datasets
 keras-core==0.1.7
 keras-tuner==1.4.5
 keras-cv==0.6.4
-keras-nlp==0.6.2
+keras-nlp==0.6.3
 pycocotools

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -44,7 +44,7 @@ PROJECT_URL = {
     "keras": "https://github.com/keras-team/keras/tree/v2.14.0/",
     "keras_tuner": "https://github.com/keras-team/keras-tuner/tree/v1.4.5/",
     "keras_cv": "https://github.com/keras-team/keras-cv/tree/v0.6.4/",
-    "keras_nlp": "https://github.com/keras-team/keras-nlp/tree/v0.6.2/",
+    "keras_nlp": "https://github.com/keras-team/keras-nlp/tree/v0.6.3/",
     "keras_core": "https://github.com/keras-team/keras-core/tree/v0.1.7/",
 }
 USE_MULTIPROCESSING = False


### PR DESCRIPTION
This doesn't actually change any symbols (it's only for adding Keras 3 support), but still good to track the latest release here.