### PR TITLE
Add classification_with_keras_hub to `guides_master.py`

### DIFF
--- a/scripts/guides_master.py
+++ b/scripts/guides_master.py
@@ -79,6 +79,10 @@ HUB_GUIDES_MASTER = {
             "path": "stable_diffusion_3_in_keras_hub",
             "title": "Stable Diffusion 3 in KerasHub",
         },
+        {
+            "path": "classification_with_keras_hub",
+            "title": "Classification with KerasHub",
+        },
     ],
 }
 


### PR DESCRIPTION
Adds the recently merged classification guide (#1948), so that it will be shown on the [Keras.io](http://keras.io/) page.