### PR TITLE
fix build failure

### DIFF
--- a/scripts/api_master.py
+++ b/scripts/api_master.py
@@ -614,11 +614,11 @@ API_MASTER = {
                                     "title": "MelSpectrogram layer",
                                     "generate": ["keras.layers.MelSpectrogram"],
                                 },
-                                {
-                                    "path": "stft_spectrogram",
-                                    "title": "STFTSpectrogram layer",
-                                    "generate": ["keras.layers.STFTSpectrogram"],
-                                },
+                                # {
+                                #     "path": "stft_spectrogram",
+                                #     "title": "STFTSpectrogram layer",
+                                #     "generate": ["keras.layers.STFTSpectrogram"],
+                                # },
                             ],
                         },
                     ],


### PR DESCRIPTION
`STFTSpectrogram` is not part of Keras 3.6 yet and causing build failure, commenting the part till it will be available as part of next stable release.