### PR TITLE
Fix source links aways contain an extra slash

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -147,7 +147,7 @@ def make_source_link(cls, project_url):
     line = inspect.getsourcelines(cls)[-1]
     return (
         f'<span style="float:right;">'
-        f"[[source]]({project_url}/{path}.py#L{line})"
+        f"[[source]]({project_url}{path}.py#L{line})"
         f"</span>"
     )
 


### PR DESCRIPTION
like stated here:
https://github.com/keras-team/keras-io/blob/master/scripts/docstrings.py#L135
and here:
https://github.com/keras-team/keras-io/blob/master/scripts/autogen.py#L46
`project_url` always already has a trailing slash.