### PR TITLE
Add new strings to process docstrings

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -27,6 +27,8 @@ class KerasDocumentationGenerator:
         docstring = docstring.replace("Returns:", "# Returns")
         docstring = docstring.replace("Example:", "# Example\n")
         docstring = docstring.replace("Examples:", "# Examples\n")
+        docstring = docstring.replace("Usage:", "# Usage\n")
+        docstring = docstring.replace("Sample usage:", "# Sample usage\n")
 
         docstring = re.sub(r"\nReference:\n\s*", "\n**Reference**\n\n", docstring)
         docstring = re.sub(r"\nReferences:\n\s*", "\n**References**\n\n", docstring)

--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -28,6 +28,7 @@ class KerasDocumentationGenerator:
         docstring = docstring.replace("Example:", "# Example\n")
         docstring = docstring.replace("Examples:", "# Examples\n")
         docstring = docstring.replace("Usage:", "# Usage\n")
+        docstring = docstring.replace("Example usage:", "# Example usage\n")
         docstring = docstring.replace("Sample usage:", "# Sample usage\n")
 
         docstring = re.sub(r"\nReference:\n\s*", "\n**Reference**\n\n", docstring)


### PR DESCRIPTION
Added `Usage:` `Example usage:` and `Sample usage:` to highlight in bold, which is having numerous entries in keras.io.

Example:
https://keras.io/api/keras_cv/layers/augmentation/random_augmentation_pipeline/
https://keras.io/api/keras_nlp/models/gemma/gemma_backbone/