### PR TITLE
Fix autogen.py try to install removed layer

### DIFF
--- a/scripts/hub_api_master.py
+++ b/scripts/hub_api_master.py
@@ -1295,11 +1295,6 @@ PREPROCESSING_LAYERS_MASTER = {
             "generate": ["keras_hub.layers.ImageConverter"],
         },
         {
-            "path": "resizing_image_converter",
-            "title": "ResizingImageConverter layer",
-            "generate": ["keras_hub.layers.ResizingImageConverter"],
-        },
-        {
             "path": "start_end_packer",
             "title": "StartEndPacker layer",
             "generate": ["keras_hub.layers.StartEndPacker"],


### PR DESCRIPTION
I tried to setup keras-io with docker and got following error.

command:
```
docker build -t keras-io . && docker run --rm -p 8000:8000 keras-io
```

error:
```
10.66 ...Processing api/keras_hub/preprocessing_layers/resizing_image_converter
10.66 Traceback (most recent call last):
10.66   File "/scripts/docstrings.py", line 121, in import_object
10.66     last_object_got = importlib.import_module(".".join(seen_names))
10.66   File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
10.66     return _bootstrap._gcd_import(name[level:], package, level)
10.66   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
10.66   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
10.66   File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
10.66 ModuleNotFoundError: No module named 'keras_hub.layers.ResizingImageConverter'
10.66 
10.66 During handling of the above exception, another exception occurred:
10.66 
10.66 Traceback (most recent call last):
10.66   File "/scripts/autogen.py", line 1165, in <module>
10.66     keras_io.make_md_sources()
10.66   File "/scripts/autogen.py", line 130, in make_md_sources
10.66     self.make_md_source_for_entry(self.master, path_stack=[], title_stack=[])
10.66   File "/scripts/autogen.py", line 595, in make_md_source_for_entry
10.66     self.make_md_source_for_entry(entry, path_stack[:], title_stack[:])
10.66   File "/scripts/autogen.py", line 595, in make_md_source_for_entry
10.66     self.make_md_source_for_entry(entry, path_stack[:], title_stack[:])
10.66   File "/scripts/autogen.py", line 595, in make_md_source_for_entry
10.66     self.make_md_source_for_entry(entry, path_stack[:], title_stack[:])
10.66   [Previous line repeated 1 more time]
10.66   File "/scripts/autogen.py", line 527, in make_md_source_for_entry
10.66     generated_md += self.docstring_printer.render(element)
10.66   File "/scripts/docstrings.py", line 73, in render
10.66     object_ = import_object(element)
10.66   File "/scripts/docstrings.py", line 124, in import_object
10.66     last_object_got = getattr(last_object_got, name)
10.66 AttributeError: module 'keras_hub.layers' has no attribute 'ResizingImageConverter'
------
Dockerfile:9
--------------------
   7 |     COPY ./ ./
   8 |     WORKDIR scripts
   9 | >>> RUN python autogen.py make
  10 |     
  11 |     CMD ["python", "-u", "autogen.py", "serve"]
--------------------
ERROR: failed to solve: process "/bin/sh -c python autogen.py make" did not complete successfully: exit code: 1
```
I removed ResizingImageConverter since resizing_image_converter.py seems to be removed in [this pull request](https://github.com/keras-team/keras-hub/pull/1901).
