### PR TITLE
fix metric.reset_state spelling error

### DIFF
--- a/guides/ipynb/keras_tuner/getting_started.ipynb
+++ b/guides/ipynb/keras_tuner/getting_started.ipynb
@@ -895,7 +895,7 @@
     "    def result(self):\n",
     "        return self.sum / ops.cast(self.count, \"float32\")\n",
     "\n",
-    "    def reset_states(self):\n",
+    "    def reset_state(self):\n",
     "        self.sum.assign(0)\n",
     "        self.count.assign(0)\n",
     ""

--- a/guides/keras_tuner/getting_started.py
+++ b/guides/keras_tuner/getting_started.py
@@ -607,7 +607,7 @@ class CustomMetric(keras.metrics.Metric):
     def result(self):
         return self.sum / ops.cast(self.count, "float32")
 
-    def reset_states(self):
+    def reset_state(self):
         self.sum.assign(0)
         self.count.assign(0)
 

--- a/guides/md/keras_tuner/getting_started.md
+++ b/guides/md/keras_tuner/getting_started.md
@@ -1540,7 +1540,7 @@ class CustomMetric(keras.metrics.Metric):
     def result(self):
         return self.sum / ops.cast(self.count, "float32")
 
-    def reset_states(self):
+    def reset_state(self):
         self.sum.assign(0)
         self.count.assign(0)
 

--- a/templates/api/metrics/index.md
+++ b/templates/api/metrics/index.md
@@ -177,7 +177,7 @@ class BinaryTruePositives(keras.metrics.Metric):
   def result(self):
     return self.true_positives
 
-  def reset_states(self):
+  def reset_state(self):
     self.true_positives.assign(0)
 
 m = BinaryTruePositives()


### PR DESCRIPTION
The method is called reset_state in the source.

Source: https://github.com/keras-team/keras/blob/master/keras/src/metrics/metric.py