### PR TITLE
Fix imbalanced classification notebook.

### DIFF
--- a/examples/structured_data/ipynb/imbalanced_classification.ipynb
+++ b/examples/structured_data/ipynb/imbalanced_classification.ipynb
@@ -246,7 +246,7 @@
     "so as to reflect that False Negatives are more costly than False Positives.\n",
     "\n",
     "Next time your credit card gets  declined in an online purchase -- this is why.\n",
-    "\n",
+    "\n"
     ]
   }
  ],


### PR DESCRIPTION
Fix typo in imbalanced classification notebook.

The notebook is not working. Error:
![Screenshot 2024-03-02 at 2 44 11 PM](https://github.com/keras-team/keras-io/assets/1141079/488a83e4-45ca-4743-85ce-813fb90811a2)

Remove the comma fixed it.


