### PR TITLE
Repeat code for the kerasCV image classification guide

### DIFF
--- a/guides/ipynb/keras_cv/classification_with_keras_cv.ipynb
+++ b/guides/ipynb/keras_cv/classification_with_keras_cv.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -83,8 +83,7 @@
     "\n",
     "# Import tensorflow for `tf.data` and its preprocessing functions\n",
     "import tensorflow as tf\n",
-    "import tensorflow_datasets as tfds\n",
-    ""
+    "import tensorflow_datasets as tfds\n"
    ]
   },
   {
@@ -117,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -145,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -170,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -191,14 +190,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
-    "top_classes = predictions[0].argsort(axis=-1)\n",
-    ""
+    "top_classes = predictions[0].argsort(axis=-1)\n"
    ]
   },
   {
@@ -215,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -239,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -280,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -339,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -367,14 +365,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
-    "model.fit(train_dataset)\n",
-    ""
+    "model.fit(train_dataset)\n"
    ]
   },
   {
@@ -388,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -432,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -469,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -534,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -584,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -635,7 +632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -677,7 +674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -716,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -759,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -793,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -814,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -856,17 +853,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
-    "inference_resizing = keras_cv.layers.Resizing(\n",
-    "    IMAGE_SIZE[0], IMAGE_SIZE[1], crop_to_aspect_ratio=True\n",
-    ")\n",
-    "eval_ds = eval_ds.map(inference_resizing, num_parallel_calls=tf.data.AUTOTUNE)\n",
-    "\n",
     "inference_resizing = keras_cv.layers.Resizing(\n",
     "    IMAGE_SIZE[0], IMAGE_SIZE[1], crop_to_aspect_ratio=True\n",
     ")\n",
@@ -894,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -929,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -992,8 +984,7 @@
     "            hold=self.hold,\n",
     "        )\n",
     "\n",
-    "        return ops.where(step > self.total_steps, 0.0, lr)\n",
-    ""
+    "        return ops.where(step > self.total_steps, 0.0, lr)\n"
    ]
   },
   {
@@ -1011,7 +1002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1049,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1079,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1099,7 +1090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1126,7 +1117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/guides/keras_cv/classification_with_keras_cv.py
+++ b/guides/keras_cv/classification_with_keras_cv.py
@@ -523,11 +523,6 @@ inference_resizing = keras_cv.layers.Resizing(
 )
 eval_ds = eval_ds.map(inference_resizing, num_parallel_calls=tf.data.AUTOTUNE)
 
-inference_resizing = keras_cv.layers.Resizing(
-    IMAGE_SIZE[0], IMAGE_SIZE[1], crop_to_aspect_ratio=True
-)
-eval_ds = eval_ds.map(inference_resizing, num_parallel_calls=tf.data.AUTOTUNE)
-
 image_batch = next(iter(eval_ds.take(1)))["images"]
 keras_cv.visualization.plot_image_gallery(
     image_batch,

--- a/guides/md/keras_cv/classification_with_keras_cv.md
+++ b/guides/md/keras_cv/classification_with_keras_cv.md
@@ -731,11 +731,6 @@ inference_resizing = keras_cv.layers.Resizing(
 )
 eval_ds = eval_ds.map(inference_resizing, num_parallel_calls=tf.data.AUTOTUNE)
 
-inference_resizing = keras_cv.layers.Resizing(
-    IMAGE_SIZE[0], IMAGE_SIZE[1], crop_to_aspect_ratio=True
-)
-eval_ds = eval_ds.map(inference_resizing, num_parallel_calls=tf.data.AUTOTUNE)
-
 image_batch = next(iter(eval_ds.take(1)))["images"]
 keras_cv.visualization.plot_image_gallery(
     image_batch,


### PR DESCRIPTION
The reason for these modifications is actually not an error but rather a section of code that was repeated twice during the guide's writing. Here is a picture of it

![Screenshot (324)](https://github.com/keras-team/keras-io/assets/103279526/74f0858e-6283-431f-92fe-ba52071fe6f0)

This code attempts to resize the evaluation dataset for inference; however, it is duplicated twice throughout the py, md, and ipynb files. Additionally, resizing was already completed for the train dataset in the form of an augmentation layer. Consequently, not for the train dataset either.

I did not raise any issues about it because it did not result in any errors. I have just made a pull request and eliminated the recurring instances.

cc: @fchollet 