### PR TITLE
fixing classification_with_grn_and_vsn various errors

### DIFF
--- a/examples/structured_data/classification_with_grn_and_vsn.py
+++ b/examples/structured_data/classification_with_grn_and_vsn.py
@@ -110,6 +110,24 @@ CSV_HEADER = [
     "income_level",
 ]
 
+"""
+Arranged CSV_HEADER to match the FEATURES_NAME metadata described below
+"""
+
+CSV_HEADER_FEATURE = ['age', 'wage_per_hour', 'capital_gains', 'capital_losses',
+'dividends_from_stocks', 'num_persons_worked_for_employer',
+'weeks_worked_in_year', 'instance_weight', 'class_of_worker',
+'detailed_industry_recode', 'detailed_occupation_recode', 'education',
+'enroll_in_edu_inst_last_wk', 'marital_stat', 'major_industry_code', 'major_occupation_code',
+'race', 'hispanic_origin', 'sex', 'member_of_a_labor_union', 'reason_for_unemployment',
+'full_or_part_time_employment_stat', 'tax_filer_stat', 'region_of_previous_residence',
+'state_of_previous_residence', 'detailed_household_and_family_stat', 'detailed_household_summary_in_household',
+'migration_code-change_in_msa', 'migration_code-change_in_reg', 'migration_code-move_within_reg',
+'live_in_this_house_1_year_ago', 'migration_prev_res_in_sunbelt', 'family_members_under_18',
+'country_of_birth_father', 'country_of_birth_mother', 'country_of_birth_self', 'citizenship',
+'own_business_or_self_employed', 'fill_inc_questionnaire_for_veterans_admin', 'veterans_benefits',
+'year', 'income_level']
+
 data_url = "https://archive.ics.uci.edu/static/public/117/census+income+kdd.zip"
 keras.utils.get_file(origin=data_url, extract=True)
 
@@ -137,6 +155,8 @@ test_data_path = os.path.join(
 )
 
 data = pd.read_csv(train_data_path, header=None, names=CSV_HEADER)
+# Rearrange the dataframe columns to match FEATURES_NAMES metadata described below
+data = data[CSV_HEADER_FEATURE]
 test_data = pd.read_csv(test_data_path, header=None, names=CSV_HEADER)
 
 print(f"Data shape: {data.shape}")
