### PR TITLE
Migrating End-to-end Masked Language Modeling with BERT example to Keras 3

### DIFF
--- a/examples/nlp/ipynb/masked_language_modeling.ipynb
+++ b/examples/nlp/ipynb/masked_language_modeling.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Ankur Singh](https://twitter.com/ankur310794)<br>\n",
     "**Date created:** 2020/09/18<br>\n",
-    "**Last modified:** 2020/09/18<br>\n",
+    "**Last modified:** 2024/03/15<br>\n",
     "**Description:** Implement a Masked Language Model (MLM) with BERT and fine-tune it on the IMDB Reviews dataset."
    ]
   },
@@ -62,16 +62,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"KERAS_BACKEND\"] = \"tensorflow\"\n",
+    "import keras_nlp\n",
+    "import keras\n",
     "import tensorflow as tf\n",
-    "from tensorflow import keras\n",
-    "from tensorflow.keras import layers\n",
-    "from tensorflow.keras.layers import TextVectorization\n",
+    "from keras import layers\n",
+    "from keras.layers import TextVectorization\n",
     "from dataclasses import dataclass\n",
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -91,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -126,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -138,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -199,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -341,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -353,13 +357,13 @@
     "    attention_output = layers.MultiHeadAttention(\n",
     "        num_heads=config.NUM_HEAD,\n",
     "        key_dim=config.EMBED_DIM // config.NUM_HEAD,\n",
-    "        name=\"encoder_{}/multiheadattention\".format(i),\n",
+    "        name=\"encoder_{}_multiheadattention\".format(i),\n",
     "    )(query, key, value)\n",
-    "    attention_output = layers.Dropout(0.1, name=\"encoder_{}/att_dropout\".format(i))(\n",
+    "    attention_output = layers.Dropout(0.1, name=\"encoder_{}_att_dropout\".format(i))(\n",
     "        attention_output\n",
     "    )\n",
     "    attention_output = layers.LayerNormalization(\n",
-    "        epsilon=1e-6, name=\"encoder_{}/att_layernormalization\".format(i)\n",
+    "        epsilon=1e-6, name=\"encoder_{}_att_layernormalization\".format(i)\n",
     "    )(query + attention_output)\n",
     "\n",
     "    # Feed-forward layer\n",
@@ -368,39 +372,23 @@
     "            layers.Dense(config.FF_DIM, activation=\"relu\"),\n",
     "            layers.Dense(config.EMBED_DIM),\n",
     "        ],\n",
-    "        name=\"encoder_{}/ffn\".format(i),\n",
+    "        name=\"encoder_{}_ffn\".format(i),\n",
     "    )\n",
     "    ffn_output = ffn(attention_output)\n",
-    "    ffn_output = layers.Dropout(0.1, name=\"encoder_{}/ffn_dropout\".format(i))(\n",
+    "    ffn_output = layers.Dropout(0.1, name=\"encoder_{}_ffn_dropout\".format(i))(\n",
     "        ffn_output\n",
     "    )\n",
     "    sequence_output = layers.LayerNormalization(\n",
-    "        epsilon=1e-6, name=\"encoder_{}/ffn_layernormalization\".format(i)\n",
+    "        epsilon=1e-6, name=\"encoder_{}_ffn_layernormalization\".format(i)\n",
     "    )(attention_output + ffn_output)\n",
     "    return sequence_output\n",
     "\n",
     "\n",
-    "def get_pos_encoding_matrix(max_len, d_emb):\n",
-    "    pos_enc = np.array(\n",
-    "        [\n",
-    "            [pos / np.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]\n",
-    "            if pos != 0\n",
-    "            else np.zeros(d_emb)\n",
-    "            for pos in range(max_len)\n",
-    "        ]\n",
-    "    )\n",
-    "    pos_enc[1:, 0::2] = np.sin(pos_enc[1:, 0::2])  # dim 2i\n",
-    "    pos_enc[1:, 1::2] = np.cos(pos_enc[1:, 1::2])  # dim 2i+1\n",
-    "    return pos_enc\n",
+    "loss_fn = keras.losses.SparseCategoricalCrossentropy(reduction=None)\n",
+    "loss_tracker = keras.metrics.Mean(name=\"loss\")\n",
     "\n",
     "\n",
