### PR TITLE
A Vision Transformer without Attention example to Keras 3

### DIFF
--- a/examples/vision/ipynb/shiftvit.ipynb
+++ b/examples/vision/ipynb/shiftvit.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Ritwik Raha](https://twitter.com/ritwik_raha), [Shivalika Singh](https://www.linkedin.com/in/shivalika-singh/)<br>\n",
     "**Date created:** 2022/02/24<br>\n",
-    "**Last modified:** 2022/10/15<br>\n",
+    "**Last modified:** 2024/12/06<br>\n",
     "**Description:** A minimal implementation of ShiftViT."
    ]
   },
@@ -39,19 +39,7 @@
     "In this example, we minimally implement the paper with close alignement to the author's\n",
     "[official implementation](https://github.com/microsoft/SPACH/blob/main/models/shiftvit.py).\n",
     "\n",
-    "This example requires TensorFlow 2.9 or higher, as well as TensorFlow Addons, which can\n",
-    "be installed using the following command:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install -qq -U tensorflow-addons"
+    "This example requires TensorFlow 2.9 or higher."
    ]
   },
   {
@@ -74,10 +62,10 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "import keras\n",
+    "from keras import ops\n",
+    "from keras import layers\n",
     "import tensorflow as tf\n",
-    "from tensorflow import keras\n",
-    "from tensorflow.keras import layers\n",
-    "import tensorflow_addons as tfa\n",
     "\n",
     "import pathlib\n",
     "import glob\n",
@@ -237,8 +225,7 @@
     "            layers.Rescaling(1 / 255.0),\n",
     "        ]\n",
     "    )\n",
-    "    return data_augmentation\n",
-    ""
+    "    return data_augmentation\n"
    ]
   },
   {
@@ -341,7 +328,7 @@
     "            [\n",
     "                layers.Dense(\n",
     "                    units=initial_filters,\n",
-    "                    activation=tf.nn.gelu,\n",
+    "                    activation=\"gelu\",\n",
     "                ),\n",
     "                layers.Dropout(rate=self.mlp_dropout_rate),\n",
     "                layers.Dense(units=input_channels),\n",
@@ -351,8 +338,7 @@
     "\n",
     "    def call(self, x):\n",
     "        x = self.mlp(x)\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -389,16 +375,18 @@
     "    def __init__(self, drop_path_prob, **kwargs):\n",
     "        super().__init__(**kwargs)\n",
     "        self.drop_path_prob = drop_path_prob\n",
+    "        self.seed_generator = keras.random.SeedGenerator(1337)\n",
     "\n",
     "    def call(self, x, training=False):\n",
     "        if training:\n",
     "            keep_prob = 1 - self.drop_path_prob\n",
-    "            shape = (tf.shape(x)[0],) + (1,) * (len(tf.shape(x)) - 1)\n",
-    "            random_tensor = keep_prob + tf.random.uniform(shape, 0, 1)\n",
-    "            random_tensor = tf.floor(random_tensor)\n",
+    "            shape = (ops.shape(x)[0],) + (1,) * (len(ops.shape(x)) - 1)\n",
+    "            random_tensor = keep_prob + keras.random.uniform(\n",
+    "                shape, 0, 1, seed=self.seed_generator\n",
+    "            )\n",
+    "            random_tensor = ops.floor(random_tensor)\n",
     "            return (x / keep_prob) * random_tensor\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -523,17 +511,17 @@
     "            offset_width = 0\n",
     "            target_height = self.shift_pixel\n",
     "            target_width = 0\n",
-    "        crop = tf.image.crop_to_bounding_box(\n",
+    "        crop = ops.image.crop_images(\n",
     "            x,\n",
-    "            offset_height=offset_height,\n",
-    "            offset_width=offset_width,\n",
+    "            top_cropping=offset_height,\n",
+    "            left_cropping=offset_width,\n",
     "            target_height=self.H - target_height,\n",
     "            target_width=self.W - target_width,\n",
     "        )\n",
-    "        shift_pad = tf.image.pad_to_bounding_box(\n",
+    "        shift_pad = ops.image.pad_images(\n",
     "            crop,\n",
-    "            offset_height=offset_height,\n",
-    "            offset_width=offset_width,\n",
+    "            top_padding=offset_height,\n",
+    "            left_padding=offset_width,\n",
     "            target_height=self.H,\n",
     "            target_width=self.W,\n",
     "        )\n",
@@ -541,7 +529,7 @@
     "\n",
     "    def call(self, x, training=False):\n",
     "        # Split the feature maps\n",
-    "        x_splits = tf.split(x, num_or_size_splits=self.C // self.num_div, axis=-1)\n",
+    "        x_splits = ops.split(x, indices_or_sections=self.C // self.num_div, axis=-1)\n",
     "\n",
     "        # Shift the feature maps\n",
     "        x_splits[0] = self.get_shift_pad(x_splits[0], mode=\"left\")\n",
@@ -550,13 +538,12 @@
     "        x_splits[3] = self.get_shift_pad(x_splits[3], mode=\"down\")\n",
     "\n",
     "        # Concatenate the shifted and unshifted feature maps\n",
-    "        x = tf.concat(x_splits, axis=-1)\n",
+    "        x = ops.concatenate(x_splits, axis=-1)\n",
     "\n",
     "        # Add the residual connection\n",
     "        shortcut = x\n",
     "        x = shortcut + self.drop_path(self.mlp(self.layer_norm(x)), training=training)\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -622,8 +609,7 @@
     "        # Apply the patch merging algorithm on the feature maps\n",
     "        x = self.layer_norm(x)\n",
     "        x = self.reduction(x)\n",
-    "        return x\n",
-    ""
+    "        return x\n"
    ]
   },
   {
@@ -737,8 +723,7 @@
     "                \"mlp_expand_ratio\": self.mlp_expand_ratio,\n",
     "            }\n",
     "        )\n",
-    "        return config\n",
-    ""
+    "        return config\n"
    ]
   },
   {
@@ -903,8 +888,7 @@
     "            x = stage(x, training=False)\n",
     "        x = self.global_avg_pool(x)\n",
     "        logits = self.classifier(x)\n",
-    "        return logits\n",
-    ""
+    "        return logits\n"
    ]
   },
   {
@@ -979,7 +963,7 @@
     "        self.lr_max = lr_max\n",
     "        self.warmup_steps = warmup_steps\n",
     "        self.total_steps = total_steps\n",
-    "        self.pi = tf.constant(np.pi)\n",
+    "        self.pi = ops.array(np.pi)\n",
     "\n",
     "    def __call__(self, step):\n",
     "        # Check whether the total number of steps is larger than the warmup\n",
@@ -993,10 +977,10 @@
     "        # `cos_annealed_lr` is a graph that increases to 1 from the initial\n",
     "        # step to the warmup step. After that this graph decays to -1 at the\n",
     "        # final step mark.\n",
-    "        cos_annealed_lr = tf.cos(\n",
+    "        cos_annealed_lr = ops.cos(\n",
     "            self.pi\n",
-    "            * (tf.cast(step, tf.float32) - self.warmup_steps)\n",
-    "            / tf.cast(self.total_steps - self.warmup_steps, tf.float32)\n",
+    "            * (ops.cast(step, dtype=\"float32\") - self.warmup_steps)\n",
+    "            / ops.cast(self.total_steps - self.warmup_steps, dtype=\"float32\")\n",
     "        )\n",
     "\n",
     "        # Shift the mean of the `cos_annealed_lr` graph to 1. Now the grpah goes\n",
@@ -1021,20 +1005,18 @@
     "\n",
     "            # With the formula for a straight line (y = mx+c) build the warmup\n",
     "            # schedule\n",
-    "            warmup_rate = slope * tf.cast(step, tf.float32) + self.lr_start\n",
+    "            warmup_rate = slope * ops.cast(step, dtype=\"float32\") + self.lr_start\n",
     "\n",
     "            # When the current step is lesser that warmup steps, get the line\n",
     "            # graph. When the current step is greater than the warmup steps, get\n",
     "            # the scaled cos graph.\n",
-    "            learning_rate = tf.where(\n",
+    "            learning_rate = ops.where(\n",
     "                step < self.warmup_steps, warmup_rate, learning_rate\n",
     "            )\n",
     "\n",
     "        # When the current step is more that the total steps, return 0 else return\n",
     "        # the calculated graph.\n",
-    "        return tf.where(\n",
-    "            step > self.total_steps, 0.0, learning_rate, name=\"learning_rate\"\n",
-    "        )\n",
+    "        return ops.where(step > self.total_steps, 0.0, learning_rate)\n",
     "\n",
     "    def get_config(self):\n",
     "        config = {\n",
@@ -1043,8 +1025,7 @@
     "            \"total_steps\": self.total_steps,\n",
     "            \"warmup_steps\": self.warmup_steps,\n",
     "        }\n",
-    "        return config\n",
-    ""
+    "        return config\n"
    ]
   },
   {
@@ -1085,7 +1066,7 @@
     ")\n",
     "\n",
     "# Get the optimizer.\n",
-    "optimizer = tfa.optimizers.AdamW(\n",
+    "optimizer = keras.optimizers.AdamW(\n",
     "    learning_rate=scheduled_lrs, weight_decay=config.weight_decay\n",
     ")\n",
     "\n",
@@ -1142,7 +1123,7 @@
    },
    "outputs": [],
    "source": [
-    "model.save(\"ShiftViT\")"
+    "model.export(\"ShiftViT\")"
    ]
   },
   {
@@ -1192,12 +1173,9 @@
    },
    "outputs": [],
    "source": [
-    "# Custom objects are not included when the model is saved.\n",
-    "# At loading time, these objects need to be passed for reconstruction of the model\n",
-    "saved_model = tf.keras.models.load_model(\n",
-    "    \"ShiftViT\",\n",
-    "    custom_objects={\"WarmUpCosine\": WarmUpCosine, \"AdamW\": tfa.optimizers.AdamW},\n",
-    ")"
+    "# Using TFSMLayer to reload the TF SavedModel as a Keras layer.\n",
+    "# This is not limited to SavedModels that originate from Keras – it will work with any SavedModel, e.g. TF-Hub models.\n",
+    "saved_model = keras.layers.TFSMLayer(\"ShiftViT\", call_endpoint=\"serving_default\")"
    ]
   },
   {
@@ -1226,9 +1204,9 @@
     "    img = tf.io.decode_jpeg(img, channels=3)\n",
     "\n",
     "    # resize image to match input size accepted by model\n",
-    "    # use `method` as `nearest` to preserve dtype of input passed to `resize()`\n",
-    "    img = tf.image.resize(\n",
-    "        img, [config.input_shape[0], config.input_shape[1]], method=\"nearest\"\n",
+    "    # use `interpolation` as `nearest` to preserve dtype of input passed to `resize()`\n",
+    "    img = ops.image.resize(\n",
+    "        img, [config.input_shape[0], config.input_shape[1]], interpolation=\"nearest\"\n",
     "    )\n",
     "    return img\n",
     "\n",
@@ -1250,10 +1228,12 @@
     "\n",
     "def predict(predict_ds):\n",
     "    # ShiftViT model returns logits (non-normalized predictions)\n",
-    "    logits = saved_model.predict(predict_ds)\n",
+    "    model = keras.Sequential([saved_model])\n",
+    "    output_dict = model.predict(predict_ds)\n",
+    "    logits = list(output_dict.values())[0]\n",
     "\n",
     "    # normalize predictions by calling softmax()\n",
-    "    probabilities = tf.nn.softmax(logits)\n",
+    "    probabilities = ops.softmax(logits)\n",
     "    return probabilities\n",
     "\n",
     "\n",
@@ -1270,8 +1250,7 @@
     "        config.label_map[label]: np.round((probabilities[label]) * 100, 2)\n",
     "        for label in labels\n",
     "    }\n",
-    "    return confidences\n",
-    ""
+    "    return confidences\n"
    ]
   },
   {

--- a/examples/vision/md/shiftvit.md
+++ b/examples/vision/md/shiftvit.md
@@ -2,7 +2,7 @@
 
 **Author:** [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Ritwik Raha](https://twitter.com/ritwik_raha), [Shivalika Singh](https://www.linkedin.com/in/shivalika-singh/)<br>
 **Date created:** 2022/02/24<br>
-**Last modified:** 2022/10/15<br>
+**Last modified:** 2024/12/06<br>
 **Description:** A minimal implementation of ShiftViT.
 
 
@@ -30,13 +30,7 @@ operation with a shifting operation.
 In this example, we minimally implement the paper with close alignement to the author's
 [official implementation](https://github.com/microsoft/SPACH/blob/main/models/shiftvit.py).
 
-This example requires TensorFlow 2.9 or higher, as well as TensorFlow Addons, which can
-be installed using the following command:
-
-
-```python
-!pip install -qq -U tensorflow-addons
-```
+This example requires TensorFlow 2.9 or higher.
 
 
 ---
@@ -47,10 +41,10 @@ be installed using the following command:
 import numpy as np
 import matplotlib.pyplot as plt
 
+import keras
+from keras import ops
+from keras import layers
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-import tensorflow_addons as tfa
 
 import pathlib
 import glob
@@ -262,7 +256,7 @@ class MLP(layers.Layer):
             [
                 layers.Dense(
                     units=initial_filters,
-                    activation=tf.nn.gelu,
+                    activation="gelu",
                 ),
                 layers.Dropout(rate=self.mlp_dropout_rate),
                 layers.Dense(units=input_channels),
@@ -297,13 +291,16 @@ class DropPath(layers.Layer):
     def __init__(self, drop_path_prob, **kwargs):
         super().__init__(**kwargs)
         self.drop_path_prob = drop_path_prob
+        self.seed_generator = keras.random.SeedGenerator(1337)
 
     def call(self, x, training=False):
         if training:
             keep_prob = 1 - self.drop_path_prob
-            shape = (tf.shape(x)[0],) + (1,) * (len(tf.shape(x)) - 1)
-            random_tensor = keep_prob + tf.random.uniform(shape, 0, 1)
-            random_tensor = tf.floor(random_tensor)
+            shape = (ops.shape(x)[0],) + (1,) * (len(ops.shape(x)) - 1)
+            random_tensor = keep_prob + keras.random.uniform(
+                shape, 0, 1, seed=self.seed_generator
+            )
+            random_tensor = ops.floor(random_tensor)
             return (x / keep_prob) * random_tensor
         return x
 
@@ -418,17 +415,17 @@ class ShiftViTBlock(layers.Layer):
             offset_width = 0
             target_height = self.shift_pixel
             target_width = 0
-        crop = tf.image.crop_to_bounding_box(
+        crop = ops.image.crop_images(
             x,
-            offset_height=offset_height,
-            offset_width=offset_width,
+            top_cropping=offset_height,
+            left_cropping=offset_width,
             target_height=self.H - target_height,
             target_width=self.W - target_width,
         )
-        shift_pad = tf.image.pad_to_bounding_box(
+        shift_pad = ops.image.pad_images(
             crop,
-            offset_height=offset_height,
-            offset_width=offset_width,
+            top_padding=offset_height,
+            left_padding=offset_width,
             target_height=self.H,
             target_width=self.W,
         )
@@ -436,7 +433,7 @@ class ShiftViTBlock(layers.Layer):
 
     def call(self, x, training=False):
         # Split the feature maps
-        x_splits = tf.split(x, num_or_size_splits=self.C // self.num_div, axis=-1)
+        x_splits = ops.split(x, indices_or_sections=self.C // self.num_div, axis=-1)
 
         # Shift the feature maps
         x_splits[0] = self.get_shift_pad(x_splits[0], mode="left")
@@ -445,7 +442,7 @@ class ShiftViTBlock(layers.Layer):
         x_splits[3] = self.get_shift_pad(x_splits[3], mode="down")
 
         # Concatenate the shifted and unshifted feature maps
-        x = tf.concat(x_splits, axis=-1)
+        x = ops.concatenate(x_splits, axis=-1)
 
         # Add the residual connection
         shortcut = x
@@ -805,7 +802,7 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
         self.lr_max = lr_max
         self.warmup_steps = warmup_steps
         self.total_steps = total_steps
-        self.pi = tf.constant(np.pi)
+        self.pi = ops.array(np.pi)
 
     def __call__(self, step):
         # Check whether the total number of steps is larger than the warmup
@@ -819,10 +816,10 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
         # `cos_annealed_lr` is a graph that increases to 1 from the initial
         # step to the warmup step. After that this graph decays to -1 at the
         # final step mark.
-        cos_annealed_lr = tf.cos(
+        cos_annealed_lr = ops.cos(
             self.pi
-            * (tf.cast(step, tf.float32) - self.warmup_steps)
-            / tf.cast(self.total_steps - self.warmup_steps, tf.float32)
+            * (ops.cast(step, dtype="float32") - self.warmup_steps)
+            / ops.cast(self.total_steps - self.warmup_steps, dtype="float32")
         )
 
         # Shift the mean of the `cos_annealed_lr` graph to 1. Now the grpah goes
@@ -847,20 +844,18 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
 
             # With the formula for a straight line (y = mx+c) build the warmup
             # schedule
-            warmup_rate = slope * tf.cast(step, tf.float32) + self.lr_start
+            warmup_rate = slope * ops.cast(step, dtype="float32") + self.lr_start
 
             # When the current step is lesser that warmup steps, get the line
             # graph. When the current step is greater than the warmup steps, get
             # the scaled cos graph.
-            learning_rate = tf.where(
+            learning_rate = ops.where(
                 step < self.warmup_steps, warmup_rate, learning_rate
             )
 
         # When the current step is more that the total steps, return 0 else return
         # the calculated graph.
-        return tf.where(
-            step > self.total_steps, 0.0, learning_rate, name="learning_rate"
-        )
+        return ops.where(step > self.total_steps, 0.0, learning_rate)
 
     def get_config(self):
         config = {
@@ -899,7 +894,7 @@ scheduled_lrs = WarmUpCosine(
 )
 
 # Get the optimizer.
-optimizer = tfa.optimizers.AdamW(
+optimizer = keras.optimizers.AdamW(
     learning_rate=scheduled_lrs, weight_decay=config.weight_decay
 )
 
@@ -1054,7 +1049,7 @@ It can be saved in TF SavedModel format only. In general, this is the recommende
 
 
 ```python
-model.save("ShiftViT")
+model.export("ShiftViT")
 ```
 
 ---
@@ -1072,12 +1067,9 @@ model.save("ShiftViT")
 
 
 ```python
-# Custom objects are not included when the model is saved.
-# At loading time, these objects need to be passed for reconstruction of the model
-saved_model = tf.keras.models.load_model(
-    "ShiftViT",
-    custom_objects={"WarmUpCosine": WarmUpCosine, "AdamW": tfa.optimizers.AdamW},
-)
+# Using TFSMLayer to reload the TF SavedModel as a Keras layer.
+# This is not limited to SavedModels that originate from Keras – it will work with any SavedModel, e.g. TF-Hub models.
+saved_model = keras.layers.TFSMLayer("ShiftViT", call_endpoint="serving_default")
 ```
 
 
@@ -1094,9 +1086,9 @@ def process_image(img_path):
     img = tf.io.decode_jpeg(img, channels=3)
 
     # resize image to match input size accepted by model
-    # use `method` as `nearest` to preserve dtype of input passed to `resize()`
-    img = tf.image.resize(
-        img, [config.input_shape[0], config.input_shape[1]], method="nearest"
+    # use `interpolation` as `nearest` to preserve dtype of input passed to `resize()`
+    img = ops.image.resize(
+        img, [config.input_shape[0], config.input_shape[1]], interpolation="nearest"
     )
     return img
 
@@ -1118,10 +1110,12 @@ def create_tf_dataset(image_dir):
 
 def predict(predict_ds):
     # ShiftViT model returns logits (non-normalized predictions)
-    logits = saved_model.predict(predict_ds)
+    model = keras.Sequential([saved_model])
+    output_dict = model.predict(predict_ds)
+    logits = list(output_dict.values())[0]
 
     # normalize predictions by calling softmax()
-    probabilities = tf.nn.softmax(logits)
+    probabilities = ops.softmax(logits)
     return probabilities
 
 

--- a/examples/vision/shiftvit.py
+++ b/examples/vision/shiftvit.py
@@ -2,9 +2,10 @@
 Title: A Vision Transformer without Attention
 Author: [Aritra Roy Gosthipaty](https://twitter.com/ariG23498), [Ritwik Raha](https://twitter.com/ritwik_raha), [Shivalika Singh](https://www.linkedin.com/in/shivalika-singh/)
 Date created: 2022/02/24
-Last modified: 2022/10/15
+Last modified: 2024/12/06
 Description: A minimal implementation of ShiftViT.
 Accelerator: GPU
+Converted to Keras 3 by: [Sitam Meur](https://github.com/sitamgithub-MSIT)
 """
 
 """

--- a/examples/vision/shiftvit.py
+++ b/examples/vision/shiftvit.py
@@ -238,7 +238,7 @@ class MLP(layers.Layer):
             [
                 layers.Dense(
                     units=initial_filters,
-                    activation=tf.nn.gelu,
+                    activation="gelu",
                 ),
                 layers.Dropout(rate=self.mlp_dropout_rate),
                 layers.Dense(units=input_channels),

--- a/scripts/examples_master.py
+++ b/scripts/examples_master.py
@@ -118,6 +118,7 @@ EXAMPLES_MASTER = {
                     "path": "shiftvit",
                     "title": "A Vision Transformer without Attention",
                     "subcategory": "Image classification",
+                    "keras_3": True,
                 },
                 {
                     "path": "image_classification_using_global_context_vision_transformer",


### PR DESCRIPTION
This PR changes the [A Vision Transformer without Attention](https://keras.io/examples/vision/shiftvit/) example to Keras 3.0

For example, here is the notebook link provided: https://colab.research.google.com/drive/1tgIPW6DOux-dNicegYcnG8lnWswrE0Ji?usp=sharing

cc: @fchollet 

The following describes the Git difference for the changed files:

<details><summary>Changes:</summary>

```
diff --git a/examples/vision/shiftvit.py b/examples/vision/shiftvit.py
index e0c42d1d..bd053246 100644
--- a/examples/vision/shiftvit.py
+++ b/examples/vision/shiftvit.py
@@ -27,11 +27,7 @@ operation with a shifting operation.
 In this example, we minimally implement the paper with close alignement to the author's
 [official implementation](https://github.com/microsoft/SPACH/blob/main/models/shiftvit.py).
 
-This example requires TensorFlow 2.9 or higher, as well as TensorFlow Addons, which can
-be installed using the following command:
-"""
-"""shell
-pip install -qq -U tensorflow-addons
+This example requires TensorFlow 2.9 or higher.
 """
 
 """
@@ -41,10 +37,10 @@ pip install -qq -U tensorflow-addons
 import numpy as np
 import matplotlib.pyplot as plt
 
+import keras
+from keras import ops
+from keras import layers
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-import tensorflow_addons as tfa
 
 import pathlib
 import glob
@@ -276,13 +272,16 @@ class DropPath(layers.Layer):
     def __init__(self, drop_path_prob, **kwargs):
         super().__init__(**kwargs)
         self.drop_path_prob = drop_path_prob
+        self.seed_generator = keras.random.SeedGenerator(1337)
 
     def call(self, x, training=False):
         if training:
             keep_prob = 1 - self.drop_path_prob
-            shape = (tf.shape(x)[0],) + (1,) * (len(tf.shape(x)) - 1)
-            random_tensor = keep_prob + tf.random.uniform(shape, 0, 1)
-            random_tensor = tf.floor(random_tensor)
+            shape = (ops.shape(x)[0],) + (1,) * (len(ops.shape(x)) - 1)
+            random_tensor = keep_prob + keras.random.uniform(
+                shape, 0, 1, seed=self.seed_generator
+            )
+            random_tensor = ops.floor(random_tensor)
             return (x / keep_prob) * random_tensor
         return x
 
@@ -396,17 +395,17 @@ class ShiftViTBlock(layers.Layer):
             offset_width = 0
             target_height = self.shift_pixel
             target_width = 0
-        crop = tf.image.crop_to_bounding_box(
+        crop = ops.image.crop_images(
             x,
-            offset_height=offset_height,
-            offset_width=offset_width,
+            top_cropping=offset_height,
+            left_cropping=offset_width,
             target_height=self.H - target_height,
             target_width=self.W - target_width,
         )
-        shift_pad = tf.image.pad_to_bounding_box(
+        shift_pad = ops.image.pad_images(
             crop,
-            offset_height=offset_height,
-            offset_width=offset_width,
+            top_padding=offset_height,
+            left_padding=offset_width,
             target_height=self.H,
             target_width=self.W,
         )
@@ -414,7 +413,7 @@ class ShiftViTBlock(layers.Layer):
 
     def call(self, x, training=False):
         # Split the feature maps
-        x_splits = tf.split(x, num_or_size_splits=self.C // self.num_div, axis=-1)
+        x_splits = ops.split(x, indices_or_sections=self.C // self.num_div, axis=-1)
 
         # Shift the feature maps
         x_splits[0] = self.get_shift_pad(x_splits[0], mode="left")
@@ -423,7 +422,7 @@ class ShiftViTBlock(layers.Layer):
         x_splits[3] = self.get_shift_pad(x_splits[3], mode="down")
 
         # Concatenate the shifted and unshifted feature maps
-        x = tf.concat(x_splits, axis=-1)
+        x = ops.concatenate(x_splits, axis=-1)
 
         # Add the residual connection
         shortcut = x
@@ -779,7 +778,7 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
         self.lr_max = lr_max
         self.warmup_steps = warmup_steps
         self.total_steps = total_steps
-        self.pi = tf.constant(np.pi)
+        self.pi = ops.array(np.pi)
 
     def __call__(self, step):
         # Check whether the total number of steps is larger than the warmup
@@ -793,10 +792,10 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
         # `cos_annealed_lr` is a graph that increases to 1 from the initial
         # step to the warmup step. After that this graph decays to -1 at the
         # final step mark.
-        cos_annealed_lr = tf.cos(
+        cos_annealed_lr = ops.cos(
             self.pi
-            * (tf.cast(step, tf.float32) - self.warmup_steps)
-            / tf.cast(self.total_steps - self.warmup_steps, tf.float32)
+            * (ops.cast(step, dtype="float32") - self.warmup_steps)
+            / ops.cast(self.total_steps - self.warmup_steps, dtype="float32")
         )
 
         # Shift the mean of the `cos_annealed_lr` graph to 1. Now the grpah goes
@@ -821,20 +820,18 @@ class WarmUpCosine(keras.optimizers.schedules.LearningRateSchedule):
 
             # With the formula for a straight line (y = mx+c) build the warmup
             # schedule
-            warmup_rate = slope * tf.cast(step, tf.float32) + self.lr_start
+            warmup_rate = slope * ops.cast(step, dtype="float32") + self.lr_start
 
             # When the current step is lesser that warmup steps, get the line
             # graph. When the current step is greater than the warmup steps, get
             # the scaled cos graph.
-            learning_rate = tf.where(
+            learning_rate = ops.where(
                 step < self.warmup_steps, warmup_rate, learning_rate
             )
 
         # When the current step is more that the total steps, return 0 else return
         # the calculated graph.
-        return tf.where(
-            step > self.total_steps, 0.0, learning_rate, name="learning_rate"
-        )
+        return ops.where(step > self.total_steps, 0.0, learning_rate)
 
     def get_config(self):
         config = {
@@ -871,7 +868,7 @@ scheduled_lrs = WarmUpCosine(
 )
 
 # Get the optimizer.
-optimizer = tfa.optimizers.AdamW(
+optimizer = keras.optimizers.AdamW(
     learning_rate=scheduled_lrs, weight_decay=config.weight_decay
 )
 
@@ -913,7 +910,7 @@ Since we created the model by Subclassing, we can't save the model in HDF5 forma
 
 It can be saved in TF SavedModel format only. In general, this is the recommended format for saving models as well.
 """
-model.save("ShiftViT")
+model.export("ShiftViT")
 
 """
 ## Model inference
@@ -932,12 +929,9 @@ unzip -q inference_set.zip
 """
 **Load saved model**
 """
-# Custom objects are not included when the model is saved.
-# At loading time, these objects need to be passed for reconstruction of the model
-saved_model = tf.keras.models.load_model(
-    "ShiftViT",
-    custom_objects={"WarmUpCosine": WarmUpCosine, "AdamW": tfa.optimizers.AdamW},
-)
+# Using TFSMLayer to reload the TF SavedModel as a Keras layer.
+# This is not limited to SavedModels that originate from Keras – it will work with any SavedModel, e.g. TF-Hub models.
+saved_model = keras.layers.TFSMLayer("ShiftViT", call_endpoint="serving_default")
 
 """
 **Utility functions for inference**
@@ -952,9 +946,9 @@ def process_image(img_path):
     img = tf.io.decode_jpeg(img, channels=3)
 
     # resize image to match input size accepted by model
-    # use `method` as `nearest` to preserve dtype of input passed to `resize()`
-    img = tf.image.resize(
-        img, [config.input_shape[0], config.input_shape[1]], method="nearest"
+    # use `interpolation` as `nearest` to preserve dtype of input passed to `resize()`
+    img = ops.image.resize(
+        img, [config.input_shape[0], config.input_shape[1]], interpolation="nearest"
     )
     return img
 
@@ -976,10 +970,12 @@ def create_tf_dataset(image_dir):
 
 def predict(predict_ds):
     # ShiftViT model returns logits (non-normalized predictions)
-    logits = saved_model.predict(predict_ds)
+    model = keras.Sequential([saved_model])
+    output_dict = model.predict(predict_ds)
+    logits = list(output_dict.values())[0]
 
     # normalize predictions by calling softmax()
-    probabilities = tf.nn.softmax(logits)
+    probabilities = ops.softmax(logits)
     return probabilities
 
 
(END)
```