@@ -212,7 +232,7 @@ NUMERIC_FEATURE_NAMES = [
 # sure that they are treated as strings.
 CATEGORICAL_FEATURES_WITH_VOCABULARY = {
     feature_name: sorted([str(value) for value in list(data[feature_name].unique())])
-    for feature_name in CSV_HEADER
+    for feature_name in CSV_HEADER_FEATURE
     if feature_name
     not in list(NUMERIC_FEATURE_NAMES + [WEIGHT_COLUMN_NAME, TARGET_FEATURE_NAME])
 }
@@ -228,7 +248,7 @@ COLUMN_DEFAULTS = [
         in NUMERIC_FEATURE_NAMES + [TARGET_FEATURE_NAME, WEIGHT_COLUMN_NAME]
         else ["NA"]
     )
-    for feature_name in CSV_HEADER
+    for feature_name in CSV_HEADER_FEATURE
 ]
 
 """
@@ -247,14 +267,14 @@ def process(features, target):
             features[feature_name] = keras.ops.cast(features[feature_name], "string")
     # Get the instance weight.
     weight = features.pop(WEIGHT_COLUMN_NAME)
-    return features, target, weight
+    return dict(features), target, weight
 
 
 def get_dataset_from_csv(csv_file_path, shuffle=False, batch_size=128):
     dataset = tf.data.experimental.make_csv_dataset(
         csv_file_path,
         batch_size=batch_size,
-        column_names=CSV_HEADER,
+        column_names=CSV_HEADER_FEATURE,
         column_defaults=COLUMN_DEFAULTS,
         label_name=TARGET_FEATURE_NAME,
         num_epochs=1,
@@ -268,7 +288,6 @@ def get_dataset_from_csv(csv_file_path, shuffle=False, batch_size=128):
 """
 ## Create model inputs
 """
-
 
 def create_model_inputs():
     inputs = {}


### PR DESCRIPTION
### Dataset preparation errors 
---

The example file from structured_data `classification_with_grn_and vsn.py` I think it is using the wrong dataset, i.e., the data_url: `https://archive.ics.uci.edu/static/public/20/census+income.zip` leads to a download of an incorrect dataset. The correct data_url, I believe should be: `https://archive.ics.uci.edu/static/public/117/census+income+kdd.zip`, a fix has been added.

To extract the downloaded `.tar.gz file`, created during a call to `keras.utils.get_file`, a fix has been added.

A fix was also added to clean up the directory that the files where extracted to during download in order to run the script again without errors:

Additionally, the original script has the code snippet:

```python
train_data_path = os.path.join(
    os.path.expanduser("~"), ".keras", "datasets", "adult.data"
)
test_data_path = os.path.join(
    os.path.expanduser("~"), ".keras", "datasets", "adult.test"
)
```
The above snippet doesn't account for the directory created during `keras.utils.get_file` extraction process `census+income+kdd.zip` which leads to an incorrect path for both `train_data_path` and `test_data_path`, and a fix has been added.

### Additional training errors
---

After covering the above dataset's preparation process, the script also has an additional error encountered during model training, detailed below and an attempted solution provided:
```
2024-12-19 21:02:15.350619: W tensorflow/core/framework/op_kernel.cc:1816] OP_REQUIRES failed at cast_op.cc:122 : UNIMPLEMENTED: Cast string to float is not supported
2024-12-19 21:02:15.350683: W tensorflow/core/framework/local_rendezvous.cc:404] Local rendezvous is aborting with status: UNIMPLEMENTED: Cast string to float is not supported
Traceback (most recent call last):
  File "/home/humbulani/tensorflow-env/keras-io-master/examples/structured_data/classification_with_grn_and_vsn.py", line 513, in <module>
    model.fit(
  File "/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/tensorflow/python/framework/ops.py", line 5983, in raise_from_not_ok_status
    raise core._status_to_exception(e) from None  # pylint: disable=protected-access
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tensorflow.python.framework.errors_impl.UnimplementedError: Exception encountered when calling Functional.call().

{{function_node __wrapped__Cast_device_/job:localhost/replica:0/task:0/device:CPU:0}} Cast string to float is not supported [Op:Cast] name:
```

**Attempted solution**:

I believe I have precisely traced the error to the following, here is a pdb script:

```
> /home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/models/functional.py(245)_convert_inputs_to_tensors()
-> converted = []
(Pdb) p self._inputs
[<KerasTensor shape=(None,), dtype=float32, sparse=False, name=age>, <KerasTensor shape=(None,), dtype=float32, sparse=False, name=capital_gains>, <KerasTensor shape=(None,), dtype=float32, sparse=False, name=capital_losses>, ...]

(Pdb) p flat_inputs
[<tf.Tensor: shape=(265,), dtype=float32, numpy=
array([63., 52.,  2., 45.,  0., 43., 67., 26., 29., 53., 31., 59., 57.,...>, <tf.Tensor: shape=(265,), dtype=string, numpy=
array([b' Not in universe', b' Private', b' Not in universe', b' Private',
       b' Not in universe', b' Private', b' Not in universe',...>...]
```
The function [_convert_inputs_to_tensors](https://github.com/keras-team/keras/blob/master/keras/src/models/functional.py#L239) creates a `zip iterator` pairing together `flat_inputs` and `self._inputs`, and as per the `pdb` output above the first element (age) from flat_inputs and self._inputs has `float32` dtype, however the second element (capital_gains) has a `float32` dtype and a `string` dtype causing the discrepancy, and hence the error.

I think the main issue is that the `csv` file used to create the `dataset` has columns arranged in a different order compared to model `inputs`. Model inputs have structured order, in that they are arranged from numerical to categorical features.

I've tried to rearrange the dataset dataframe to match the columns before creating the train and test csv files, but somehow pandas is merely renaming the columns without actually shifting the columns.

### For more information related to original script 
---

The original script had the following error which I didn't attend to since it has other issues before training.

```
Epoch 1/20
2024-12-19 20:30:24.244976: W tensorflow/core/framework/local_rendezvous.cc:404] Local rendezvous is aborting with status: INVALID_ARGUMENT: Field 5 in record is not a valid float:  Never-married
Traceback (most recent call last):
  File "/home/humbulani/tensorflow-env/keras-io-master/examples/structured_data/classification_with_grn_and_vsn.py", line 514, in <module>
    model.fit(
  File "/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/tensorflow/python/framework/ops.py", line 5983, in raise_from_not_ok_status
    raise core._status_to_exception(e) from None  # pylint: disable=protected-access
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tensorflow.python.framework.errors_impl.InvalidArgumentError: {{function_node __wrapped__IteratorGetNext_output_types_42_device_/job:localhost/replica:0/task:0/device:CPU:0}} Field 5 in record is not a valid float:  Never-married [Op:IteratorGetNext] name: 
```

### Environment
---
```
Tensorflow == 2.16.1
Python == 3.11
Keras == 3.7.0
```