### PR TITLE
Migrating Abstractive Text Summarization with BART example to Keras 3

### DIFF
--- a/examples/nlp/abstractive_summarization_with_bart.py
+++ b/examples/nlp/abstractive_summarization_with_bart.py
@@ -42,8 +42,8 @@ pip install git+https://github.com/keras-team/keras-nlp.git py7zr -q
 """
 
 """
-This examples uses [Keras Core](https://keras.io/keras_core/) to work in any of
-`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras Core is baked into
+This examples uses [Keras 3](https://keras.io/keras_3/) to work in any of
+`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras 3 is baked into
 KerasNLP, simply change the `"KERAS_BACKEND"` environment variable to select
 the backend of your choice. We select the JAX backend below.
 """
@@ -60,10 +60,9 @@ import py7zr
 import time
 
 import keras_nlp
+import keras
 import tensorflow as tf
 import tensorflow_datasets as tfds
-
-import keras_core as keras
 
 """
 Let's also define our hyperparameters.

--- a/examples/nlp/abstractive_summarization_with_bart.py
+++ b/examples/nlp/abstractive_summarization_with_bart.py
@@ -2,9 +2,10 @@
 Title: Abstractive Text Summarization with BART
 Author: [Abheesht Sharma](https://github.com/abheesht17/)
 Date created: 2023/07/08
-Last modified: 2023/07/08
+Last modified: 2024/03/20
 Description: Use KerasNLP to fine-tune BART on the abstractive summarization task.
 Accelerator: GPU
+Converted to Keras 3 by: [Sitam Meur](https://github.com/sitamgithub-MSIT)
 """
 
 """

--- a/examples/nlp/ipynb/abstractive_summarization_with_bart.ipynb
+++ b/examples/nlp/ipynb/abstractive_summarization_with_bart.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Abheesht Sharma](https://github.com/abheesht17/)<br>\n",
     "**Date created:** 2023/07/08<br>\n",
-    "**Last modified:** 2023/07/08<br>\n",
+    "**Last modified:** 2024/03/20<br>\n",
     "**Description:** Use KerasNLP to fine-tune BART on the abstractive summarization task."
    ]
   },
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -71,15 +71,15 @@
     "colab_type": "text"
    },
    "source": [
-    "This examples uses [Keras Core](https://keras.io/keras_core/) to work in any of\n",
-    "`\"tensorflow\"`, `\"jax\"` or `\"torch\"`. Support for Keras Core is baked into\n",
+    "This examples uses [Keras 3](https://keras.io/keras_3/) to work in any of\n",
+    "`\"tensorflow\"`, `\"jax\"` or `\"torch\"`. Support for Keras 3 is baked into\n",
     "KerasNLP, simply change the `\"KERAS_BACKEND\"` environment variable to select\n",
     "the backend of your choice. We select the JAX backend below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -111,10 +111,9 @@
     "import time\n",
     "\n",
     "import keras_nlp\n",
+    "import keras\n",
     "import tensorflow as tf\n",
-    "import tensorflow_datasets as tfds\n",
-    "\n",
-    "import keras_core as keras"
+    "import tensorflow_datasets as tfds"
    ]
   },
   {
@@ -128,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -156,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -187,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -215,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -255,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -285,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -322,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -351,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -399,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/examples/nlp/md/abstractive_summarization_with_bart.md
+++ b/examples/nlp/md/abstractive_summarization_with_bart.md
@@ -2,7 +2,7 @@
 
 **Author:** [Abheesht Sharma](https://github.com/abheesht17/)<br>
 **Date created:** 2023/07/08<br>
-**Last modified:** 2023/07/08<br>
+**Last modified:** 2024/03/20<br>
 **Description:** Use KerasNLP to fine-tune BART on the abstractive summarization task.
 
 
@@ -59,8 +59,8 @@ couple of utility libraries.
 
 ```
 </div>
-This examples uses [Keras Core](https://keras.io/keras_core/) to work in any of
-`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras Core is baked into
+This examples uses [Keras 3](https://keras.io/keras_3) to work in any of
+`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras 3 is baked into
 KerasNLP, simply change the `"KERAS_BACKEND"` environment variable to select
 the backend of your choice. We select the JAX backend below.
 
@@ -79,10 +79,9 @@ import py7zr
 import time
 
 import keras_nlp
+import keras
 import tensorflow as tf
 import tensorflow_datasets as tfds
-
-import keras_core as keras
 ```
 
 <div class="k-default-codeblock">


### PR DESCRIPTION
This PR changes the [Abstractive Text Summarization with BART](https://keras.io/examples/nlp/abstractive_summarization_with_bart/) example to Keras 3.0

For example, here is the notebook link provided:
https://colab.research.google.com/drive/1lqtjRaiBrSlfdmlJPuHB8ifYAJFY96eb?usp=sharing

cc: @fchollet 

The following describes the Git difference for the changed files:

<details><summary>Changes:</summary>

```
diff --git a/examples/nlp/abstractive_summarization_with_bart.py b/examples/nlp/abstractive_summarization_with_bart.py
index f712383e..fc14a4b0 100644
--- a/examples/nlp/abstractive_summarization_with_bart.py
+++ b/examples/nlp/abstractive_summarization_with_bart.py
@@ -42,8 +42,8 @@ pip install git+https://github.com/keras-team/keras-nlp.git py7zr -q
 """
 
 """
-This examples uses [Keras Core](https://keras.io/keras_core/) to work in any of
-`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras Core is baked into
+This examples uses [Keras 3](https://keras.io/keras_3/) to work in any of
+`"tensorflow"`, `"jax"` or `"torch"`. Support for Keras 3 is baked into
 KerasNLP, simply change the `"KERAS_BACKEND"` environment variable to select
 the backend of your choice. We select the JAX backend below.
 """
@@ -60,11 +60,10 @@ import py7zr
 import time
 
 import keras_nlp
+import keras
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
-import keras_core as keras
-
 """
 Let's also define our hyperparameters.
 """
(END)
```