### PR TITLE
Fix imbalanced classification notebook error by removing comma

### DIFF
--- a/examples/structured_data/ipynb/imbalanced_classification.ipynb
+++ b/examples/structured_data/ipynb/imbalanced_classification.ipynb
@@ -246,7 +246,7 @@
     "so as to reflect that False Negatives are more costly than False Positives.\n",
     "\n",
     "Next time your credit card gets  declined in an online purchase -- this is why.\n",
-    "\n",
+    "\n"
     ]
   }
  ],


### PR DESCRIPTION
Fix imbalanced classification notebook error by removing comma.

Before fix:
imbalanced classification notebook is currently not working 
![Screenshot 2024-03-02 at 2 44 11 PM](https://github.com/keras-team/keras-io/assets/1141079/502d2c92-cb36-41f5-a437-369e30f00f26)

After fix (my local VScode):
![Screenshot 2024-03-02 at 2 47 38 PM](https://github.com/keras-team/keras-io/assets/1141079/0c21fb85-c291-4799-95b8-1bae7cd65d80)


