### PR TITLE
gnn_citations.(py|md|ipynb) GRU code path does not work

### DIFF
--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -415,15 +415,8 @@ class GraphConvLayer(layers.Layer):
         self.normalize = normalize
 
         self.ffn_prepare = create_ffn(hidden_units, dropout_rate)
-        if self.combination_type == "gated":
-            self.update_fn = layers.GRU(
-                units=hidden_units,
-                activation="tanh",
-                recurrent_activation="sigmoid",
-                dropout=dropout_rate,
-                return_state=True,
-                recurrent_dropout=dropout_rate,
-            )
+        if self.combination_type == "gru":
+            self.update_fn = create_gru(hidden_units, dropout_rate)
         else:
             self.update_fn = create_ffn(hidden_units, dropout_rate)
 
@@ -524,6 +517,22 @@ of the Keras model object, rather than input data for training or prediction.
 The model will accept a **batch** of `node_indices`, which are used to lookup the
 node features and neighbours from the `graph_info`.
 """
+
+def create_gru(hidden_units, dropout_rate):
+  inputs = keras.layers.Input(shape=(2, hidden_units[0]))
+  x = inputs
+  gru_layers = []
+  for i, units in enumerate(hidden_units):
+    x = layers.GRU(
+        units=units,
+        activation="tanh",
+        recurrent_activation="sigmoid",
+        return_sequences=True,
+        dropout=dropout_rate,
+        return_state=False,
+        recurrent_dropout=dropout_rate,
+    )(x)
+  return keras.Model(inputs=inputs, outputs=x)
 
 
 class GNNNodeClassifier(tf.keras.Model):

--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -396,19 +396,20 @@ Two other key techniques that are not covered are [Graph Attention Networks](htt
 and [Message Passing Neural Networks](https://arxiv.org/abs/1704.01212).
 """
 
+
 def create_gru(hidden_units, dropout_rate):
     inputs = keras.layers.Input(shape=(2, hidden_units[0]))
     x = inputs
     for units in hidden_units:
-      x = layers.GRU(
-          units=units,
-          activation="tanh",
-          recurrent_activation="sigmoid",
-          return_sequences=True,
-          dropout=dropout_rate,
-          return_state=False,
-          recurrent_dropout=dropout_rate,
-      )(x)
+        x = layers.GRU(
+            units=units,
+            activation="tanh",
+            recurrent_activation="sigmoid",
+            return_sequences=True,
+            dropout=dropout_rate,
+            return_state=False,
+            recurrent_dropout=dropout_rate,
+        )(x)
     return keras.Model(inputs=inputs, outputs=x)
 
 

--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -533,6 +533,7 @@ The model will accept a **batch** of `node_indices`, which are used to lookup th
 node features and neighbours from the `graph_info`.
 """
 
+
 class GNNNodeClassifier(tf.keras.Model):
     def __init__(
         self,

--- a/examples/graph/gnn_citations.py
+++ b/examples/graph/gnn_citations.py
@@ -396,6 +396,21 @@ Two other key techniques that are not covered are [Graph Attention Networks](htt
 and [Message Passing Neural Networks](https://arxiv.org/abs/1704.01212).
 """
 
