### PR TITLE
Linear activation function in the output layer of one LSTM example

### DIFF
--- a/examples/timeseries/timeseries_weather_forecasting.py
+++ b/examples/timeseries/timeseries_weather_forecasting.py
@@ -271,7 +271,7 @@ print("Target shape:", targets.numpy().shape)
 
 inputs = keras.layers.Input(shape=(inputs.shape[1], inputs.shape[2]))
 lstm_out = keras.layers.LSTM(32)(inputs)
-outputs = keras.layers.Dense(1)(lstm_out)
+outputs = keras.layers.Dense(1, activation=keras.activations.sigmoid)(lstm_out)
 
 model = keras.Model(inputs=inputs, outputs=outputs)
 model.compile(optimizer=keras.optimizers.Adam(learning_rate=learning_rate), loss="mse")


### PR DESCRIPTION
Based on my understanding the default activation function used in the
output layer used for the predictions typically has a sigmoid activation function?

see Fig. 10.16: https://www.deeplearningbook.org/contents/rnn.html (and other literatures)