### PR TITLE
fix: broken json file issue for tabtransformer jupyter notebook

### DIFF
--- a/examples/structured_data/ipynb/tabtransformer.ipynb
+++ b/examples/structured_data/ipynb/tabtransformer.ipynb
@@ -799,7 +799,7 @@
     "examples, a pre-training procedure can be employed to train the Transformer layers using unlabeled data.\n",
     "This is followed by fine-tuning of the pre-trained Transformer layers along with\n",
     "the top MLP layer using the labeled data.\n",
-    "\n",
+    "\n"
     ]
   }
  ],

--- a/examples/structured_data/tabtransformer.py
+++ b/examples/structured_data/tabtransformer.py
@@ -566,5 +566,4 @@ For a scenario where there are a few labeled examples and a large number of unla
 examples, a pre-training procedure can be employed to train the Transformer layers using unlabeled data.
 This is followed by fine-tuning of the pre-trained Transformer layers along with
 the top MLP layer using the labeled data.
-
 """


### PR DESCRIPTION
There is a broken link on colab hyperlink at https://keras.io/examples/structured_data/tabtransformer/ 