### PR TITLE
Correct minor issue in the guide "Understanding masking & padding"

### DIFF
--- a/guides/ipynb/understanding_masking_and_padding.ipynb
+++ b/guides/ipynb/understanding_masking_and_padding.ipynb
@@ -526,7 +526,7 @@
     "        broadcast_float_mask = tf.expand_dims(tf.cast(mask, \"float32\"), -1)\n",
     "        inputs_exp = tf.exp(inputs) * broadcast_float_mask\n",
     "        inputs_sum = tf.reduce_sum(\n",
-    "            inputs_exp * broadcast_float_mask, axis=-1, keepdims=True\n",
+    "            inputs_exp * broadcast_float_mask, axis=1, keepdims=True\n",
     "        )\n",
     "        return inputs_exp / inputs_sum\n",
     "\n",

--- a/guides/md/understanding_masking_and_padding.md
+++ b/guides/md/understanding_masking_and_padding.md
@@ -418,7 +418,7 @@ class TemporalSoftmax(keras.layers.Layer):
         broadcast_float_mask = tf.expand_dims(tf.cast(mask, "float32"), -1)
         inputs_exp = tf.exp(inputs) * broadcast_float_mask
         inputs_sum = tf.reduce_sum(
-            inputs_exp * broadcast_float_mask, axis=-1, keepdims=True
+            inputs_exp * broadcast_float_mask, axis=1, keepdims=True
         )
         return inputs_exp / inputs_sum
 


### PR DESCRIPTION
Correct the axis for computing the denominator of softmax in the example which creates a `TemporalSoftmax` class.