### PR TITLE
intro_to_keras_for_engineers.py: Fix broken link

### DIFF
--- a/guides/intro_to_keras_for_engineers.py
+++ b/guides/intro_to_keras_for_engineers.py
@@ -356,7 +356,7 @@ the power and usability of `fit()`? It's easy to customize
 
 - [Customizing what happens in `fit()` with TensorFlow](http://keras.io/guides/custom_train_step_in_tensorflow/)
 - [Customizing what happens in `fit()` with JAX](http://keras.io/guides/custom_train_step_in_jax/)
-- [Customizing what happens in `fit()` with PyTorch](http://keras.io/guides/custom_train_step_in_pytorch/)
+- [Customizing what happens in `fit()` with PyTorch](http://keras.io/guides/custom_train_step_in_torch/)
 
 ## How to write custom training loops
 


### PR DESCRIPTION
Broken Link:
https://keras.io/guides/custom_train_step_in_pytorch/

Corrected Link:
https://keras.io/guides/custom_train_step_in_torch/

---

IMO, the target URL should have been renamed to "_in_pytorch" to be consistent with the official name of the framework.