### PR TITLE
Redirect Keras-cv to /src

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -142,7 +142,7 @@ def make_source_link(cls, project_url):
             f"current imported package version {module_version}"
         )
     path = cls.__module__.replace(".", "/")
-    if base_module in ("keras_cv", "tf_keras"):
+    if base_module in ("tf_keras"):
         path = path.replace("/src/", "/")
     line = inspect.getsourcelines(cls)[-1]
     return (


### PR DESCRIPTION
Redirect Keras-cv to /src since keras-cv is moved under /src/
Fixes: https://github.com/keras-team/keras-io/issues/1892