### PR TITLE
Set input dtype to int32 for categorical features in tabtransformer example

### DIFF
--- a/examples/structured_data/ipynb/tabtransformer.ipynb
+++ b/examples/structured_data/ipynb/tabtransformer.ipynb
@@ -409,7 +409,7 @@
     "            )\n",
     "        else:\n",
     "            inputs[feature_name] = layers.Input(\n",
-    "                name=feature_name, shape=(), dtype=\"float32\"\n",
+    "                name=feature_name, shape=(), dtype=\"int32\"\n",
     "            )\n",
     "    return inputs\n",
     ""
@@ -489,7 +489,7 @@
     "def create_mlp(hidden_units, dropout_rate, activation, normalization_layer, name=None):\n",
     "    mlp_layers = []\n",
     "    for units in hidden_units:\n",
-    "        mlp_layers.append(normalization_layer()),\n",
+    "        mlp_layers.append(normalization_layer())\n",
     "        mlp_layers.append(layers.Dense(units, activation=activation))\n",
     "        mlp_layers.append(layers.Dropout(dropout_rate))\n",
     "\n",

--- a/examples/structured_data/md/tabtransformer.md
+++ b/examples/structured_data/md/tabtransformer.md
@@ -303,7 +303,7 @@ def create_model_inputs():
             )
         else:
             inputs[feature_name] = layers.Input(
-                name=feature_name, shape=(), dtype="float32"
+                name=feature_name, shape=(), dtype="int32"
             )
     return inputs
 
@@ -359,7 +359,7 @@ def encode_inputs(inputs, embedding_dims):
 def create_mlp(hidden_units, dropout_rate, activation, normalization_layer, name=None):
     mlp_layers = []
     for units in hidden_units:
-        mlp_layers.append(normalization_layer()),
+        mlp_layers.append(normalization_layer())
         mlp_layers.append(layers.Dense(units, activation=activation))
         mlp_layers.append(layers.Dropout(dropout_rate))
 

--- a/examples/structured_data/tabtransformer.py
+++ b/examples/structured_data/tabtransformer.py
@@ -276,7 +276,7 @@ def create_model_inputs():
             )
         else:
             inputs[feature_name] = layers.Input(
-                name=feature_name, shape=(), dtype="float32"
+                name=feature_name, shape=(), dtype="int32"
             )
     return inputs
 
@@ -328,7 +328,7 @@ def encode_inputs(inputs, embedding_dims):
 def create_mlp(hidden_units, dropout_rate, activation, normalization_layer, name=None):
     mlp_layers = []
     for units in hidden_units:
-        mlp_layers.append(normalization_layer()),
+        mlp_layers.append(normalization_layer())
         mlp_layers.append(layers.Dense(units, activation=activation))
         mlp_layers.append(layers.Dropout(dropout_rate))
 


### PR DESCRIPTION
In `create_model_inputs`, the same inputs were created for both numeric and categorical variables, so I updated the dtype for categorical variables