### PR TITLE
Update data_format for GlobalAveragingPool1D timeseries_classification

### DIFF
--- a/examples/timeseries/timeseries_classification_transformer.py
+++ b/examples/timeseries/timeseries_classification_transformer.py
@@ -113,7 +113,7 @@ def build_model(
     for _ in range(num_transformer_blocks):
         x = transformer_encoder(x, head_size, num_heads, ff_dim, dropout)
 
-    x = layers.GlobalAveragePooling1D(data_format="channels_first")(x)
+    x = layers.GlobalAveragePooling1D(data_format="channels_last")(x)
     for dim in mlp_units:
         x = layers.Dense(dim, activation="relu")(x)
         x = layers.Dropout(mlp_dropout)(x)


### PR DESCRIPTION

The tutorial time series classification with transformer used FordA dataset which as per my understanding is actually time series data collected in 500 timestamps for one feature (i.e Noise). So the dataset which is initially of shape (x,500) converted into (x,500,1) and theoritically it should be of form (batch_size, steps, features).

Even in the Tutorial page under model summary it is mentioned like below.

Our model processes a tensor of shape `(batch size, sequence length, features)`, where sequence length is the number of time steps and features is each input timeseries.

But as per documentation of GlobalAveragePooling1D, `data_format="channels_first"` means the data should be of shape (batch_size, features, steps)

As per the dataset we are passing to the model, the layer GlobalAveragePooling1D with `data_format="channels_last"` makes more sense to me.