### PR TITLE
Update gnn_citations.py

### DIFF
--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -242,7 +242,7 @@ def create_ffn(hidden_units, dropout_rate, name=None):
 ### Prepare the data for the baseline model
 """
 
-feature_names = set(papers.columns) - {"paper_id", "subject"}
+feature_names = list(set(papers.columns) - {"paper_id", "subject"})
 num_features = len(feature_names)
 num_classes = len(class_idx)
 

--- a/examples/graph/ipynb/gnn_citations.ipynb
+++ b/examples/graph/ipynb/gnn_citations.ipynb
@@ -461,7 +461,7 @@
    },
    "outputs": [],
    "source": [
-    "feature_names = set(papers.columns) - {\"paper_id\", \"subject\"}\n",
+    "feature_names = list(set(papers.columns) - {\"paper_id\", \"subject\"})\n",
     "num_features = len(feature_names)\n",
     "num_classes = len(class_idx)\n",
     "\n",

--- a/examples/graph/md/gnn_citations.md
+++ b/examples/graph/md/gnn_citations.md
@@ -400,7 +400,7 @@ def create_ffn(hidden_units, dropout_rate, name=None):
 
 
 ```python
-feature_names = set(papers.columns) - {"paper_id", "subject"}
+feature_names = list(set(papers.columns) - {"paper_id", "subject"})
 num_features = len(feature_names)
 num_classes = len(class_idx)
 


### PR DESCRIPTION
Fixing a simple issue

Traceback (most recent call last):
  File "/Users/xxxxxx/Desktop/keras-io/examples/graph/gnn_citations.py", line 251, in <module>
    x_train = train_data[feature_names].to_numpy()
              ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/pandas/core/frame.py", line 3857, in __getitem__
    check_dict_or_set_indexers(key)
  File "/opt/homebrew/lib/python3.11/site-packages/pandas/core/indexing.py", line 2687, in check_dict_or_set_indexers
    raise TypeError(
TypeError: Passing a set as an indexer is not supported. Use a list instead.

Convert to list