+def create_gru(hidden_units, dropout_rate):
+    inputs = keras.layers.Input(shape=(2, hidden_units[0]))
+    x = inputs
+    for units in hidden_units:
+      x = layers.GRU(
+          units=units,
+          activation="tanh",
+          recurrent_activation="sigmoid",
+          return_sequences=True,
+          dropout=dropout_rate,
+          return_state=False,
+          recurrent_dropout=dropout_rate,
+      )(x)
+    return keras.Model(inputs=inputs, outputs=x)
+
 
 class GraphConvLayer(layers.Layer):
     def __init__(
@@ -517,23 +532,6 @@ of the Keras model object, rather than input data for training or prediction.
 The model will accept a **batch** of `node_indices`, which are used to lookup the
 node features and neighbours from the `graph_info`.
 """
-
-def create_gru(hidden_units, dropout_rate):
-  inputs = keras.layers.Input(shape=(2, hidden_units[0]))
-  x = inputs
-  gru_layers = []
-  for i, units in enumerate(hidden_units):
-    x = layers.GRU(
-        units=units,
-        activation="tanh",
-        recurrent_activation="sigmoid",
-        return_sequences=True,
-        dropout=dropout_rate,
-        return_state=False,
-        recurrent_dropout=dropout_rate,
-    )(x)
-  return keras.Model(inputs=inputs, outputs=x)
-
 
 class GNNNodeClassifier(tf.keras.Model):
     def __init__(

--- a/examples/graph/ipynb/gnn_citations.ipynb
+++ b/examples/graph/ipynb/gnn_citations.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -271,7 +271,8 @@
     "colors = papers[\"subject\"].tolist()\n",
     "cora_graph = nx.from_pandas_edgelist(citations.sample(n=1500))\n",
     "subjects = list(papers[papers[\"paper_id\"].isin(list(cora_graph.nodes))][\"subject\"])\n",
-    "nx.draw_spring(cora_graph, node_size=15, node_color=subjects)\n"
+    "nx.draw_spring(cora_graph, node_size=15, node_color=subjects)\n",
+    ""
    ]
   },
   {
@@ -285,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -317,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -341,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -369,7 +370,8 @@
     "        callbacks=[early_stopping],\n",
     "    )\n",
     "\n",
-    "    return history\n"
+    "    return history\n",
+    ""
    ]
   },
   {
@@ -383,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -404,7 +406,8 @@
     "    ax2.legend([\"train\", \"test\"], loc=\"upper right\")\n",
     "    ax2.set_xlabel(\"Epochs\")\n",
     "    ax2.set_ylabel(\"Accuracy\")\n",
-    "    plt.show()\n"
+    "    plt.show()\n",
+    ""
    ]
   },
   {
@@ -420,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -435,7 +438,8 @@
     "        fnn_layers.append(layers.Dropout(dropout_rate))\n",
     "        fnn_layers.append(layers.Dense(units, activation=tf.nn.gelu))\n",
     "\n",
-    "    return keras.Sequential(fnn_layers, name=name)\n"
+    "    return keras.Sequential(fnn_layers, name=name)\n",
+    ""
    ]
   },
   {
@@ -451,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -483,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -519,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -539,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -559,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -583,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -605,7 +609,8 @@
     "    for instance_idx, probs in enumerate(probabilities):\n",
     "        print(f\"Instance {instance_idx + 1}:\")\n",
     "        for class_idx, prob in enumerate(probs):\n",
-    "            print(f\"- {class_values[class_idx]}: {round(prob * 100, 2)}%\")\n"
+    "            print(f\"- {class_values[class_idx]}: {round(prob * 100, 2)}%\")\n",
+    ""
    ]
   },
   {
@@ -619,7 +624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -661,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -699,7 +704,7 @@
     "respect to the `edge_weights` using a *permutation invariant* pooling operation, such as *sum*, *mean*, and *max*,\n",
     "to prepare a single aggregated message for each node. See, for example, [tf.math.unsorted_segment_sum](https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum)\n",
     "APIs used to aggregate neighbour messages.\n",
-    "3. **Update**: The `node_repesentations` and `aggregated_messages`—both of shape `[num_nodes, representation_dim]`—\n",
+    "3. **Update**: The `node_repesentations` and `aggregated_messages`\u2014both of shape `[num_nodes, representation_dim]`\u2014\n",
     "are combined and processed to produce the new state of the node representations (node embeddings).\n",
     "If `combination_type` is `gru`, the `node_repesentations` and `aggregated_messages` are stacked to create a sequence,\n",
     "then processed by a GRU layer. Otherwise, the `node_repesentations` and `aggregated_messages` are added\n",
@@ -716,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -737,7 +742,7 @@
     "          recurrent_dropout=dropout_rate,\n",
     "      )(x)\n",
     "    return keras.Model(inputs=inputs, outputs=x)\n",
-    "\n",
+    "\n",  
     "\n",
     "class GraphConvLayer(layers.Layer):\n",
     "    def __init__(\n",
@@ -835,7 +840,8 @@
     "            node_indices, neighbour_messages, node_repesentations\n",
     "        )\n",
     "        # Update the node embedding with the neighbour messages.\n",
-    "        return self.update(node_repesentations, aggregated_messages)\n"
+    "        return self.update(node_repesentations, aggregated_messages)\n",
+    ""
    ]
   },
   {
@@ -867,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -941,7 +947,8 @@
     "        # Fetch node embeddings for the input node_indices.\n",
     "        node_embeddings = tf.gather(x, input_node_indices)\n",
     "        # Compute logits\n",
-    "        return self.compute_logits(node_embeddings)\n"
+    "        return self.compute_logits(node_embeddings)\n",
+    ""
    ]
   },
   {
@@ -957,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -992,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -1013,7 +1020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -1035,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -1060,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -1104,7 +1111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "colab_type": "code"
    },
@@ -1144,7 +1151,7 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1158,9 +1165,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/examples/graph/ipynb/gnn_citations.ipynb
+++ b/examples/graph/ipynb/gnn_citations.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -271,8 +271,7 @@
     "colors = papers[\"subject\"].tolist()\n",
     "cora_graph = nx.from_pandas_edgelist(citations.sample(n=1500))\n",
     "subjects = list(papers[papers[\"paper_id\"].isin(list(cora_graph.nodes))][\"subject\"])\n",
-    "nx.draw_spring(cora_graph, node_size=15, node_color=subjects)\n",
-    ""
+    "nx.draw_spring(cora_graph, node_size=15, node_color=subjects)\n"
    ]
   },
   {
@@ -286,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -318,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -342,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -370,8 +369,7 @@
     "        callbacks=[early_stopping],\n",
     "    )\n",
     "\n",
-    "    return history\n",
-    ""
+    "    return history\n"
    ]
   },
   {
@@ -385,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -406,8 +404,7 @@
     "    ax2.legend([\"train\", \"test\"], loc=\"upper right\")\n",
     "    ax2.set_xlabel(\"Epochs\")\n",
     "    ax2.set_ylabel(\"Accuracy\")\n",
-    "    plt.show()\n",
-    ""
+    "    plt.show()\n"
    ]
   },
   {
@@ -423,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -438,8 +435,7 @@
     "        fnn_layers.append(layers.Dropout(dropout_rate))\n",
     "        fnn_layers.append(layers.Dense(units, activation=tf.nn.gelu))\n",
     "\n",
-    "    return keras.Sequential(fnn_layers, name=name)\n",
-    ""
+    "    return keras.Sequential(fnn_layers, name=name)\n"
    ]
   },
   {
@@ -455,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -487,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -523,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -543,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -563,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -587,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -609,8 +605,7 @@
     "    for instance_idx, probs in enumerate(probabilities):\n",
     "        print(f\"Instance {instance_idx + 1}:\")\n",
     "        for class_idx, prob in enumerate(probs):\n",
-    "            print(f\"- {class_values[class_idx]}: {round(prob * 100, 2)}%\")\n",
-    ""
+    "            print(f\"- {class_values[class_idx]}: {round(prob * 100, 2)}%\")\n"
    ]
   },
   {
@@ -624,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -666,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -704,7 +699,7 @@
     "respect to the `edge_weights` using a *permutation invariant* pooling operation, such as *sum*, *mean*, and *max*,\n",
     "to prepare a single aggregated message for each node. See, for example, [tf.math.unsorted_segment_sum](https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum)\n",
     "APIs used to aggregate neighbour messages.\n",
-    "3. **Update**: The `node_repesentations` and `aggregated_messages`\u2014both of shape `[num_nodes, representation_dim]`\u2014\n",
+    "3. **Update**: The `node_repesentations` and `aggregated_messages`—both of shape `[num_nodes, representation_dim]`—\n",
     "are combined and processed to produce the new state of the node representations (node embeddings).\n",
     "If `combination_type` is `gru`, the `node_repesentations` and `aggregated_messages` are stacked to create a sequence,\n",
     "then processed by a GRU layer. Otherwise, the `node_repesentations` and `aggregated_messages` are added\n",
@@ -721,12 +716,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
+    "\n",
+    "def create_gru(hidden_units, dropout_rate):\n",
+    "    inputs = keras.layers.Input(shape=(2, hidden_units[0]))\n",
+    "    x = inputs\n",
+    "    for units in hidden_units:\n",
+    "      x = layers.GRU(\n",
+    "          units=units,\n",
+    "          activation=\"tanh\",\n",
+    "          recurrent_activation=\"sigmoid\",\n",
+    "          return_sequences=True,\n",
+    "          dropout=dropout_rate,\n",
+    "          return_state=False,\n",
+    "          recurrent_dropout=dropout_rate,\n",
+    "      )(x)\n",
+    "    return keras.Model(inputs=inputs, outputs=x)\n",
+    "\n",
     "\n",
     "class GraphConvLayer(layers.Layer):\n",
     "    def __init__(\n",
@@ -746,15 +757,8 @@
     "        self.normalize = normalize\n",
     "\n",
     "        self.ffn_prepare = create_ffn(hidden_units, dropout_rate)\n",
-    "        if self.combination_type == \"gated\":\n",
-    "            self.update_fn = layers.GRU(\n",
-    "                units=hidden_units,\n",
-    "                activation=\"tanh\",\n",
-    "                recurrent_activation=\"sigmoid\",\n",
-    "                dropout=dropout_rate,\n",
-    "                return_state=True,\n",
-    "                recurrent_dropout=dropout_rate,\n",
-    "            )\n",
+    "        if self.combination_type == \"gru\":\n",
+    "            self.update_fn = create_gru(hidden_units, dropout_rate)\n",
     "        else:\n",
     "            self.update_fn = create_ffn(hidden_units, dropout_rate)\n",
     "\n",
@@ -831,8 +835,7 @@
     "            node_indices, neighbour_messages, node_repesentations\n",
     "        )\n",
     "        # Update the node embedding with the neighbour messages.\n",
-    "        return self.update(node_repesentations, aggregated_messages)\n",
-    ""
+    "        return self.update(node_repesentations, aggregated_messages)\n"
    ]
   },
   {
@@ -864,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -938,8 +941,7 @@
     "        # Fetch node embeddings for the input node_indices.\n",
     "        node_embeddings = tf.gather(x, input_node_indices)\n",
     "        # Compute logits\n",
-    "        return self.compute_logits(node_embeddings)\n",
-    ""
+    "        return self.compute_logits(node_embeddings)\n"
    ]
   },
   {
@@ -955,7 +957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -990,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1011,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1033,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1058,7 +1060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1102,7 +1104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -1142,7 +1144,7 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1156,9 +1158,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/examples/graph/md/gnn_citations.md
+++ b/examples/graph/md/gnn_citations.md
@@ -928,6 +928,22 @@ and [Message Passing Neural Networks](https://arxiv.org/abs/1704.01212).
 
 ```python
 
+def create_gru(hidden_units, dropout_rate):
+    inputs = keras.layers.Input(shape=(2, hidden_units[0]))
+    x = inputs
+    for units in hidden_units:
+      x = layers.GRU(
+          units=units,
+          activation="tanh",
+          recurrent_activation="sigmoid",
+          return_sequences=True,
+          dropout=dropout_rate,
+          return_state=False,
+          recurrent_dropout=dropout_rate,
+      )(x)
+    return keras.Model(inputs=inputs, outputs=x)
+
+
 class GraphConvLayer(layers.Layer):
     def __init__(
         self,
@@ -946,16 +962,9 @@ class GraphConvLayer(layers.Layer):
         self.normalize = normalize
 
         self.ffn_prepare = create_ffn(hidden_units, dropout_rate)
-        if self.combination_type == "gated":
-            self.update_fn = layers.GRU(
-                units=hidden_units,
-                activation="tanh",
-                recurrent_activation="sigmoid",
-                dropout=dropout_rate,
-                return_state=True,
-                recurrent_dropout=dropout_rate,
-            )
-        else:
+        if self.combination_type == "gru":
+            self.update_fn = create_gru(hidden_units, dropout_rate)
+	else:
             self.update_fn = create_ffn(hidden_units, dropout_rate)
 
     def prepare(self, node_repesentations, weights=None):


### PR DESCRIPTION
There is an optional GRU code path in the gnn_citations.(py|md|ipynb). However it doesn't currently work.

The combination_type "gated" should be "gru"

If you set the combination_type to "gated" you get back a ValueError:

"Invalid combination type: gated"  from the aggregate method call

Fixing that issue exposes another issue in that "layers.GRU" units must be an integer and not a list as it currently is `hidden_units`

To resolve this I made a method to match the signature of the create_ffn and add multiple GRU layers

However it complicates the example a bit...

Also the use of hidden units like this doesn't work if  the hidden_layer sizes are different.

If you are happy with this change I will also update the ipynb and md files.