### PR TITLE
Link fixes for Text Generation using FNet example

### DIFF
--- a/examples/generative/md/text_generation_fnet.md
+++ b/examples/generative/md/text_generation_fnet.md
@@ -5,7 +5,7 @@
 **Last modified:** 2021/10/05<br>
 
 
-<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/nlp/ipynb/text_generation_fnet.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/nlp/text_generation_fnet.py)
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/examples/generative/ipynb/text_generation_fnet.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/examples/generative/text_generation_fnet.py)
 
 
 **Description:** FNet transformer for text generation in Keras.


### PR DESCRIPTION
For the [Text Generation using FNet example](https://keras.io/examples/generative/text_generation_fnet/) broken colab and github source links have been fixed.

cc: @fchollet 