### PR TITLE
Fix issue with invert_multi_hot function

### DIFF
--- a/examples/nlp/multi_label_classification.py
+++ b/examples/nlp/multi_label_classification.py
@@ -30,16 +30,6 @@ Additionally, you can also find the dataset on
 ## Imports
 """
 
-from tensorflow.keras import layers
-from tensorflow import keras
-import tensorflow as tf
-
-from sklearn.model_selection import train_test_split
-from ast import literal_eval
-
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
 
 """
 ## Perform exploratory data analysis
@@ -48,6 +38,14 @@ In this section, we first load the dataset into a `pandas` dataframe and then pe
 some basic exploratory data analysis (EDA).
 """
 
+from tensorflow.keras import layers
+from tensorflow import keras
+import tensorflow as tf
+from sklearn.model_selection import train_test_split
+from ast import literal_eval
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
 arxiv_data = pd.read_csv(
     "https://github.com/soumik12345/multi-label-text-classification/releases/download/v0.2/arxiv_data.csv"
 )
@@ -152,7 +150,7 @@ vocab = lookup.get_vocabulary()
 
 def invert_multi_hot(encoded_labels):
     """Reverse a single multi-hot encoded label to a tuple of vocab terms."""
-    hot_indices = np.argwhere(encoded_labels == 1.0)[..., 0]
+    hot_indices = np.nonzero(encoded_labels)[1]
     return np.take(vocab, hot_indices)
 
 
@@ -404,7 +402,8 @@ for i, text in enumerate(text_batch[:5]):
             reverse=True,
         )
     ][:3]
-    print(f"Predicted Label(s): ({', '.join([label for label in top_3_labels])})")
+    print(
+        f"Predicted Label(s): ({', '.join([label for label in top_3_labels])})")
     print(" ")
 
 """


### PR DESCRIPTION
The original `invert_multi_hot` function does not correctly reverse a single multi-hot encoded label to a tuple of vocabulary terms. There are a few issues with the original implementation that prevent it from working as expected:
1. It raises a `TypeError: Cannot convert 1.0 to EagerTensor of dtype int64` if `encoded_labels` are not converted to a NumPy array.
2. The use of `[..., 0]` for indexing does not correctly select the proper elements, causing incorrect behavior.

**Original Function**:
```python
def invert_multi_hot(encoded_labels):
    """Reverse a single multi-hot encoded label to a tuple of vocab terms."""
    hot_indices = np.argwhere(encoded_labels == 1.0)[..., 0]
    return np.take(vocab, hot_indices)
```
**Reasons** 

1. **TypeError Issue:** The original function attempts to use NumPy functions directly on TensorFlow tensors. Specifically, `np.argwhere(encoded_labels == 1.0)` does not handle TensorFlow tensors correctly without explicit conversion to a NumPy array. This leads to an error `TypeError: Cannot convert 1.0 to EagerTensor of dtype int64` because NumPy operations on TensorFlow tensors can result in unexpected type conversions
2. **Incorrect Indexing with `[..., 0]`**: The use of `[..., 0]` in `np.argwhere(encoded_labels == 1.0)[..., 0]` attempts to select the first element along the last axis. This approach does not correctly identify the indices of non-zero elements in the multi-hot encoded labels, leading to incorrect output.  However, this can be fixed by using 1 instead of 0 but only after conversion. 

To address these issues, I have modified the `invert_multi_hot` function to correctly handle multi-hot encoded labels by using `np.nonzero(encoded_labels)[1]`. This approach ensures that the function accurately identifies the column indices where the elements are non-zero, which correspond to the "hot" indices in the multi-hot encoding. Additionally, this approach works seamlessly with both TensorFlow tensors and NumPy arrays without requiring explicit conversion. 

```python
def invert_multi_hot(encoded_labels):
    """Reverse a single multi-hot encoded label to a tuple of vocab terms."""
    hot_indices = np.nonzero(encoded_labels)[1]
    return np.take(vocab, hot_indices)
```
I have tested the corrected version of the function with various multi-hot encoded labels to verify its correctness. The function now accurately reverses the multi-hot encoding and returns the corresponding vocabulary terms. I hope this helps. I welcome any feedback or suggestions for further improvement. Thanks! 