### PR TITLE
tiny: Remove unused function arg in DeepLabV3+ example

### DIFF
--- a/examples/vision/deeplabv3_plus.py
+++ b/examples/vision/deeplabv3_plus.py
@@ -2,7 +2,7 @@
 Title: Multiclass semantic segmentation using DeepLabV3+
 Author: [Soumik Rakshit](http://github.com/soumik12345)
 Date created: 2021/08/31
-Last modified: 2023/07/19
+Last modified: 2024/01/05
 Description: Implement DeepLabV3+ architecture for Multi-class Semantic Segmentation.
 Accelerator: GPU
 Converted to Keras 3: [Muhammad Anas Raza](https://anasrz.com)
@@ -134,7 +134,6 @@ def convolution_block(
     num_filters=256,
     kernel_size=3,
     dilation_rate=1,
-    padding="same",
     use_bias=False,
 ):
     x = layers.Conv2D(

--- a/examples/vision/ipynb/deeplabv3_plus.ipynb
+++ b/examples/vision/ipynb/deeplabv3_plus.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Soumik Rakshit](http://github.com/soumik12345)<br>\n",
     "**Date created:** 2021/08/31<br>\n",
-    "**Last modified:** 2023/07/19<br>\n",
+    "**Last modified:** 2024/01/05<br>\n",
     "**Description:** Implement DeepLabV3+ architecture for Multi-class Semantic Segmentation."
    ]
   },
@@ -194,7 +194,6 @@
     "    num_filters=256,\n",
     "    kernel_size=3,\n",
     "    dilation_rate=1,\n",
-    "    padding=\"same\",\n",
     "    use_bias=False,\n",
     "):\n",
     "    x = layers.Conv2D(\n",

--- a/examples/vision/md/deeplabv3_plus.md
+++ b/examples/vision/md/deeplabv3_plus.md
@@ -2,7 +2,7 @@
 
 **Author:** [Soumik Rakshit](http://github.com/soumik12345)<br>
 **Date created:** 2021/08/31<br>
-**Last modified:** 2023/07/19<br>
+**Last modified:** 2024/01/05<br>
 **Description:** Implement DeepLabV3+ architecture for Multi-class Semantic Segmentation.
 
 
@@ -158,7 +158,6 @@ def convolution_block(
     num_filters=256,
     kernel_size=3,
     dilation_rate=1,
-    padding="same",
     use_bias=False,
 ):
     x = layers.Conv2D(


### PR DESCRIPTION
I came across this example and noticed an unused function argument that is not used anywhere. I intend to enhance the readability of the example by removing the argument.