### PR TITLE
Fixed TypeError by adding tensor data type cast layer

### DIFF
--- a/examples/vision/oxford_pets_image_segmentation.py
+++ b/examples/vision/oxford_pets_image_segmentation.py
@@ -141,6 +141,20 @@ flip, random rotation and RandAugment to the train dataset. Here is
 
 We only apply the resizing operation to the validation dataset
 """
+castf32 =  lambda inputs: {
+    "images": tf.cast(inputs["images"], dtype=tf.float32),
+    "segmentation_masks":  tf.cast(inputs["segmentation_masks"], dtype=tf.float32)
+}
+
+class Cast2f32(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Cast2f32, self).__init__()
+
+    def build(self, inputs):
+        pass
+
+    def call(self, inputs):
+        return castf32(inputs)
 
 resize_fn = keras_cv.layers.Resizing(
     HEIGHT,
@@ -155,6 +169,7 @@ augment_fn = keras.Sequential(
             factor=ROTATION_FACTOR,
             segmentation_classes=NUM_CLASSES,
         ),
+        Cast2f32(),
         keras_cv.layers.RandAugment(
             value_range=(0, 1),
             geometric=False,


### PR DESCRIPTION
In the current version, `keras_cv.layers.RandomRotation` in the `augment_fn` returns the resulting tensor as int64 format and causes type error when `.map(augment_fn, num_parallel_calls=AUTOTUNE)` part in the `augmented_train_ds` runs. In the error message, it complains that the images and segmentation masks have different dtypes as shown below.

>Call arguments received by layer 'rand_augment' (type RandAugment):
  • inputs={'images': 'tf.Tensor(shape=(160, 160, 3), dtype=float32)', 'segmentation_masks': 'tf.Tensor(shape=(160, 160, 1), dtype=int64)'}


As a workaround, I added a function and a keras custom class that casts the output tensor of `keras_cv.layers.RandomRotation` to float32. After the addition I tested it works in colab and local jupyter notebook with keras 2.13 and 2.14.