### PR TITLE
Update Variational AutoEncoder example to support both `tensorflow` and `torch` backends

### DIFF
--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -13,7 +13,7 @@ Accelerator: GPU
 
 import os
 
-os.environ["KERAS_BACKEND"] = "tensorflow"  # @param ["tensorflow", "torch"]
+os.environ["KERAS_BACKEND"] = "tensorflow"  # @param ["tensorflow", "torch", "jax"]
 
 import numpy as np
 import keras

--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -28,11 +28,15 @@ from keras import ops
 class Sampling(layers.Layer):
     """Uses (z_mean, z_log_var) to sample z, the vector encoding a digit."""
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.seed_generator = keras.random.SeedGenerator(1337)
+
     def call(self, inputs):
         z_mean, z_log_var = inputs
         batch = ops.shape(z_mean)[0]
         dim = ops.shape(z_mean)[1]
-        epsilon = keras.random.normal(shape=(batch, dim))
+        epsilon = keras.random.normal(shape=(batch, dim), seed=self.seed_generator)
         return z_mean + ops.exp(0.5 * z_log_var) * epsilon
 
 


### PR DESCRIPTION
Update the example [**Variational AutoEncoder**](https://keras.io/examples/generative/vae/) example to support both `tensorflow` and `torch` backends.

Colab: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1K-v6mcHqTqnETR_edkhXOpDJ1NxK6v5-?usp=sharing)

I also created a [notebook using the JAX backend](https://colab.research.google.com/drive/101543d1uz7GFwg9EsIYvg6ky32vGkUNg?usp=sharing), but couldn't find a clean way to incorporate it into the same example.