### PR TITLE
Added the remaining bounding box formats from keras_cv

### DIFF
--- a/scripts/cv_api_master.py
+++ b/scripts/cv_api_master.py
@@ -130,8 +130,11 @@ BOUNDING_BOX_FORMATS = {
     "generate": [
         "keras_cv.bounding_box.CENTER_XYWH",
         "keras_cv.bounding_box.XYWH",
+        "keras_cv.bounding_box.REL_XYWH",
         "keras_cv.bounding_box.XYXY",
         "keras_cv.bounding_box.REL_XYXY",
+        "keras_cv.bounding_box.YXYX",
+        "keras_cv.bounding_box.REL_YXYX",
     ],
 }
 


### PR DESCRIPTION
Currently keras_cv supports 3 more bounding box formats than what is mentioned in the documentation. This PR adds those remaining paths in `cv_api_master.py`.