### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ pandas
 jupyter
 pycocotools
 pydot
-tensorflow~=2.14.0
+tensorflow~=2.15.0
 tensorflow_datasets
 keras-core==0.1.7
 keras-tuner==1.4.5
-keras-cv==0.6.4
+keras-cv==0.7.1
 tf_keras==2.15.0
 keras-nlp==0.6.3

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -46,8 +46,8 @@ KERAS_TEAM_GH = "https://github.com/keras-team"
 PROJECT_URL = {
     "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.0.0/",
     "keras_tuner": f"{KERAS_TEAM_GH}/keras-tuner/tree/v1.4.5/",
-    "keras_cv": f"{KERAS_TEAM_GH}/keras-cv/tree/v0.6.4/",
-    "keras_nlp": f"{KERAS_TEAM_GH}/keras-nlp/tree/v0.6.2/",
+    "keras_cv": f"{KERAS_TEAM_GH}/keras-cv/tree/v0.7.1/",
+    "keras_nlp": f"{KERAS_TEAM_GH}/keras-nlp/tree/v0.6.3/",
     "tf_keras": f"{KERAS_TEAM_GH}/tf-keras/tree/v2.15.0/",
 }
 USE_MULTIPROCESSING = False


### PR DESCRIPTION
This still won't include Keras 3 (because of tf conflict), but includes the correct versions of tensorflow and keras-cv to render everything.

This should work (without GPU support):
pip install -r requirements.txt
pip install -U keras