### PR TITLE
Value error fixed in keras-io/guides/keras_nlp /transformer_pretraining.py documentation

### DIFF
--- a/guides/keras_nlp/transformer_pretraining.py
+++ b/guides/keras_nlp/transformer_pretraining.py
@@ -434,7 +434,7 @@ inputs = keras.Input(shape=(SEQ_LENGTH,), dtype=tf.int32)
 
 # Encode and pool the tokens.
 encoded_tokens = encoder_model(inputs)
-pooled_tokens = keras.layers.GlobalAveragePooling1D()(encoded_tokens[0])
+pooled_tokens = keras.layers.GlobalAveragePooling1D()(encoded_tokens)
 
 # Predict an output label.
 outputs = keras.layers.Dense(1, activation="sigmoid")(pooled_tokens)


### PR DESCRIPTION
This code fixes the small bug in the transformer_pretraining.py documentation which leads to Value error,It has been tested

`pooled_tokens = keras.layers.GlobalAveragePooling1D()(encoded_tokens[0]) encoded_tokens[0] `is giving the following error
[line 437](https://github.com/keras-team/keras-io/blob/master/guides/keras_nlp/transformer_pretraining.py#L437)


```
ValueError`                                Traceback (most recent call last)
[<ipython-input-23-599e891a0cf7>](https://localhost:8080/#) in <cell line: 8>()
      6 # Encode and pool the tokens.
      7 encoded_tokens = encoder_model(inputs)
----> 8 pooled_tokens = keras.layers.GlobalAveragePooling1D()(encoded_tokens[0])
      9 
     10 # Predict an output label.

1 frames
[/usr/local/lib/python3.10/dist-packages/keras/src/engine/input_spec.py](https://localhost:8080/#) in assert_input_compatibility(input_spec, inputs, layer_name)
    233             ndim = shape.rank
    234             if ndim != spec.ndim:
--> 235                 raise ValueError(
    236                     f'Input {input_index} of layer "{layer_name}" '
    237                     "is incompatible with the layer: "

ValueError: Input 0 of layer "global_average_pooling1d" is incompatible with the layer: expected ndim=3, found ndim=2. Full shape received: (128, 256)
```
`pooled_tokens = keras.layers.GlobalAveragePooling1D()(encoded_tokens)` fixes the code