### PR TITLE
Update Dockerfile to version 3.0.5 to fix DockerImage Continuous Inte…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
-RUN pip install keras==3.0.4
+RUN pip install keras==3.0.5
 
 COPY ./ ./
 WORKDIR scripts


### PR DESCRIPTION
…gration Failure

Currently the DockerImage Continuous Integration test is failing with

3.921 RuntimeError: For project keras, URL https://github.com/keras-team/keras/tree/v3.0.5/ has version number 3.0.5 which does not match the current imported package version 3.0.4 ------
Dockerfile:9
--------------------
   7 |     COPY ./ ./
   8 |     WORKDIR scripts
   9 | >>> RUN python autogen.py make
  10 |     
  11 |     CMD ["python", "-u", "autogen.py", "serve"]
--------------------
ERROR: failed to solve: process "/bin/sh -c python autogen.py make" did not complete successfully: exit code: 1
make: *** [Makefile:2: container-test] Error 1
Error: Process completed with exit code 2.

I believe this is the case since https://github.com/keras-team/keras/commit/e6e62405fa1b4444102601636d871610d91e5783 updated Keras central