### PR TITLE
Transform double dashes to n-dash using the Smarty plugin.

### DIFF
--- a/scripts/autogen_utils.py
+++ b/scripts/autogen_utils.py
@@ -82,10 +82,17 @@ def render_markdown_to_html(md_content):
             "tables",
             "codehilite",
             "mdx_truly_sane_lists",
+            "smarty",
         ],
         extension_configs={
             "codehilite": {
                 "guess_lang": False,
+            },
+            "smarty": {
+                "smart_dashes": True,
+                "smart_quotes": False,
+                "smart_angled_quotes": False,
+                "smart_ellipses": False,
             },
         },
     )


### PR DESCRIPTION
This way code blocks, anchors, etc. are not affected.