### PR TITLE
Fixed typos in examples/audio,examples/generative modules

### DIFF
--- a/examples/audio/ipynb/uk_ireland_accent_recognition.ipynb
+++ b/examples/audio/ipynb/uk_ireland_accent_recognition.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -344,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -471,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -522,7 +522,7 @@
    "source": [
     "## Class weights calculation\n",
     "\n",
-    "Since the dataset is quite unbalanced, we wil use `class_weight` argument during training.\n",
+    "Since the dataset is quite unbalanced, we will use `class_weight` argument during training.\n",
     "\n",
     "Getting the class weights is a little tricky because even though we know the number of\n",
     "audio files for each class, it does not represent the number of samples for that class\n",
@@ -535,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -573,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -605,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -634,7 +634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -670,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -693,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -746,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -803,7 +803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -840,7 +840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -861,8 +861,7 @@
     "    )\n",
     "    os.system(command)\n",
     "\n",
-    "filename = filename + \".wav\"\n",
-    ""
+    "filename = filename + \".wav\"\n"
    ]
   },
   {
@@ -877,7 +876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -924,8 +923,7 @@
     "    # Predict the output of the accent recognition model with embeddings as input\n",
     "    predictions = model.predict(embeddings)\n",
     "\n",
-    "    return audio_wav, predictions, mel_spectrogram\n",
-    ""
+    "    return audio_wav, predictions, mel_spectrogram\n"
    ]
   },
   {
@@ -939,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -962,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -988,7 +986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/audio/md/uk_ireland_accent_recognition.md
+++ b/examples/audio/md/uk_ireland_accent_recognition.md
@@ -583,7 +583,7 @@ _________________________________________________________________
 ---
 ## Class weights calculation
 
-Since the dataset is quite unbalanced, we wil use `class_weight` argument during training.
+Since the dataset is quite unbalanced, we will use `class_weight` argument during training.
 
 Getting the class weights is a little tricky because even though we know the number of
 audio files for each class, it does not represent the number of samples for that class

--- a/examples/audio/uk_ireland_accent_recognition.py
+++ b/examples/audio/uk_ireland_accent_recognition.py
@@ -368,7 +368,7 @@ model.summary()
 """
 ## Class weights calculation
 
-Since the dataset is quite unbalanced, we wil use `class_weight` argument during training.
+Since the dataset is quite unbalanced, we will use `class_weight` argument during training.
 
 Getting the class weights is a little tricky because even though we know the number of
 audio files for each class, it does not represent the number of samples for that class

--- a/examples/generative/dreambooth.py
+++ b/examples/generative/dreambooth.py
@@ -634,7 +634,7 @@ images_dreamboothed = dreambooth_model.text_to_image(
 plot_images(images_dreamboothed, prompt)
 
 """
-Feel free to experiment with different prompts (don't forget to add the unique identifer
+Feel free to experiment with different prompts (don't forget to add the unique identifier
 and the class label!) to see how the results change. We welcome you to check out our
 codebase and more experimental results
 [here](https://github.com/sayakpaul/dreambooth-keras#results). You can also read

--- a/examples/generative/ipynb/dreambooth.ipynb
+++ b/examples/generative/ipynb/dreambooth.ipynb
@@ -941,7 +941,7 @@
     "colab_type": "text"
    },
    "source": [
-    "Feel free to experiment with different prompts (don't forget to add the unique identifer\n",
+    "Feel free to experiment with different prompts (don't forget to add the unique identifier\n",
     "and the class label!) to see how the results change. We welcome you to check out our\n",
     "codebase and more experimental results\n",
     "[here](https://github.com/sayakpaul/dreambooth-keras#results). You can also read\n",

--- a/examples/generative/ipynb/molecule_generation.ipynb
+++ b/examples/generative/ipynb/molecule_generation.ipynb
@@ -505,7 +505,7 @@
     "A gradient penalty is an alternative soft constraint on the\n",
     "1-Lipschitz continuity as an improvement upon the gradient clipping scheme from the\n",
     "original neural network\n",
-    "(\"1-Lipschitz continuity\" means that the norm of the gradient is at most 1 at evey single\n",
+    "(\"1-Lipschitz continuity\" means that the norm of the gradient is at most 1 at every single\n",
     "point of the function).\n",
     "It adds a regularization term to the loss function."
    ]

--- a/examples/generative/ipynb/pixelcnn.ipynb
+++ b/examples/generative/ipynb/pixelcnn.ipynb
@@ -29,14 +29,14 @@
     "probability distribution of later elements. In the following example, images are generated\n",
     "in this fashion, pixel-by-pixel, via a masked convolution kernel that only looks at data\n",
     "from previously generated pixels (origin at the top left) to generate later pixels.\n",
-    "During inference, the output of the network is used as a probability ditribution\n",
+    "During inference, the output of the network is used as a probability distribution\n",
     "from which new pixel values are sampled to generate a new image\n",
     "(here, with MNIST, the pixels values are either black or white)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -146,8 +146,7 @@
     "        x = self.conv1(inputs)\n",
     "        x = self.pixel_conv(x)\n",
     "        x = self.conv2(x)\n",
-    "        return keras.layers.add([inputs, x])\n",
-    ""
+    "        return keras.layers.add([inputs, x])\n"
    ]
   },
   {
@@ -161,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -214,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/generative/ipynb/wgan-graphs.ipynb
+++ b/examples/generative/ipynb/wgan-graphs.ipynb
@@ -332,7 +332,7 @@
     "followed by a reshape and softmax to match that of a multi-dimensional adjacency/feature\n",
     "tensor.\n",
     "\n",
-    "As the discriminator network will recieves as input a graph (`A`, `H`) from either the\n",
+    "As the discriminator network will receives as input a graph (`A`, `H`) from either the\n",
     "generator or from the training set, we'll need to implement graph convolutional layers,\n",
     "which allows us to operate on graphs. This means that input to the discriminator network\n",
     "will first pass through graph convolutional layers, then an average-pooling layer,\n",

--- a/examples/generative/md/dreambooth.md
+++ b/examples/generative/md/dreambooth.md
@@ -731,7 +731,7 @@ plot_images(images_dreamboothed, prompt)
 ![png](/img/examples/generative/dreambooth/dreambooth_44_1.png)
 
 
-Feel free to experiment with different prompts (don't forget to add the unique identifer
+Feel free to experiment with different prompts (don't forget to add the unique identifier
 and the class label!) to see how the results change. We welcome you to check out our
 codebase and more experimental results
 [here](https://github.com/sayakpaul/dreambooth-keras#results). You can also read

--- a/examples/generative/md/molecule_generation.md
+++ b/examples/generative/md/molecule_generation.md
@@ -498,7 +498,7 @@ penalty is further guided by the model's property (QED) prediction.
 A gradient penalty is an alternative soft constraint on the
 1-Lipschitz continuity as an improvement upon the gradient clipping scheme from the
 original neural network
-("1-Lipschitz continuity" means that the norm of the gradient is at most 1 at evey single
+("1-Lipschitz continuity" means that the norm of the gradient is at most 1 at every single
 point of the function).
 It adds a regularization term to the loss function.
 

--- a/examples/generative/md/pixelcnn.md
+++ b/examples/generative/md/pixelcnn.md
@@ -20,7 +20,7 @@ from an input vector where the probability distribution of prior elements dictat
 probability distribution of later elements. In the following example, images are generated
 in this fashion, pixel-by-pixel, via a masked convolution kernel that only looks at data
 from previously generated pixels (origin at the top left) to generate later pixels.
-During inference, the output of the network is used as a probability ditribution
+During inference, the output of the network is used as a probability distribution
 from which new pixel values are sampled to generate a new image
 (here, with MNIST, the pixels values are either black or white).
 

--- a/examples/generative/md/wgan-graphs.md
+++ b/examples/generative/md/wgan-graphs.md
@@ -289,7 +289,7 @@ networks will then output (for each example in the batch) a tanh-activated vecto
 followed by a reshape and softmax to match that of a multi-dimensional adjacency/feature
 tensor.
 
-As the discriminator network will recieves as input a graph (`A`, `H`) from either the
+As the discriminator network will receives as input a graph (`A`, `H`) from either the
 generator or from the training set, we'll need to implement graph convolutional layers,
 which allows us to operate on graphs. This means that input to the discriminator network
 will first pass through graph convolutional layers, then an average-pooling layer,

--- a/examples/generative/molecule_generation.py
+++ b/examples/generative/molecule_generation.py
@@ -402,7 +402,7 @@ penalty is further guided by the model's property (QED) prediction.
 A gradient penalty is an alternative soft constraint on the
 1-Lipschitz continuity as an improvement upon the gradient clipping scheme from the
 original neural network
-("1-Lipschitz continuity" means that the norm of the gradient is at most 1 at evey single
+("1-Lipschitz continuity" means that the norm of the gradient is at most 1 at every single
 point of the function).
 It adds a regularization term to the loss function.
 """

--- a/examples/generative/pixelcnn.py
+++ b/examples/generative/pixelcnn.py
@@ -17,7 +17,7 @@ from an input vector where the probability distribution of prior elements dictat
 probability distribution of later elements. In the following example, images are generated
 in this fashion, pixel-by-pixel, via a masked convolution kernel that only looks at data
 from previously generated pixels (origin at the top left) to generate later pixels.
-During inference, the output of the network is used as a probability ditribution
+During inference, the output of the network is used as a probability distribution
 from which new pixel values are sampled to generate a new image
 (here, with MNIST, the pixels values are either black or white).
 """

--- a/examples/generative/wgan-graphs.py
+++ b/examples/generative/wgan-graphs.py
@@ -258,7 +258,7 @@ networks will then output (for each example in the batch) a tanh-activated vecto
 followed by a reshape and softmax to match that of a multi-dimensional adjacency/feature
 tensor.
 
-As the discriminator network will recieves as input a graph (`A`, `H`) from either the
+As the discriminator network will receives as input a graph (`A`, `H`) from either the
 generator or from the training set, we'll need to implement graph convolutional layers,
 which allows us to operate on graphs. This means that input to the discriminator network
 will first pass through graph convolutional layers, then an average-pooling layer,


### PR DESCRIPTION
Fixed typos in examples/audio,examples/generative modules.