### PR TITLE
Add `--upgrade`  to keras install

### DIFF
--- a/templates/getting_started/index.md
+++ b/templates/getting_started/index.md
@@ -21,7 +21,7 @@ in computer vision, natural language processing, and generative AI.
 You can install Keras from PyPI via:
 
 ```
-pip install keras
+pip install --upgrade keras
 ```
 
 You can check your local Keras version number via:
@@ -47,8 +47,8 @@ The cause is that `tensorflow==2.15` will overwrite your Keras installation with
 KerasCV and KerasNLP can be installed via pip:
 
 ```
-pip install keras-cv
-pip install keras-nlp
+pip install --upgrade keras-cv
+pip install --upgrade keras-nlp
 ```
 
 Critically, **you should reinstall Keras 3 after installing KerasNLP**.
@@ -73,7 +73,7 @@ As an example, here is how to create a JAX GPU environment with [Conda](https://
 conda create -y -n keras-jax python=3.10
 conda activate keras-jax
 pip install -r requirements-jax-cuda.txt
-pip install keras
+pip install --upgrade keras
 ```
 
 Note that it may not always be possible to use the GPU with multiple backends in the same environment due to conflicting

--- a/templates/keras_cv/index.md
+++ b/templates/keras_cv/index.md
@@ -51,7 +51,7 @@ Keras 2, and will no longer be necessary after TensorFlow 2.16.
 
 ```
 pip install --upgrade keras-cv tensorflow
-pip install keras>=3
+pip install --upgrade keras
 ```
 
 To install the latest changes nightly for KerasCV and Keras, you can use our

--- a/templates/keras_nlp/index.md
+++ b/templates/keras_nlp/index.md
@@ -68,7 +68,7 @@ Keras 2, and will no longer be necessary after TensorFlow 2.16.
 
 ```
 pip install --upgrade keras-nlp
-pip install --upgrade keras>=3
+pip install --upgrade keras
 ```
 
 To install the latest nightly changes for both KerasNLP and Keras, you can use


### PR DESCRIPTION
If the user's env already has keras via tensorflow, `pip install keras` doesn't do anything since its already installed.  So adding `--upgrade`.

Also, `!pip install --upgrade keras>=3` fails in Colab since pip checks for dependencies and shows error - 
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorflow 2.14.0 requires keras<2.15,>=2.14.0, but you have keras 3.0.1 which is incompatible.
```
So, we will have to use `pip install --upgrade keras` if we want to upgrade to version 3.