### PR TITLE
Load models from Kaggle Models' GCS bucket

### DIFF
--- a/examples/vision/cait.py
+++ b/examples/vision/cait.py
@@ -790,7 +790,7 @@ as well as
 ## Load a pretrained model
 """
 
-model_gcs_path = "gs://tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed"
+model_gcs_path = "gs://kaggle-tfhub-models-uncompressed/tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed"
 pretrained_model = keras.Sequential(
     [keras.layers.TFSMLayer(model_gcs_path, call_endpoint="serving_default")]
 )

--- a/examples/vision/ipynb/cait.ipynb
+++ b/examples/vision/ipynb/cait.ipynb
@@ -27,7 +27,7 @@
     "Touvron et al. Depth scaling, i.e. increasing the model depth for obtaining better\n",
     "performance and generalization has been quite successful for convolutional neural\n",
     "networks ([Tan et al.](https://arxiv.org/abs/1905.11946),\n",
-    "[Doll\u00e1r et al.](https://arxiv.org/abs/2103.06877), for example). But applying\n",
+    "[Dollár et al.](https://arxiv.org/abs/2103.06877), for example). But applying\n",
     "the same model scaling principles to\n",
     "Vision Transformers ([Dosovitskiy et al.](https://arxiv.org/abs/2010.11929)) doesn't\n",
     "translate equally well -- their performance gets saturated quickly with depth scaling.\n",
@@ -154,8 +154,7 @@
     "        )\n",
     "\n",
     "    def call(self, x, training=False):\n",
-    "        return x * self.gamma\n",
-    ""
+    "        return x * self.gamma\n"
    ]
   },
   {
@@ -203,8 +202,7 @@
     "            )\n",
     "            random_tensor = ops.floor(random_tensor)\n",
     "            return (x / keep_prob) * random_tensor\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -326,8 +324,7 @@
     "        x_cls = self.proj(x_cls)\n",
     "        x_cls = self.proj_drop(x_cls, training=training)\n",
     "\n",
-    "        return x_cls, attn\n",
-    ""
+    "        return x_cls, attn\n"
    ]
   },
   {
@@ -430,8 +427,7 @@
     "        x = self.proj(x)\n",
     "        x = self.proj_drop(x, training=training)\n",
     "\n",
-    "        return x, attn\n",
-    ""
+    "        return x, attn\n"
    ]
   },
   {
@@ -464,8 +460,7 @@
     "            bias_initializer=keras.initializers.RandomNormal(stddev=1e-6),\n",
     "        )(x)\n",
     "        x = layers.Dropout(dropout_rate)(x)\n",
-    "    return x\n",
-    ""
+    "    return x\n"
    ]
   },
   {
@@ -606,8 +601,7 @@
     "    x4 = StochasticDepth(sd_prob)(x4) if sd_prob else x4\n",
     "    outputs = layers.Add()([x2, x4])\n",
     "\n",
-    "    return keras.Model(encoded_patches, [outputs, attn_scores], name=name)\n",
-    ""
+    "    return keras.Model(encoded_patches, [outputs, attn_scores], name=name)\n"
    ]
   },
   {
@@ -798,8 +792,7 @@
     "            (x, sa_ffn_attn, ca_ffn_attn)\n",
     "            if self.pre_logits\n",
     "            else (self.head(x), sa_ffn_attn, ca_ffn_attn)\n",
-    "        )\n",
-    ""
+    "        )\n"
    ]
   },
   {
@@ -889,8 +882,7 @@
     "    config[\"pre_logits\"] = pre_logits\n",
     "    config[\"num_classes\"] = num_classes\n",
     "\n",
-    "    return config\n",
-    ""
+    "    return config\n"
    ]
   },
   {
@@ -974,7 +966,7 @@
    },
    "outputs": [],
    "source": [
-    "model_gcs_path = \"gs://tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed\"\n",
+    "model_gcs_path = \"gs://kaggle-tfhub-models-uncompressed/tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed\"\n",
     "pretrained_model = keras.Sequential(\n",
     "    [keras.layers.TFSMLayer(model_gcs_path, call_endpoint=\"serving_default\")]\n",
     ")"
@@ -1024,8 +1016,7 @@
     "    image_bytes = io.BytesIO(urlopen(url).read())\n",
     "    image = PIL.Image.open(image_bytes)\n",
     "    preprocessed_image = preprocess_image(image)\n",
-    "    return image, preprocessed_image\n",
-    ""
+    "    return image, preprocessed_image\n"
    ]
   },
   {
@@ -1225,8 +1216,7 @@
     "        interpolation=\"bicubic\",\n",
     "    )\n",
     "\n",
-    "    return attentions\n",
-    ""
+    "    return attentions\n"
    ]
   },
   {

--- a/examples/vision/md/cait.md
+++ b/examples/vision/md/cait.md
@@ -804,7 +804,7 @@ as well as
 
 
 ```python
-model_gcs_path = "gs://tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed"
+model_gcs_path = "gs://kaggle-tfhub-models-uncompressed/tfhub-modules/sayakpaul/cait_xxs24_224/1/uncompressed"
 pretrained_model = keras.Sequential(
     [keras.layers.TFSMLayer(model_gcs_path, call_endpoint="serving_default")]
 )


### PR DESCRIPTION
This bucket should be preferred after tfhub.dev has been migrated to Kaggle Models in November 2023.