### PR TITLE
Do not replace double dashes with m-dash.

### DIFF
--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -924,9 +924,6 @@ class KerasIO:
         ]
         title = md_content[2 : md_content.find("\n")]
 
-        # Replace -- with —
-        html_content = html_content.replace("--", "—")
-
         self.render_single_docs_page_from_html(
             target_path,
             title,


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-io/issues/1696

This replacement breaks:
- install commands like `pip install --upgrade keras` which can no longer be copy-pasted
- anchors in pages like https://keras.io/getting_started/#tensorflow--keras-2-backwards-compatibility