### PR TITLE
Migrating numpy namespace to numpy 2.0 in writing_your_own_callbacks.py, .md and .ipynb files

### DIFF
--- a/guides/ipynb/writing_your_own_callbacks.ipynb
+++ b/guides/ipynb/writing_your_own_callbacks.ipynb
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -144,8 +144,7 @@
     "        loss=\"mean_squared_error\",\n",
     "        metrics=[\"mean_absolute_error\"],\n",
     "    )\n",
-    "    return model\n",
-    ""
+    "    return model\n"
    ]
   },
   {
@@ -159,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -194,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -256,8 +255,7 @@
     "\n",
     "    def on_predict_batch_end(self, batch, logs=None):\n",
     "        keys = list(logs.keys())\n",
-    "        print(\"...Predicting: end of batch {}; got log keys: {}\".format(batch, keys))\n",
-    ""
+    "        print(\"...Predicting: end of batch {}; got log keys: {}\".format(batch, keys))\n"
    ]
   },
   {
@@ -271,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -309,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -402,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },
@@ -429,7 +427,7 @@
     "        # The epoch the training stops at.\n",
     "        self.stopped_epoch = 0\n",
     "        # Initialize the best as infinity.\n",
-    "        self.best = np.Inf\n",
+    "        self.best = np.inf\n",
     "\n",
     "    def on_epoch_end(self, epoch, logs=None):\n",
     "        current = logs.get(\"loss\")\n",
@@ -478,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab_type": "code"
    },

--- a/guides/md/writing_your_own_callbacks.md
+++ b/guides/md/writing_your_own_callbacks.md
@@ -408,7 +408,7 @@ class EarlyStoppingAtMinLoss(keras.callbacks.Callback):
         # The epoch the training stops at.
         self.stopped_epoch = 0
         # Initialize the best as infinity.
-        self.best = np.Inf
+        self.best = np.inf
 
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get("loss")

--- a/guides/writing_your_own_callbacks.py
+++ b/guides/writing_your_own_callbacks.py
@@ -305,7 +305,7 @@ class EarlyStoppingAtMinLoss(keras.callbacks.Callback):
         # The epoch the training stops at.
         self.stopped_epoch = 0
         # Initialize the best as infinity.
-        self.best = np.Inf
+        self.best = np.inf
 
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get("loss")


### PR DESCRIPTION
Numpy 2.0 deprecates part of their namespace, see https://numpy.org/doc/stable/numpy_2_0_migration_guide.html for all details.
Keras is affected by **np.Inf** -> **np.inf**