-    "loss_fn = keras.losses.SparseCategoricalCrossentropy(\n",
-    "    reduction=tf.keras.losses.Reduction.NONE\n",
-    ")\n",
-    "loss_tracker = tf.keras.metrics.Mean(name=\"loss\")\n",
-    "\n",
-    "\n",
-    "class MaskedLanguageModel(tf.keras.Model):\n",
+    "class MaskedLanguageModel(keras.Model):\n",
     "    def train_step(self, inputs):\n",
     "        if len(inputs) == 3:\n",
     "            features, labels, sample_weight = inputs\n",
@@ -436,17 +424,14 @@
     "\n",
     "\n",
     "def create_masked_language_bert_model():\n",
-    "    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)\n",
+    "    inputs = layers.Input((config.MAX_LEN,), dtype=\"int64\")\n",
     "\n",
     "    word_embeddings = layers.Embedding(\n",
     "        config.VOCAB_SIZE, config.EMBED_DIM, name=\"word_embedding\"\n",
     "    )(inputs)\n",
-    "    position_embeddings = layers.Embedding(\n",
-    "        input_dim=config.MAX_LEN,\n",
-    "        output_dim=config.EMBED_DIM,\n",
-    "        weights=[get_pos_encoding_matrix(config.MAX_LEN, config.EMBED_DIM)],\n",
-    "        name=\"position_embedding\",\n",
-    "    )(tf.range(start=0, limit=config.MAX_LEN, delta=1))\n",
+    "    position_embeddings = keras_nlp.layers.PositionEmbedding(\n",
+    "        sequence_length=config.MAX_LEN\n",
+    "    )(word_embeddings)\n",
     "    embeddings = word_embeddings + position_embeddings\n",
     "\n",
     "    encoder_output = embeddings\n",
