### PR TITLE
Fix preset table doc links

### DIFF
--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -32,7 +32,7 @@ EXAMPLES_GH_LOCATION = Path("keras-team") / "keras-io" / "blob" / "master" / "ex
 GUIDES_GH_LOCATION = Path("keras-team") / "keras-io" / "blob" / "master" / "guides"
 KERAS_TEAM_GH = "https://github.com/keras-team"
 PROJECT_URL = {
-    "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.6.0/",
+    "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.7.0/",
     "keras_tuner": f"{KERAS_TEAM_GH}/keras-tuner/tree/v1.4.7/",
     "keras_hub": f"{KERAS_TEAM_GH}/keras-hub/tree/v0.17.0/",
     "tf_keras": f"{KERAS_TEAM_GH}/tf-keras/tree/v2.18.0/",


### PR DESCRIPTION
We had relative links that broke when we changed the site structure, switch to absolute links.

Also:
- Better sort order for preset table.
- Use less metadata in the table.