### PR TITLE
Fix notebooks using Colab TPU

### DIFF
--- a/examples/keras_recipes/ipynb/tfrecord.ipynb
+++ b/examples/keras_recipes/ipynb/tfrecord.ipynb
@@ -159,7 +159,9 @@
     "            \"target\": tf.io.FixedLenFeature([], tf.int64),\n",
     "        }\n",
     "        if labeled\n",
-    "        else {\"image\": tf.io.FixedLenFeature([], tf.string),}\n",
+    "        else {\n",
+    "            \"image\": tf.io.FixedLenFeature([], tf.string),\n",
+    "        }\n",
     "    )\n",
     "    example = tf.io.parse_single_example(example, tfrecord_format)\n",
     "    image = decode_image(example[\"image\"])\n",
@@ -440,7 +442,7 @@
   }
  ],
  "metadata": {
-  "accelerator": "GPU",
+  "accelerator": "TPU",
   "colab": {
    "collapsed_sections": [],
    "name": "tfrecord",

--- a/examples/nlp/ipynb/text_extraction_with_bert.ipynb
+++ b/examples/nlp/ipynb/text_extraction_with_bert.ipynb
@@ -6,7 +6,7 @@
     "colab_type": "text"
    },
    "source": [
-    "# BERT (from HuggingFace Transformers) for Text Extraction\n",
+    "# Text Extraction with BERT\n",
     "\n",
     "**Author:** [Apoorv Nandan](https://twitter.com/NandanApoorv)<br>\n",
     "**Date created:** 2020/05/23<br>\n",
@@ -44,8 +44,8 @@
     "\n",
     "**References:**\n",
     "\n",
-    "- [BERT](https://arxiv.org/pdf/1810.04805.pdf)\n",
-    "- [SQuAD](https://arxiv.org/abs/1606.05250)\n"
+    "- [BERT](https://arxiv.org/abs/1810.04805)\n",
+    "- [SQuAD](https://arxiv.org/abs/1606.05250)"
    ]
   },
   {
@@ -54,7 +54,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Setup\n"
+    "## Setup"
    ]
   },
   {
@@ -77,7 +77,7 @@
     "from transformers import BertTokenizer, TFBertModel, BertConfig\n",
     "\n",
     "max_len = 384\n",
-    "configuration = BertConfig()  # default parameters and configuration for BERT\n"
+    "configuration = BertConfig()  # default parameters and configuration for BERT"
    ]
   },
   {
@@ -86,7 +86,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Set-up BERT tokenizer\n"
+    "## Set-up BERT tokenizer"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "slow_tokenizer.save_pretrained(save_path)\n",
     "\n",
     "# Load the fast tokenizer from saved file\n",
-    "tokenizer = BertWordPieceTokenizer(\"bert_base_uncased/vocab.txt\", lowercase=True)\n"
+    "tokenizer = BertWordPieceTokenizer(\"bert_base_uncased/vocab.txt\", lowercase=True)"
    ]
   },
   {
@@ -114,7 +114,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Load the data\n"
+    "## Load the data"
    ]
   },
   {
@@ -128,7 +128,7 @@
     "train_data_url = \"https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json\"\n",
     "train_path = keras.utils.get_file(\"train.json\", train_data_url)\n",
     "eval_data_url = \"https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json\"\n",
-    "eval_path = keras.utils.get_file(\"eval.json\", eval_data_url)\n"
+    "eval_path = keras.utils.get_file(\"eval.json\", eval_data_url)"
    ]
   },
   {
@@ -140,7 +140,7 @@
     "## Preprocess the data\n",
     "\n",
     "1. Go through the JSON file and store every record as a `SquadExample` object.\n",
-    "2. Go through each `SquadExample` and create `x_train, y_train, x_eval, y_eval`.\n"
+    "2. Go through each `SquadExample` and create `x_train, y_train, x_eval, y_eval`."
    ]
   },
   {
@@ -284,7 +284,7 @@
     "\n",
     "eval_squad_examples = create_squad_examples(raw_eval_data)\n",
     "x_eval, y_eval = create_inputs_targets(eval_squad_examples)\n",
-    "print(f\"{len(eval_squad_examples)} evaluation points created.\")\n"
+    "print(f\"{len(eval_squad_examples)} evaluation points created.\")"
    ]
   },
   {
@@ -293,7 +293,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Create the Question-Answering Model using BERT and Functional API\n"
+    "Create the Question-Answering Model using BERT and Functional API"
    ]
   },
   {
@@ -334,7 +334,7 @@
     "    optimizer = keras.optimizers.Adam(lr=5e-5)\n",
     "    model.compile(optimizer=optimizer, loss=[loss, loss])\n",
     "    return model\n",
-    "\n"
+    ""
    ]
   },
   {
@@ -344,7 +344,7 @@
    },
    "source": [
     "This code should preferably be run on Google Colab TPU runtime.\n",
-    "With Colab TPUs, each epoch will take 5-6 minutes.\n"
+    "With Colab TPUs, each epoch will take 5-6 minutes."
    ]
   },
   {
@@ -367,7 +367,7 @@
     "else:\n",
     "    model = create_model()\n",
     "\n",
-    "model.summary()\n"
+    "model.summary()"
    ]
   },
   {
@@ -379,7 +379,7 @@
     "## Create evaluation Callback\n",
     "\n",
     "This callback will compute the exact match score using the validation data\n",
-    "after every epoch.\n"
+    "after every epoch."
    ]
   },
   {
@@ -445,7 +445,7 @@
     "                count += 1\n",
     "        acc = count / len(self.y_eval[0])\n",
     "        print(f\"\\nepoch={epoch+1}, exact match score={acc:.2f}\")\n",
-    "\n"
+    ""
    ]
   },
   {
@@ -454,7 +454,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Train and Evaluate\n"
+    "## Train and Evaluate"
    ]
   },
   {
@@ -473,12 +473,12 @@
     "    verbose=2,\n",
     "    batch_size=64,\n",
     "    callbacks=[exact_match_callback],\n",
-    ")\n"
+    ")"
    ]
   }
  ],
  "metadata": {
-  "accelerator": "GPU",
+  "accelerator": "TPU",
   "colab": {
    "collapsed_sections": [],
    "name": "text_extraction_with_bert",

--- a/examples/nlp/text_extraction_with_bert.py
+++ b/examples/nlp/text_extraction_with_bert.py
@@ -31,7 +31,7 @@ We fine-tune a BERT model to perform this task as follows:
 
 **References:**
 
-- [BERT](https://arxiv.org/pdf/1810.04805.pdf)
+- [BERT](https://arxiv.org/abs/1810.04805)
 - [SQuAD](https://arxiv.org/abs/1606.05250)
 """
 """

--- a/examples/vision/ipynb/xray_classification_with_tpus.ipynb
+++ b/examples/vision/ipynb/xray_classification_with_tpus.ipynb
@@ -756,7 +756,7 @@
   }
  ],
  "metadata": {
-  "accelerator": "GPU",
+  "accelerator": "TPU",
   "colab": {
    "collapsed_sections": [],
    "name": "xray_classification_with_tpus",


### PR DESCRIPTION
There are 4 notebooks that specify `Accelerator: TPU`, however their IPython metadata still specified `GPU` as the accelerator, so the Colab would open with the incorrect accelerator.

Example at HEAD:
https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/vision/ipynb/xray_classification_with_tpus.ipynb

Validation of fix:
https://colab.research.google.com/github/jeffcarp/keras-io/blob/fix-colab-tpu-metadata/examples/vision/ipynb/xray_classification_with_tpus.ipynb

Fixed by re-exporting the .py files to .ipynb, using command:

```
python3 tutobooks.py py2nb ../examples/keras_recipes/tfrecord.py ../examples/keras_recipes/ipynb/tfrecord.ipynb
```