@@ -520,14 +505,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
    "outputs": [],
    "source": [
     "bert_masked_model.fit(mlm_ds, epochs=5, callbacks=[generator_callback])\n",
-    "bert_masked_model.save(\"bert_mlm_imdb.h5\")"
+    "bert_masked_model.save(\"bert_mlm_imdb.keras\")"
    ]
   },
   {
@@ -545,7 +530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -553,10 +538,10 @@
    "source": [
     "# Load pretrained bert model\n",
     "mlm_model = keras.models.load_model(\n",
-    "    \"bert_mlm_imdb.h5\", custom_objects={\"MaskedLanguageModel\": MaskedLanguageModel}\n",
+    "    \"bert_mlm_imdb.keras\", custom_objects={\"MaskedLanguageModel\": MaskedLanguageModel}\n",
     ")\n",
-    "pretrained_bert_model = tf.keras.Model(\n",
-    "    mlm_model.input, mlm_model.get_layer(\"encoder_0/ffn_layernormalization\").output\n",
+    "pretrained_bert_model = keras.Model(\n",
+    "    mlm_model.input, mlm_model.get_layer(\"encoder_0_ffn_layernormalization\").output\n",
     ")\n",
     "\n",
     "# Freeze it\n",
@@ -564,7 +549,7 @@
     "\n",
     "\n",
     "def create_classifier_bert_model():\n",
-    "    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)\n",
+    "    inputs = layers.Input((config.MAX_LEN,), dtype=\"int64\")\n",
     "    sequence_output = pretrained_bert_model(inputs)\n",
     "    pooled_output = layers.GlobalMaxPooling1D()(sequence_output)\n",
     "    hidden_layer = layers.Dense(64, activation=\"relu\")(pooled_output)\n",
@@ -617,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/nlp/masked_language_modeling.py
+++ b/examples/nlp/masked_language_modeling.py
@@ -2,9 +2,10 @@
 Title: End-to-end Masked Language Modeling with BERT
 Author: [Ankur Singh](https://twitter.com/ankur310794)
 Date created: 2020/09/18
-Last modified: 2020/09/18
+Last modified: 2024/03/15
 Description: Implement a Masked Language Model (MLM) with BERT and fine-tune it on the IMDB Reviews dataset.
 Accelerator: GPU
+Converted to Keras 3 by: [Sitam Meur](https://github.com/sitamgithub-MSIT)
 """
 
 """

--- a/examples/nlp/masked_language_modeling.py
+++ b/examples/nlp/masked_language_modeling.py
@@ -43,10 +43,14 @@ Note: This example should be run with `tf-nightly`.
 Install `tf-nightly` via `pip install tf-nightly`.
 """
 
+import os
+
+os.environ["KERAS_BACKEND"] = "tensorflow"
+import keras_nlp
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-from tensorflow.keras.layers import TextVectorization
+from keras import layers
+from keras.layers import TextVectorization
 from dataclasses import dataclass
 import pandas as pd
 import numpy as np
@@ -264,13 +268,13 @@ def bert_module(query, key, value, i):
     attention_output = layers.MultiHeadAttention(
         num_heads=config.NUM_HEAD,
         key_dim=config.EMBED_DIM // config.NUM_HEAD,
-        name="encoder_{}/multiheadattention".format(i),
+        name="encoder_{}_multiheadattention".format(i),
     )(query, key, value)
-    attention_output = layers.Dropout(0.1, name="encoder_{}/att_dropout".format(i))(
+    attention_output = layers.Dropout(0.1, name="encoder_{}_att_dropout".format(i))(
         attention_output
     )
     attention_output = layers.LayerNormalization(
-        epsilon=1e-6, name="encoder_{}/att_layernormalization".format(i)
+        epsilon=1e-6, name="encoder_{}_att_layernormalization".format(i)
     )(query + attention_output)
 
     # Feed-forward layer
@@ -279,41 +283,25 @@ def bert_module(query, key, value, i):
             layers.Dense(config.FF_DIM, activation="relu"),
             layers.Dense(config.EMBED_DIM),
         ],
-        name="encoder_{}/ffn".format(i),
+        name="encoder_{}_ffn".format(i),
     )
     ffn_output = ffn(attention_output)
-    ffn_output = layers.Dropout(0.1, name="encoder_{}/ffn_dropout".format(i))(
+    ffn_output = layers.Dropout(0.1, name="encoder_{}_ffn_dropout".format(i))(
         ffn_output
     )
     sequence_output = layers.LayerNormalization(
-        epsilon=1e-6, name="encoder_{}/ffn_layernormalization".format(i)
+        epsilon=1e-6, name="encoder_{}_ffn_layernormalization".format(i)
     )(attention_output + ffn_output)
     return sequence_output
 
 
-def get_pos_encoding_matrix(max_len, d_emb):
-    pos_enc = np.array(
-        [
-            (
-                [pos / np.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]
-                if pos != 0
-                else np.zeros(d_emb)
-            )
-            for pos in range(max_len)
-        ]
-    )
-    pos_enc[1:, 0::2] = np.sin(pos_enc[1:, 0::2])  # dim 2i
-    pos_enc[1:, 1::2] = np.cos(pos_enc[1:, 1::2])  # dim 2i+1
-    return pos_enc
-
-
 loss_fn = keras.losses.SparseCategoricalCrossentropy(
-    reduction=tf.keras.losses.Reduction.NONE
+    reduction=None
 )
-loss_tracker = tf.keras.metrics.Mean(name="loss")
+loss_tracker = keras.metrics.Mean(name="loss")
 
 
-class MaskedLanguageModel(tf.keras.Model):
+class MaskedLanguageModel(keras.Model):
     def train_step(self, inputs):
         if len(inputs) == 3:
             features, labels, sample_weight = inputs
@@ -349,17 +337,14 @@ class MaskedLanguageModel(tf.keras.Model):
 
 
 def create_masked_language_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int64")
 
     word_embeddings = layers.Embedding(
         config.VOCAB_SIZE, config.EMBED_DIM, name="word_embedding"
     )(inputs)
-    position_embeddings = layers.Embedding(
-        input_dim=config.MAX_LEN,
-        output_dim=config.EMBED_DIM,
-        weights=[get_pos_encoding_matrix(config.MAX_LEN, config.EMBED_DIM)],
-        name="position_embedding",
-    )(tf.range(start=0, limit=config.MAX_LEN, delta=1))
+    position_embeddings = keras_nlp.layers.PositionEmbedding(
+      sequence_length=config.MAX_LEN
+    )(word_embeddings)
     embeddings = word_embeddings + position_embeddings
 
     encoder_output = embeddings
@@ -426,7 +411,7 @@ bert_masked_model.summary()
 """
 
 bert_masked_model.fit(mlm_ds, epochs=5, callbacks=[generator_callback])
-bert_masked_model.save("bert_mlm_imdb.h5")
+bert_masked_model.save("bert_mlm_imdb.keras")
 
 """
 ## Fine-tune a sentiment classification model
@@ -439,10 +424,10 @@ pretrained BERT features.
 
 # Load pretrained bert model
 mlm_model = keras.models.load_model(
-    "bert_mlm_imdb.h5", custom_objects={"MaskedLanguageModel": MaskedLanguageModel}
+    "bert_mlm_imdb.keras", custom_objects={"MaskedLanguageModel": MaskedLanguageModel}
 )
-pretrained_bert_model = tf.keras.Model(
-    mlm_model.input, mlm_model.get_layer("encoder_0/ffn_layernormalization").output
+pretrained_bert_model = keras.Model(
+    mlm_model.input, mlm_model.get_layer("encoder_0_ffn_layernormalization").output
 )
 
 # Freeze it
@@ -450,7 +435,7 @@ pretrained_bert_model.trainable = False
 
 
 def create_classifier_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int64")
     sequence_output = pretrained_bert_model(inputs)
     pooled_output = layers.GlobalMaxPooling1D()(sequence_output)
     hidden_layer = layers.Dense(64, activation="relu")(pooled_output)

--- a/examples/nlp/masked_language_modeling.py
+++ b/examples/nlp/masked_language_modeling.py
@@ -295,9 +295,7 @@ def bert_module(query, key, value, i):
     return sequence_output
 
 
-loss_fn = keras.losses.SparseCategoricalCrossentropy(
-    reduction=None
-)
+loss_fn = keras.losses.SparseCategoricalCrossentropy(reduction=None)
 loss_tracker = keras.metrics.Mean(name="loss")
 
 
@@ -343,7 +341,7 @@ def create_masked_language_bert_model():
         config.VOCAB_SIZE, config.EMBED_DIM, name="word_embedding"
     )(inputs)
     position_embeddings = keras_nlp.layers.PositionEmbedding(
-      sequence_length=config.MAX_LEN
+        sequence_length=config.MAX_LEN
     )(word_embeddings)
     embeddings = word_embeddings + position_embeddings
 


### PR DESCRIPTION
This PR changes the [End-to-end Masked Language Modeling with BERT](https://keras.io/examples/nlp/masked_language_modeling/) example to Keras 3.0 [TF Only Backend].

For example, here is the notebook link provided:
https://colab.research.google.com/drive/1O6uJdUeZzQMl7T6sKlMu5gZaUtM2U-nU?usp=sharing

cc: @fchollet 

The following describes the Git difference for the changed files:

<details><summary>Changes:</summary>

```
diff --git a/examples/nlp/masked_language_modeling.py b/examples/nlp/masked_language_modeling.py
index 6378079e..6997a2b1 100644
--- a/examples/nlp/masked_language_modeling.py
+++ b/examples/nlp/masked_language_modeling.py
@@ -43,10 +43,14 @@ Note: This example should be run with `tf-nightly`.
 Install `tf-nightly` via `pip install tf-nightly`.
 """
 
+import os
+
+os.environ["KERAS_BACKEND"] = "tensorflow"
+import keras_nlp
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-from tensorflow.keras.layers import TextVectorization
+from keras import layers
+from keras.layers import TextVectorization
 from dataclasses import dataclass
 import pandas as pd
 import numpy as np
@@ -264,13 +268,13 @@ def bert_module(query, key, value, i):
     attention_output = layers.MultiHeadAttention(
         num_heads=config.NUM_HEAD,
         key_dim=config.EMBED_DIM // config.NUM_HEAD,
-        name="encoder_{}/multiheadattention".format(i),
+        name="encoder_{}_multiheadattention".format(i),
     )(query, key, value)
-    attention_output = layers.Dropout(0.1, name="encoder_{}/att_dropout".format(i))(
+    attention_output = layers.Dropout(0.1, name="encoder_{}_att_dropout".format(i))(
         attention_output
     )
     attention_output = layers.LayerNormalization(
-        epsilon=1e-6, name="encoder_{}/att_layernormalization".format(i)
+        epsilon=1e-6, name="encoder_{}_att_layernormalization".format(i)
     )(query + attention_output)
 
     # Feed-forward layer
@@ -279,41 +283,25 @@ def bert_module(query, key, value, i):
             layers.Dense(config.FF_DIM, activation="relu"),
             layers.Dense(config.EMBED_DIM),
         ],
-        name="encoder_{}/ffn".format(i),
+        name="encoder_{}_ffn".format(i),
     )
     ffn_output = ffn(attention_output)
-    ffn_output = layers.Dropout(0.1, name="encoder_{}/ffn_dropout".format(i))(
+    ffn_output = layers.Dropout(0.1, name="encoder_{}_ffn_dropout".format(i))(
         ffn_output
     )
     sequence_output = layers.LayerNormalization(
-        epsilon=1e-6, name="encoder_{}/ffn_layernormalization".format(i)
+        epsilon=1e-6, name="encoder_{}_ffn_layernormalization".format(i)
     )(attention_output + ffn_output)
     return sequence_output
 
 
-def get_pos_encoding_matrix(max_len, d_emb):
-    pos_enc = np.array(
-        [
-            (
-                [pos / np.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]
-                if pos != 0
-                else np.zeros(d_emb)
-            )
-            for pos in range(max_len)
-        ]
-    )
-    pos_enc[1:, 0::2] = np.sin(pos_enc[1:, 0::2])  # dim 2i
-    pos_enc[1:, 1::2] = np.cos(pos_enc[1:, 1::2])  # dim 2i+1
-    return pos_enc
-
-
 loss_fn = keras.losses.SparseCategoricalCrossentropy(
-    reduction=tf.keras.losses.Reduction.NONE
+    reduction=None
 )
-loss_tracker = tf.keras.metrics.Mean(name="loss")
+loss_tracker = keras.metrics.Mean(name="loss")
 
 
-class MaskedLanguageModel(tf.keras.Model):
+class MaskedLanguageModel(keras.Model):
     def train_step(self, inputs):
         if len(inputs) == 3:
             features, labels, sample_weight = inputs
@@ -349,17 +337,14 @@ class MaskedLanguageModel(tf.keras.Model):
 
 
 def create_masked_language_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int64")
 
     word_embeddings = layers.Embedding(
         config.VOCAB_SIZE, config.EMBED_DIM, name="word_embedding"
     )(inputs)
-    position_embeddings = layers.Embedding(
-        input_dim=config.MAX_LEN,
-        output_dim=config.EMBED_DIM,
-        weights=[get_pos_encoding_matrix(config.MAX_LEN, config.EMBED_DIM)],
-        name="position_embedding",
-    )(tf.range(start=0, limit=config.MAX_LEN, delta=1))
+    position_embeddings = keras_nlp.layers.PositionEmbedding(
+      sequence_length=config.MAX_LEN
+    )(word_embeddings)
     embeddings = word_embeddings + position_embeddings
 
     encoder_output = embeddings
@@ -426,7 +411,7 @@ bert_masked_model.summary()
 """
 
 bert_masked_model.fit(mlm_ds, epochs=5, callbacks=[generator_callback])
-bert_masked_model.save("bert_mlm_imdb.h5")
+bert_masked_model.save("bert_mlm_imdb.keras")
 
 """
 ## Fine-tune a sentiment classification model
@@ -439,10 +424,10 @@ pretrained BERT features.
 
 # Load pretrained bert model
 mlm_model = keras.models.load_model(
-    "bert_mlm_imdb.h5", custom_objects={"MaskedLanguageModel": MaskedLanguageModel}
+    "bert_mlm_imdb.keras", custom_objects={"MaskedLanguageModel": MaskedLanguageModel}
 )
-pretrained_bert_model = tf.keras.Model(
-    mlm_model.input, mlm_model.get_layer("encoder_0/ffn_layernormalization").output
+pretrained_bert_model = keras.Model(
+    mlm_model.input, mlm_model.get_layer("encoder_0_ffn_layernormalization").output
 )
 
 # Freeze it
@@ -450,7 +435,7 @@ pretrained_bert_model.trainable = False
 
 
 def create_classifier_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int64")
     sequence_output = pretrained_bert_model(inputs)
     pooled_output = layers.GlobalMaxPooling1D()(sequence_output)
     hidden_layer = layers.Dense(64, activation="relu")(pooled_output)
(END)
```