### PR TITLE
Adapting the script fnet_classification_with_keras_hub.py to be Backend-Agnostic

### DIFF
--- a/examples/nlp/fnet_classification_with_keras_hub.py
+++ b/examples/nlp/fnet_classification_with_keras_hub.py
@@ -133,17 +133,13 @@ def load_data_from_directory(directory, label):
 
 # Function to create Pandas dataframes
 def create_df(directory_pos, directory_neg):
-
     # Load data from both directories
     pos_data = load_data_from_directory(directory_pos, label=1)
     neg_data = load_data_from_directory(directory_neg, label=0)
-
     # Combine data from both pos and neg
     all_data = pos_data + neg_data
-
     # Shuffle the data randomly
     random.shuffle(all_data)
-
     # Create a pandas DataFrame
     df = pd.DataFrame(all_data, columns=["text", "label"])
     return df
@@ -226,7 +222,7 @@ less than the specified sequence length. Otherwise, the sequence is truncated.
 
 tokenizer = keras_hub.tokenizers.WordPieceTokenizer(
     vocabulary=vocab,
-    lowercase=False,
+    lowercase=True,
     sequence_length=MAX_SEQUENCE_LENGTH,
 )
 
@@ -296,13 +292,10 @@ class UnifiedPyDataset(keras.utils.PyDataset):
         low = index * self.batch_size
         # Cap upper bound at array length; the last batch may be smaller
         # if the total number of items is not a multiple of batch size.
-
         high_text = min(low + self.batch_size, len(self.text_x))
-
         # text files batches
         batch_text_x = self.text_x[low:high_text]
         batch_text_y = self.text_y[low:high_text]
-
         # Tokenize the data in dataframe and stack them into an nd.array of axis_0=batch
         text = np.array([[tokenizer(text) for text in batch_text_x]])
         return (

--- a/examples/nlp/ipynb/fnet_classification_with_keras_hub.ipynb
+++ b/examples/nlp/ipynb/fnet_classification_with_keras_hub.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Abheesht Sharma](https://github.com/abheesht17/)<br>\n",
     "**Date created:** 2022/06/01<br>\n",
-    "**Last modified:** 2022/12/21<br>\n",
+    "**Last modified:** 2025/01/06<br>\n",
     "**Description:** Text Classification on the IMDb Dataset using `keras_hub.layers.FNetEncoder` layer."
    ]
   },
@@ -87,10 +87,17 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import random\n",
+    "import math\n",
+    "\n",
+    "os.environ[\"KERAS_BACKEND\"] = \"torch\"  # or jax, or tensorflow\n",
+    "\n",
     "import keras_hub\n",
     "import keras\n",
-    "import tensorflow as tf\n",
-    "import os\n",
     "\n",
     "keras.utils.set_random_seed(42)"
    ]
@@ -113,7 +120,7 @@
    "outputs": [],
    "source": [
     "BATCH_SIZE = 64\n",
-    "EPOCHS = 3\n",
+    "EPOCHS = 1  # maybe adjusted as desired\n",
     "MAX_SEQUENCE_LENGTH = 512\n",
     "VOCAB_SIZE = 15000\n",
     "\n",
@@ -196,8 +203,9 @@
     "colab_type": "text"
    },
    "source": [
-    "We'll use the `keras.utils.text_dataset_from_directory` utility to generate\n",
-    "our labelled `tf.data.Dataset` dataset from text files."
+    "We'll use Pandas to avoid dependency on `keras.utils.text_dataset_from_directory`\n",
+    "since it is merely a wrapper that returns `tf.data.Dataset` and we wish to make\n",
+    "this script backend-agnostic"
    ]
   },
   {
@@ -208,43 +216,50 @@
    },
    "outputs": [],
    "source": [
-    "train_ds = keras.utils.text_dataset_from_directory(\n",
-    "    \"aclImdb/train\",\n",
-    "    batch_size=BATCH_SIZE,\n",
-    "    validation_split=0.2,\n",
-    "    subset=\"training\",\n",
-    "    seed=42,\n",
+    "\n",
+    "# Function to read files and label them\n",
+    "def load_data_from_directory(directory, label):\n",
+    "    data = []\n",
+    "    for filename in os.listdir(directory):\n",
+    "        if filename.endswith(\".txt\"):\n",
+    "            file_path = os.path.join(directory, filename)\n",
+    "            with open(file_path, \"r\", encoding=\"utf-8\") as file:\n",
+    "                text = file.read().strip()\n",
+    "                data.append((text, label))\n",
+    "    return data\n",
+    "\n",
+    "\n",
+    "# Function to create Pandas dataframes\n",
+    "def create_df(directory_pos, directory_neg):\n",
+    "\n",
+    "    # Load data from both directories\n",
+    "    pos_data = load_data_from_directory(directory_pos, label=1)\n",
+    "    neg_data = load_data_from_directory(directory_neg, label=0)\n",
+    "\n",
+    "    # Combine data from both pos and neg\n",
+    "    all_data = pos_data + neg_data\n",
+    "\n",
+    "    # Shuffle the data randomly\n",
+    "    random.shuffle(all_data)\n",
+    "\n",
+    "    # Create a pandas DataFrame\n",
+    "    df = pd.DataFrame(all_data, columns=[\"text\", \"label\"])\n",
+    "    return df\n",
+    "\n",
+    "\n",
+    "# Create the train and test dataframes, iloc maybe adjusted to a desired size\n",
+    "train_df = create_df(\"./aclImdb/train/pos\", \"./aclImdb/train/neg\").iloc[0:5000]\n",
+    "test_df = create_df(\"./aclImdb/test/pos\", \"./aclImdb/test/neg\").iloc[0:2500]\n",
+    "\n",
+    "# Train and Validation splits, 5% for validation\n",
+    "train_df, val_df = train_test_split(\n",
+    "    train_df, test_size=0.05, stratify=train_df[\"label\"].values, random_state=42\n",
     ")\n",
-    "val_ds = keras.utils.text_dataset_from_directory(\n",
-    "    \"aclImdb/train\",\n",
-    "    batch_size=BATCH_SIZE,\n",
-    "    validation_split=0.2,\n",
-    "    subset=\"validation\",\n",
-    "    seed=42,\n",
-    ")\n",
-    "test_ds = keras.utils.text_dataset_from_directory(\"aclImdb/test\", batch_size=BATCH_SIZE)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text"
-   },
-   "source": [
-    "We will now convert the text to lowercase."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "train_ds = train_ds.map(lambda x, y: (tf.strings.lower(x), y))\n",
-    "val_ds = val_ds.map(lambda x, y: (tf.strings.lower(x), y))\n",
-    "test_ds = test_ds.map(lambda x, y: (tf.strings.lower(x), y))"
+    "\n",
+    "# Data statistics\n",
+    "print(f\"Total training examples: {len(train_df)}\")\n",
+    "print(f\"Total validation examples: {len(val_df)}\")\n",
+    "print(f\"Total test examples: {len(test_df)}\")"
    ]
   },
   {
@@ -264,11 +279,8 @@
    },
    "outputs": [],
    "source": [
-    "for text_batch, label_batch in train_ds.take(1):\n",
-    "    for i in range(3):\n",
-    "        print(text_batch.numpy()[i])\n",
-    "        print(label_batch.numpy()[i])\n",
-    ""
+    "for i in range(3):\n",
+    "    print(f\"text: {train_df['text'][i]}, label: {train_df['label'][i]}\")"
    ]
   },
   {
@@ -296,26 +308,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab_type": "code"
-   },
-   "outputs": [],
-   "source": [
-    "\n",
-    "def train_word_piece(ds, vocab_size, reserved_tokens):\n",
-    "    word_piece_ds = ds.unbatch().map(lambda x, y: x)\n",
-    "    vocab = keras_hub.tokenizers.compute_word_piece_vocabulary(\n",
-    "        word_piece_ds.batch(1000).prefetch(2),\n",
-    "        vocabulary_size=vocab_size,\n",
-    "        reserved_tokens=reserved_tokens,\n",
-    "    )\n",
-    "    return vocab\n",
-    ""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"
@@ -337,8 +329,19 @@
    "outputs": [],
    "source": [
     "reserved_tokens = [\"[PAD]\", \"[UNK]\"]\n",
-    "train_sentences = [element[0] for element in train_ds]\n",
-    "vocab = train_word_piece(train_ds, VOCAB_SIZE, reserved_tokens)"
+    "train_sentences = [element[0] for element in train_df]\n",
+    "\n",
+    "vocab = keras_hub.tokenizers.compute_word_piece_vocabulary(\n",
+    "    data=[\n",
+    "        \"./aclImdb/train/pos/\" + f\n",
+    "        for f in os.listdir(\"./aclImdb/train/pos\")\n",
+    "        if os.path.isfile(os.path.join(\"./aclImdb/train/pos\", f))\n",
+    "    ],  # list of files in the specified directory used to create the vocab\n",
+    "    vocabulary_size=VOCAB_SIZE,\n",
+    "    reserved_tokens=reserved_tokens,\n",
+    "    lowercase=True,\n",
+    ")\n",
+    ""
    ]
   },
   {
@@ -385,7 +388,8 @@
     "    vocabulary=vocab,\n",
     "    lowercase=False,\n",
     "    sequence_length=MAX_SEQUENCE_LENGTH,\n",
-    ")"
+    ")\n",
+    ""
    ]
   },
   {
@@ -407,7 +411,7 @@
    },
    "outputs": [],
    "source": [
-    "input_sentence_ex = train_ds.take(1).get_single_element()[0][0]\n",
+    "input_sentence_ex = train_df[\"text\"][0]\n",
     "input_tokens_ex = tokenizer(input_sentence_ex)\n",
     "\n",
     "print(\"Sentence: \", input_sentence_ex)\n",
@@ -422,10 +426,7 @@
     "colab_type": "text"
    },
    "source": [
-    "## Formatting the dataset\n",
-    "\n",
-    "Next, we'll format our datasets in the form that will be fed to the models. We\n",
-    "need to tokenize the text."
+    "Create the final datasets, method adapted from `PyDataset` doc string"
    ]
   },
   {
@@ -437,19 +438,88 @@
    "outputs": [],
    "source": [
     "\n",
-    "def format_dataset(sentence, label):\n",
-    "    sentence = tokenizer(sentence)\n",
-    "    return ({\"input_ids\": sentence}, label)\n",
+    "class UnifiedPyDataset(keras.utils.PyDataset):\n",
+    "    \"\"\"A Keras-compatible dataset that processes a DataFrame for TensorFlow, JAX, and PyTorch.\"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        df,\n",
+    "        batch_size=BATCH_SIZE,\n",
+    "        workers=4,\n",
+    "        use_multiprocessing=True,\n",
+    "        max_queue_size=10,\n",
+    "        **kwargs,\n",
+    "    ):\n",
+    "        \"\"\"\n",
+    "        Args:\n",
+    "            df: pandas DataFrame with data\n",
+    "            batch_size: Batch size for dataset\n",
+    "            workers: Number of workers to use for parallel loading (Keras)\n",
+    "            use_multiprocessing: Whether to use multiprocessing\n",
+    "            max_queue_size: Maximum size of the data queue for parallel loading\n",
+    "        \"\"\"\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.dataframe = df\n",
+    "        columns = [\"text\", \"label\"]\n",
+    "\n",
+    "        # text files\n",
+    "        self.text_x = self.dataframe[\"text\"]\n",
+    "        self.text_y = self.dataframe[\"label\"]\n",
+    "\n",
+    "        # general\n",
+    "        self.batch_size = batch_size\n",
+    "        self.workers = workers\n",
+    "        self.use_multiprocessing = use_multiprocessing\n",
+    "        self.max_queue_size = max_queue_size\n",
+    "\n",
+    "    def __getitem__(self, index):\n",
+    "        \"\"\"\n",
+    "        Fetches a batch of data from the dataset at the given index.\n",
+    "\n",
+    "        Args:\n",
+    "            index: position of the batch in the dataset\n",
+    "        \"\"\"\n",
+    "\n",
+    "        # Return x, y for batch idx.\n",
+    "        low = index * self.batch_size\n",
+    "        # Cap upper bound at array length; the last batch may be smaller\n",
+    "        # if the total number of items is not a multiple of batch size.\n",
+    "\n",
+    "        high_text = min(low + self.batch_size, len(self.text_x))\n",
+    "\n",
+    "        # text files batches\n",
+    "        batch_text_x = self.text_x[low:high_text]\n",
+    "        batch_text_y = self.text_y[low:high_text]\n",
+    "\n",
+    "        # Tokenize the data in dataframe and stack them into an nd.array of axis_0=batch\n",
+    "        text = np.array([[tokenizer(text) for text in batch_text_x]])\n",
+    "        return (\n",
+    "            {\n",
+    "                \"input_ids\": keras.ops.squeeze(text),\n",
+    "            },\n",
+    "            # Target lables\n",
+    "            np.array(batch_text_y),\n",
+    "        )\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        \"\"\"\n",
+    "        Returns the number of batches in the dataset.\n",
+    "        \"\"\"\n",
+    "        return math.ceil(len(self.dataframe) / self.batch_size)\n",
     "\n",
     "\n",
-    "def make_dataset(dataset):\n",
-    "    dataset = dataset.map(format_dataset, num_parallel_calls=tf.data.AUTOTUNE)\n",
-    "    return dataset.shuffle(512).prefetch(16).cache()\n",
+    "def prepare_dataset(dataframe, training=True):\n",
+    "    ds = UnifiedPyDataset(\n",
+    "        dataframe,\n",
+    "        batch_size=32,\n",
+    "        workers=4,\n",
+    "    )\n",
+    "    return ds\n",
     "\n",
     "\n",
-    "train_ds = make_dataset(train_ds)\n",
-    "val_ds = make_dataset(val_ds)\n",
-    "test_ds = make_dataset(test_ds)"
+    "train_ds = prepare_dataset(train_df)\n",
+    "val_ds = prepare_dataset(val_df)\n",
+    "test_ds = prepare_dataset(test_df)"
    ]
   },
   {

--- a/examples/nlp/md/fnet_classification_with_keras_hub.md
+++ b/examples/nlp/md/fnet_classification_with_keras_hub.md
@@ -2,7 +2,7 @@
 
 **Author:** [Abheesht Sharma](https://github.com/abheesht17/)<br>
 **Date created:** 2022/06/01<br>
-**Last modified:** 2022/12/21<br>
+**Last modified:** 2025/01/06<br>
 **Description:** Text Classification on the IMDb Dataset using `keras_hub.layers.FNetEncoder` layer.
 
 
@@ -57,16 +57,34 @@ Before we start with the implementation, let's import all the necessary packages
 !pip install -q --upgrade keras  # Upgrade to Keras 3.
 ```
 
+    
+<div class="k-default-codeblock">
+```
+ [[34;49mnotice[1;39;49m][39;49m A new release of pip is available: [31;49m24.0[39;49m -> [32;49m24.3.1
+ [[34;49mnotice[1;39;49m][39;49m To update, run: [32;49mpip install --upgrade pip
+
+```
+</div>
+    
 ```python
+import os
+from sklearn.model_selection import train_test_split
+import pandas as pd
+import numpy as np
+import random
+import math
+
+os.environ["KERAS_BACKEND"] = "torch"  # or jax, or tensorflow
+
 import keras_hub
 import keras
-import tensorflow as tf
-import os
 
 keras.utils.set_random_seed(42)
 ```
 <div class="k-default-codeblock">
 ```
+ [[34;49mnotice[1;39;49m][39;49m A new release of pip is available: [31;49m24.0[39;49m -> [32;49m24.3.1
+ [[34;49mnotice[1;39;49m][39;49m To update, run: [32;49mpip install --upgrade pip
 
 ```
 </div>
@@ -75,7 +93,7 @@ Let's also define our hyperparameters.
 
 ```python
 BATCH_SIZE = 64
-EPOCHS = 3
+EPOCHS = 1  # maybe adjusted as desired
 MAX_SEQUENCE_LENGTH = 512
 VOCAB_SIZE = 15000
 
@@ -96,24 +114,1868 @@ First, let's download the IMDB dataset and extract it.
 
 <div class="k-default-codeblock">
 ```
---2023-11-22 17:59:33--  http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz
+--2025-01-06 21:32:09--  http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz
 Resolving ai.stanford.edu (ai.stanford.edu)... 171.64.68.10
-Connecting to ai.stanford.edu (ai.stanford.edu)|171.64.68.10|:80... connected.
-HTTP request sent, awaiting response... 200 OK
+Connecting to ai.stanford.edu (ai.stanford.edu)|171.64.68.10|:80... 
+
+connected.
+HTTP request sent, awaiting response... 
+
+200 OK
 Length: 84125825 (80M) [application/x-gzip]
 Saving to: ‘aclImdb_v1.tar.gz’
 ```
 </div>
     
-<div class="k-default-codeblock">
-```
-aclImdb_v1.tar.gz   100%[===================>]  80.23M  93.3MB/s    in 0.9s    
-```
-</div>
+    
+aclImdb_v1.tar.gz     0%[                    ]       0  --.-KB/s               
+
+    
+aclImdb_v1.tar.gz     0%[                    ]  22.19K  36.1KB/s               
+
+    
+aclImdb_v1.tar.gz     0%[                    ]  44.69K  36.4KB/s               
+
+    
+aclImdb_v1.tar.gz     0%[                    ]  64.38K  34.9KB/s               
+
+    
+aclImdb_v1.tar.gz     0%[                    ]  79.85K  32.5KB/s               
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 119.23K  38.7KB/s    eta 35m 17s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 158.60K  43.0KB/s    eta 35m 17s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 219.07K  54.9KB/s    eta 35m 17s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 271.10K  58.8KB/s    eta 23m 12s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 330.16K  63.2KB/s    eta 23m 12s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 396.26K  67.9KB/s    eta 20m 4s 
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 456.73K  70.8KB/s    eta 20m 4s 
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 528.44K  74.8KB/s    eta 18m 11s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 601.57K  78.3KB/s    eta 18m 11s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 677.51K  81.7KB/s    eta 16m 37s
+
+    
+aclImdb_v1.tar.gz     0%[                    ] 756.26K  84.9KB/s    eta 16m 37s
+
+    
+aclImdb_v1.tar.gz     1%[                    ] 840.63K  88.2KB/s    eta 15m 21s
+
+    
+aclImdb_v1.tar.gz     1%[                    ] 930.63K  91.8KB/s    eta 15m 21s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1023K  95.2KB/s    eta 14m 12s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1.09M  98.7KB/s    eta 14m 12s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1.18M   101KB/s    eta 13m 19s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1.30M   109KB/s    eta 13m 19s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1.41M   117KB/s    eta 12m 19s
+
+    
+aclImdb_v1.tar.gz     1%[                    ]   1.51M   124KB/s    eta 12m 19s
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   1.65M   134KB/s    eta 11m 29s
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   1.77M   142KB/s    eta 11m 29s
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   1.91M   150KB/s    eta 10m 42s
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   2.05M   153KB/s    eta 10m 42s
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   2.21M   162KB/s    eta 9m 58s 
+
+    
+aclImdb_v1.tar.gz     2%[                    ]   2.36M   170KB/s    eta 9m 58s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   2.52M   182KB/s    eta 9m 58s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   2.71M   193KB/s    eta 8m 48s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   2.87M   191KB/s    eta 8m 48s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   2.92M   195KB/s    eta 8m 41s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   2.97M   194KB/s    eta 8m 41s 
+
+    
+aclImdb_v1.tar.gz     3%[                    ]   3.12M   200KB/s    eta 8m 37s 
+
+    
+aclImdb_v1.tar.gz     4%[                    ]   3.27M   206KB/s    eta 8m 37s 
+
+    
+aclImdb_v1.tar.gz     4%[                    ]   3.42M   212KB/s    eta 8m 16s 
+
+    
+aclImdb_v1.tar.gz     4%[                    ]   3.61M   220KB/s    eta 8m 16s 
+
+    
+aclImdb_v1.tar.gz     4%[                    ]   3.77M   216KB/s    eta 8m 1s  
+
+    
+aclImdb_v1.tar.gz     4%[                    ]   3.83M   220KB/s    eta 8m 1s  
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.01M   226KB/s    eta 8m 1s  
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.21M   235KB/s    eta 7m 34s 
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.35M   237KB/s    eta 7m 34s 
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.48M   238KB/s    eta 7m 27s 
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.64M   242KB/s    eta 7m 27s 
+
+    
+aclImdb_v1.tar.gz     5%[>                   ]   4.78M   243KB/s    eta 7m 16s 
+
+    
+aclImdb_v1.tar.gz     6%[>                   ]   4.95M   251KB/s    eta 7m 16s 
+
+    
+aclImdb_v1.tar.gz     6%[>                   ]   5.11M   254KB/s    eta 7m 16s 
+
+    
+aclImdb_v1.tar.gz     6%[>                   ]   5.26M   255KB/s    eta 6m 56s 
+
+    
+aclImdb_v1.tar.gz     6%[>                   ]   5.42M   255KB/s    eta 6m 56s 
+
+    
+aclImdb_v1.tar.gz     6%[>                   ]   5.57M   254KB/s    eta 6m 48s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   5.73M   249KB/s    eta 6m 48s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   5.89M   247KB/s    eta 6m 40s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   6.05M   255KB/s    eta 6m 40s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   6.23M   250KB/s    eta 6m 35s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   6.29M   257KB/s    eta 6m 35s 
+
+    
+aclImdb_v1.tar.gz     7%[>                   ]   6.41M   256KB/s    eta 6m 35s 
+
+    
+aclImdb_v1.tar.gz     8%[>                   ]   6.67M   264KB/s    eta 6m 23s 
+
+    
+aclImdb_v1.tar.gz     8%[>                   ]   6.80M   261KB/s    eta 6m 23s 
+
+    
+aclImdb_v1.tar.gz     8%[>                   ]   6.96M   260KB/s    eta 6m 19s 
+
+    
+aclImdb_v1.tar.gz     8%[>                   ]   7.11M   266KB/s    eta 6m 19s 
+
+    
+aclImdb_v1.tar.gz     9%[>                   ]   7.28M   265KB/s    eta 6m 13s 
+
+    
+aclImdb_v1.tar.gz     9%[>                   ]   7.45M   263KB/s    eta 6m 13s 
+
+    
+aclImdb_v1.tar.gz     9%[>                   ]   7.61M   256KB/s    eta 6m 10s 
+
+    
+aclImdb_v1.tar.gz     9%[>                   ]   7.67M   258KB/s    eta 6m 10s 
+
+    
+aclImdb_v1.tar.gz     9%[>                   ]   7.86M   262KB/s    eta 6m 10s 
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.06M   265KB/s    eta 6m 0s  
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.19M   265KB/s    eta 6m 0s  
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.32M   257KB/s    eta 5m 58s 
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.48M   256KB/s    eta 5m 58s 
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.63M   255KB/s    eta 5m 54s 
+
+    
+aclImdb_v1.tar.gz    10%[=>                  ]   8.79M   255KB/s    eta 5m 54s 
+
+    
+aclImdb_v1.tar.gz    11%[=>                  ]   8.95M   256KB/s    eta 5m 50s 
+
+    
+aclImdb_v1.tar.gz    11%[=>                  ]   9.10M   255KB/s    eta 5m 50s 
+
+    
+aclImdb_v1.tar.gz    11%[=>                  ]   9.25M   255KB/s    eta 5m 46s 
+
+    
+aclImdb_v1.tar.gz    11%[=>                  ]   9.41M   254KB/s    eta 5m 46s 
+
+    
+aclImdb_v1.tar.gz    11%[=>                  ]   9.58M   261KB/s    eta 5m 42s 
+
+    
+aclImdb_v1.tar.gz    12%[=>                  ]   9.75M   265KB/s    eta 5m 42s 
+
+    
+aclImdb_v1.tar.gz    12%[=>                  ]   9.92M   258KB/s    eta 5m 37s 
+
+    
+aclImdb_v1.tar.gz    12%[=>                  ]  10.08M   252KB/s    eta 5m 37s 
+
+    
+aclImdb_v1.tar.gz    12%[=>                  ]  10.14M   254KB/s    eta 5m 37s 
+
+    
+aclImdb_v1.tar.gz    12%[=>                  ]  10.27M   257KB/s    eta 5m 37s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.53M   265KB/s    eta 5m 37s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.66M   268KB/s    eta 5m 27s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.68M   256KB/s    eta 5m 27s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.70M   252KB/s    eta 5m 33s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.74M   240KB/s    eta 5m 33s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.77M   226KB/s    eta 5m 39s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.82M   219KB/s    eta 5m 39s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.86M   211KB/s    eta 5m 43s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.91M   202KB/s    eta 5m 43s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  10.95M   194KB/s    eta 5m 48s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  11.02M   186KB/s    eta 5m 48s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  11.08M   178KB/s    eta 5m 51s 
+
+    
+aclImdb_v1.tar.gz    13%[=>                  ]  11.17M   172KB/s    eta 5m 51s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.25M   166KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.35M   162KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.45M   156KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.56M   151KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.67M   146KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.79M   144KB/s    eta 5m 52s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  11.90M   140KB/s    eta 5m 51s 
+
+    
+aclImdb_v1.tar.gz    14%[=>                  ]  12.02M   127KB/s    eta 5m 51s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.14M   124KB/s    eta 5m 50s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.26M   135KB/s    eta 5m 50s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.38M   143KB/s    eta 5m 50s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.50M   151KB/s    eta 5m 46s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.63M   159KB/s    eta 5m 46s 
+
+    
+aclImdb_v1.tar.gz    15%[==>                 ]  12.76M   166KB/s    eta 5m 44s 
+
+    
+aclImdb_v1.tar.gz    16%[==>                 ]  12.91M   175KB/s    eta 5m 44s 
+
+    
+aclImdb_v1.tar.gz    16%[==>                 ]  13.06M   184KB/s    eta 5m 41s 
+
+    
+aclImdb_v1.tar.gz    16%[==>                 ]  13.21M   193KB/s    eta 5m 41s 
+
+    
+aclImdb_v1.tar.gz    16%[==>                 ]  13.37M   201KB/s    eta 5m 38s 
+
+    
+aclImdb_v1.tar.gz    16%[==>                 ]  13.55M   211KB/s    eta 5m 38s 
+
+    
+aclImdb_v1.tar.gz    17%[==>                 ]  13.71M   208KB/s    eta 5m 36s 
+
+    
+aclImdb_v1.tar.gz    17%[==>                 ]  13.77M   212KB/s    eta 5m 36s 
+
+    
+aclImdb_v1.tar.gz    17%[==>                 ]  13.90M   216KB/s    eta 5m 36s 
+
+    
+aclImdb_v1.tar.gz    17%[==>                 ]  14.16M   229KB/s    eta 5m 30s 
+
+    
+aclImdb_v1.tar.gz    17%[==>                 ]  14.30M   232KB/s    eta 5m 30s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  14.45M   235KB/s    eta 5m 27s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  14.61M   239KB/s    eta 5m 27s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  14.77M   243KB/s    eta 5m 24s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  14.94M   247KB/s    eta 5m 24s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  15.10M   241KB/s    eta 5m 22s 
+
+    
+aclImdb_v1.tar.gz    18%[==>                 ]  15.16M   244KB/s    eta 5m 22s 
+
+    
+aclImdb_v1.tar.gz    19%[==>                 ]  15.34M   247KB/s    eta 5m 22s 
+
+    
+aclImdb_v1.tar.gz    19%[==>                 ]  15.54M   249KB/s    eta 5m 17s 
+
+    
+aclImdb_v1.tar.gz    19%[==>                 ]  15.68M   250KB/s    eta 5m 17s 
+
+    
+aclImdb_v1.tar.gz    19%[==>                 ]  15.82M   251KB/s    eta 5m 15s 
+
+    
+aclImdb_v1.tar.gz    19%[==>                 ]  15.97M   253KB/s    eta 5m 15s 
+
+    
+aclImdb_v1.tar.gz    20%[===>                ]  16.12M   255KB/s    eta 5m 13s 
+
+    
+aclImdb_v1.tar.gz    20%[===>                ]  16.28M   256KB/s    eta 5m 13s 
+
+    
+aclImdb_v1.tar.gz    20%[===>                ]  16.43M   256KB/s    eta 5m 10s 
+
+    
+aclImdb_v1.tar.gz    20%[===>                ]  16.59M   256KB/s    eta 5m 10s 
+
+    
+aclImdb_v1.tar.gz    20%[===>                ]  16.75M   256KB/s    eta 5m 7s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  16.89M   253KB/s    eta 5m 7s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  17.07M   262KB/s    eta 5m 5s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  17.23M   265KB/s    eta 5m 5s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  17.41M   257KB/s    eta 5m 2s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  17.57M   251KB/s    eta 5m 2s  
+
+    
+aclImdb_v1.tar.gz    21%[===>                ]  17.63M   252KB/s    eta 5m 1s  
+
+    
+aclImdb_v1.tar.gz    22%[===>                ]  17.81M   255KB/s    eta 5m 1s  
+
+    
+aclImdb_v1.tar.gz    22%[===>                ]  18.02M   258KB/s    eta 4m 57s 
+
+    
+aclImdb_v1.tar.gz    22%[===>                ]  18.16M   257KB/s    eta 4m 57s 
+
+    
+aclImdb_v1.tar.gz    22%[===>                ]  18.31M   255KB/s    eta 4m 55s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  18.45M   261KB/s    eta 4m 55s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  18.62M   260KB/s    eta 4m 53s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  18.79M   258KB/s    eta 4m 53s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  18.95M   252KB/s    eta 4m 51s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  19.01M   253KB/s    eta 4m 51s 
+
+    
+aclImdb_v1.tar.gz    23%[===>                ]  19.20M   256KB/s    eta 4m 51s 
+
+    
+aclImdb_v1.tar.gz    24%[===>                ]  19.40M   260KB/s    eta 4m 47s 
+
+    
+aclImdb_v1.tar.gz    24%[===>                ]  19.53M   258KB/s    eta 4m 47s 
+
+    
+aclImdb_v1.tar.gz    24%[===>                ]  19.68M   257KB/s    eta 4m 46s 
+
+    
+aclImdb_v1.tar.gz    24%[===>                ]  19.82M   257KB/s    eta 4m 46s 
+
+    
+aclImdb_v1.tar.gz    24%[===>                ]  19.97M   256KB/s    eta 4m 44s 
+
+    
+aclImdb_v1.tar.gz    25%[====>               ]  20.13M   257KB/s    eta 4m 44s 
+
+    
+aclImdb_v1.tar.gz    25%[====>               ]  20.28M   256KB/s    eta 4m 41s 
+
+    
+aclImdb_v1.tar.gz    25%[====>               ]  20.44M   260KB/s    eta 4m 41s 
+
+    
+aclImdb_v1.tar.gz    25%[====>               ]  20.60M   261KB/s    eta 4m 41s 
+
+    
+aclImdb_v1.tar.gz    25%[====>               ]  20.76M   263KB/s    eta 4m 37s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  20.92M   274KB/s    eta 4m 37s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  21.08M   273KB/s    eta 4m 34s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  21.25M   269KB/s    eta 4m 34s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  21.42M   272KB/s    eta 4m 32s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  21.58M   265KB/s    eta 4m 32s 
+
+    
+aclImdb_v1.tar.gz    26%[====>               ]  21.65M   265KB/s    eta 4m 31s 
+
+    
+aclImdb_v1.tar.gz    27%[====>               ]  21.83M   268KB/s    eta 4m 31s 
+
+    
+aclImdb_v1.tar.gz    27%[====>               ]  22.04M   271KB/s    eta 4m 28s 
+
+    
+aclImdb_v1.tar.gz    27%[====>               ]  22.17M   269KB/s    eta 4m 28s 
+
+    
+aclImdb_v1.tar.gz    27%[====>               ]  22.32M   276KB/s    eta 4m 26s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  22.47M   273KB/s    eta 4m 26s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  22.65M   271KB/s    eta 4m 24s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  22.83M   274KB/s    eta 4m 24s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  22.99M   267KB/s    eta 4m 23s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  23.05M   268KB/s    eta 4m 23s 
+
+    
+aclImdb_v1.tar.gz    28%[====>               ]  23.23M   271KB/s    eta 4m 23s 
+
+    
+aclImdb_v1.tar.gz    29%[====>               ]  23.44M   275KB/s    eta 4m 19s 
+
+    
+aclImdb_v1.tar.gz    29%[====>               ]  23.57M   273KB/s    eta 4m 19s 
+
+    
+aclImdb_v1.tar.gz    29%[====>               ]  23.71M   272KB/s    eta 4m 18s 
+
+    
+aclImdb_v1.tar.gz    29%[====>               ]  23.85M   265KB/s    eta 4m 18s 
+
+    
+aclImdb_v1.tar.gz    29%[====>               ]  24.02M   264KB/s    eta 4m 16s 
+
+    
+aclImdb_v1.tar.gz    30%[=====>              ]  24.16M   261KB/s    eta 4m 16s 
+
+    
+aclImdb_v1.tar.gz    30%[=====>              ]  24.32M   258KB/s    eta 4m 14s 
+
+    
+aclImdb_v1.tar.gz    30%[=====>              ]  24.48M   257KB/s    eta 4m 14s 
+
+    
+aclImdb_v1.tar.gz    30%[=====>              ]  24.65M   258KB/s    eta 4m 12s 
+
+    
+aclImdb_v1.tar.gz    30%[=====>              ]  24.81M   257KB/s    eta 4m 12s 
+
+    
+aclImdb_v1.tar.gz    31%[=====>              ]  24.96M   263KB/s    eta 4m 10s 
+
+    
+aclImdb_v1.tar.gz    31%[=====>              ]  25.14M   263KB/s    eta 4m 10s 
+
+    
+aclImdb_v1.tar.gz    31%[=====>              ]  25.30M   260KB/s    eta 4m 8s  
+
+    
+aclImdb_v1.tar.gz    31%[=====>              ]  25.47M   254KB/s    eta 4m 8s  
+
+    
+aclImdb_v1.tar.gz    32%[=====>              ]  25.72M   259KB/s    eta 4m 6s  
+
+    
+aclImdb_v1.tar.gz    32%[=====>              ]  25.92M   263KB/s    eta 4m 6s  
+
+    
+aclImdb_v1.tar.gz    32%[=====>              ]  26.06M   260KB/s    eta 4m 4s  
+
+    
+aclImdb_v1.tar.gz    32%[=====>              ]  26.21M   258KB/s    eta 4m 4s  
+
+    
+aclImdb_v1.tar.gz    32%[=====>              ]  26.29M   265KB/s    eta 4m 4s  
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  26.50M   267KB/s    eta 4m 1s  
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  26.61M   266KB/s    eta 4m 1s  
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  26.72M   265KB/s    eta 4m 1s  
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  26.84M   263KB/s    eta 3m 59s 
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  26.97M   262KB/s    eta 3m 59s 
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  27.10M   259KB/s    eta 3m 58s 
+
+    
+aclImdb_v1.tar.gz    33%[=====>              ]  27.23M   258KB/s    eta 3m 58s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.35M   248KB/s    eta 3m 58s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.41M   247KB/s    eta 3m 58s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.58M   248KB/s    eta 3m 58s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.66M   241KB/s    eta 3m 57s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.77M   237KB/s    eta 3m 57s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.87M   233KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    34%[=====>              ]  27.96M   226KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.08M   222KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.18M   221KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.29M   214KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.41M   207KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.52M   205KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.63M   202KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.76M   201KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    35%[======>             ]  28.87M   195KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.01M   197KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.16M   199KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.30M   206KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.32M   202KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.35M   194KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.39M   186KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.42M   183KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.48M   173KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.52M   169KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.58M   167KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    36%[======>             ]  29.65M   163KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  29.72M   161KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  29.79M   157KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  29.89M   157KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  29.97M   155KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  30.09M   155KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  30.20M   154KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  30.31M   158KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    37%[======>             ]  30.44M   159KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.58M   160KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.59M   144KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.62M   133KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.65M   120KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.68M   118KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.72M   118KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.77M   119KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.82M   120KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.87M   120KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  30.93M   122KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  31.00M   121KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  31.07M   121KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  31.15M   122KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    38%[======>             ]  31.23M   123KB/s    eta 3m 56s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.33M   123KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.44M   125KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.54M   124KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.65M   125KB/s    eta 3m 55s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.77M   121KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.88M   120KB/s    eta 3m 54s 
+
+    
+aclImdb_v1.tar.gz    39%[======>             ]  31.99M   117KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.10M   126KB/s    eta 3m 53s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.22M   133KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.34M   141KB/s    eta 3m 52s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.46M   148KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.59M   156KB/s    eta 3m 51s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.73M   164KB/s    eta 3m 50s 
+
+    
+aclImdb_v1.tar.gz    40%[=======>            ]  32.88M   172KB/s    eta 3m 50s 
+
+    
+aclImdb_v1.tar.gz    41%[=======>            ]  33.02M   183KB/s    eta 3m 48s 
+
+    
+aclImdb_v1.tar.gz    41%[=======>            ]  33.19M   195KB/s    eta 3m 48s 
+
+    
+aclImdb_v1.tar.gz    41%[=======>            ]  33.36M   206KB/s    eta 3m 48s 
+
+    
+aclImdb_v1.tar.gz    41%[=======>            ]  33.53M   203KB/s    eta 3m 44s 
+
+    
+aclImdb_v1.tar.gz    41%[=======>            ]  33.53M   203KB/s    eta 3m 44s 
+
+    
+aclImdb_v1.tar.gz    42%[=======>            ]  33.77M   216KB/s    eta 3m 44s 
+
+    
+aclImdb_v1.tar.gz    42%[=======>            ]  33.97M   227KB/s    eta 3m 41s 
+
+    
+aclImdb_v1.tar.gz    42%[=======>            ]  34.11M   230KB/s    eta 3m 41s 
+
+    
+aclImdb_v1.tar.gz    42%[=======>            ]  34.25M   233KB/s    eta 3m 40s 
+
+    
+aclImdb_v1.tar.gz    42%[=======>            ]  34.41M   237KB/s    eta 3m 40s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  34.56M   246KB/s    eta 3m 40s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  34.74M   252KB/s    eta 3m 37s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  34.90M   246KB/s    eta 3m 37s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  34.94M   247KB/s    eta 3m 36s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  34.97M   240KB/s    eta 3m 36s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  35.10M   242KB/s    eta 3m 36s 
+
+    
+aclImdb_v1.tar.gz    43%[=======>            ]  35.24M   243KB/s    eta 3m 36s 
+
+    
+aclImdb_v1.tar.gz    44%[=======>            ]  35.37M   244KB/s    eta 3m 34s 
+
+    
+aclImdb_v1.tar.gz    44%[=======>            ]  35.53M   247KB/s    eta 3m 34s 
+
+    
+aclImdb_v1.tar.gz    44%[=======>            ]  35.68M   249KB/s    eta 3m 33s 
+
+    
+aclImdb_v1.tar.gz    44%[=======>            ]  35.83M   250KB/s    eta 3m 33s 
+
+    
+aclImdb_v1.tar.gz    44%[=======>            ]  35.98M   250KB/s    eta 3m 31s 
+
+    
+aclImdb_v1.tar.gz    45%[========>           ]  36.14M   247KB/s    eta 3m 31s 
+
+    
+aclImdb_v1.tar.gz    45%[========>           ]  36.29M   242KB/s    eta 3m 29s 
+
+    
+aclImdb_v1.tar.gz    45%[========>           ]  36.45M   239KB/s    eta 3m 29s 
+
+    
+aclImdb_v1.tar.gz    45%[========>           ]  36.60M   249KB/s    eta 3m 27s 
+
+    
+aclImdb_v1.tar.gz    45%[========>           ]  36.78M   245KB/s    eta 3m 27s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  36.94M   239KB/s    eta 3m 26s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  37.00M   235KB/s    eta 3m 26s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  37.18M   238KB/s    eta 3m 26s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  37.38M   243KB/s    eta 3m 23s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  37.52M   241KB/s    eta 3m 23s 
+
+    
+aclImdb_v1.tar.gz    46%[========>           ]  37.67M   235KB/s    eta 3m 21s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  37.82M   233KB/s    eta 3m 21s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  37.98M   241KB/s    eta 3m 20s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  38.14M   252KB/s    eta 3m 20s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  38.31M   254KB/s    eta 3m 18s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  38.48M   249KB/s    eta 3m 18s 
+
+    
+aclImdb_v1.tar.gz    47%[========>           ]  38.48M   246KB/s    eta 3m 17s 
+
+    
+aclImdb_v1.tar.gz    48%[========>           ]  38.72M   254KB/s    eta 3m 17s 
+
+    
+aclImdb_v1.tar.gz    48%[========>           ]  38.93M   258KB/s    eta 3m 14s 
+
+    
+aclImdb_v1.tar.gz    48%[========>           ]  39.06M   256KB/s    eta 3m 14s 
+
+    
+aclImdb_v1.tar.gz    48%[========>           ]  39.20M   256KB/s    eta 3m 13s 
+
+    
+aclImdb_v1.tar.gz    49%[========>           ]  39.35M   255KB/s    eta 3m 13s 
+
+    
+aclImdb_v1.tar.gz    49%[========>           ]  39.51M   255KB/s    eta 3m 11s 
+
+    
+aclImdb_v1.tar.gz    49%[========>           ]  39.66M   256KB/s    eta 3m 11s 
+
+    
+aclImdb_v1.tar.gz    49%[========>           ]  39.82M   256KB/s    eta 3m 10s 
+
+    
+aclImdb_v1.tar.gz    49%[========>           ]  39.97M   255KB/s    eta 3m 10s 
+
+    
+aclImdb_v1.tar.gz    50%[=========>          ]  40.13M   254KB/s    eta 3m 8s  
+
+    
+aclImdb_v1.tar.gz    50%[=========>          ]  40.29M   261KB/s    eta 3m 8s  
+
+    
+aclImdb_v1.tar.gz    50%[=========>          ]  40.45M   260KB/s    eta 3m 6s  
+
+    
+aclImdb_v1.tar.gz    50%[=========>          ]  40.62M   257KB/s    eta 3m 6s  
+
+    
+aclImdb_v1.tar.gz    50%[=========>          ]  40.79M   260KB/s    eta 3m 4s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  40.96M   253KB/s    eta 3m 4s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  40.96M   250KB/s    eta 3m 4s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  41.20M   256KB/s    eta 3m 4s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  41.41M   266KB/s    eta 3m 4s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  41.55M   264KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  41.69M   263KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    51%[=========>          ]  41.71M   263KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.74M   245KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.77M   231KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.80M   223KB/s    eta 3m 0s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.85M   215KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.89M   207KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.94M   198KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  41.99M   190KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.05M   186KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.11M   184KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.20M   180KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.29M   179KB/s    eta 3m 1s  
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.38M   177KB/s    eta 2m 59s 
+
+    
+aclImdb_v1.tar.gz    52%[=========>          ]  42.50M   172KB/s    eta 2m 59s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  42.61M   167KB/s    eta 2m 58s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  42.72M   171KB/s    eta 2m 58s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  42.83M   158KB/s    eta 2m 57s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  42.96M   147KB/s    eta 2m 57s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  43.09M   146KB/s    eta 2m 56s 
+
+    
+aclImdb_v1.tar.gz    53%[=========>          ]  43.20M   147KB/s    eta 2m 56s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.33M   157KB/s    eta 2m 56s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.46M   168KB/s    eta 2m 54s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.58M   176KB/s    eta 2m 54s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.72M   186KB/s    eta 2m 53s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.85M   195KB/s    eta 2m 53s 
+
+    
+aclImdb_v1.tar.gz    54%[=========>          ]  43.98M   203KB/s    eta 2m 52s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.14M   213KB/s    eta 2m 52s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.30M   224KB/s    eta 2m 50s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.47M   229KB/s    eta 2m 50s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.64M   224KB/s    eta 2m 48s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.70M   225KB/s    eta 2m 48s 
+
+    
+aclImdb_v1.tar.gz    55%[==========>         ]  44.88M   229KB/s    eta 2m 48s 
+
+    
+aclImdb_v1.tar.gz    56%[==========>         ]  45.08M   232KB/s    eta 2m 46s 
+
+    
+aclImdb_v1.tar.gz    56%[==========>         ]  45.21M   230KB/s    eta 2m 46s 
+
+    
+aclImdb_v1.tar.gz    56%[==========>         ]  45.37M   234KB/s    eta 2m 44s 
+
+    
+aclImdb_v1.tar.gz    56%[==========>         ]  45.53M   237KB/s    eta 2m 44s 
+
+    
+aclImdb_v1.tar.gz    56%[==========>         ]  45.69M   241KB/s    eta 2m 42s 
+
+    
+aclImdb_v1.tar.gz    57%[==========>         ]  45.87M   247KB/s    eta 2m 42s 
+
+    
+aclImdb_v1.tar.gz    57%[==========>         ]  46.03M   241KB/s    eta 2m 41s 
+
+    
+aclImdb_v1.tar.gz    57%[==========>         ]  46.09M   243KB/s    eta 2m 41s 
+
+    
+aclImdb_v1.tar.gz    57%[==========>         ]  46.28M   247KB/s    eta 2m 41s 
+
+    
+aclImdb_v1.tar.gz    57%[==========>         ]  46.48M   248KB/s    eta 2m 38s 
+
+    
+aclImdb_v1.tar.gz    58%[==========>         ]  46.61M   249KB/s    eta 2m 38s 
+
+    
+aclImdb_v1.tar.gz    58%[==========>         ]  46.76M   250KB/s    eta 2m 37s 
+
+    
+aclImdb_v1.tar.gz    58%[==========>         ]  46.90M   251KB/s    eta 2m 37s 
+
+    
+aclImdb_v1.tar.gz    58%[==========>         ]  47.05M   252KB/s    eta 2m 36s 
+
+    
+aclImdb_v1.tar.gz    58%[==========>         ]  47.21M   255KB/s    eta 2m 36s 
+
+    
+aclImdb_v1.tar.gz    59%[==========>         ]  47.37M   257KB/s    eta 2m 34s 
+
+    
+aclImdb_v1.tar.gz    59%[==========>         ]  47.53M   257KB/s    eta 2m 34s 
+
+    
+aclImdb_v1.tar.gz    59%[==========>         ]  47.69M   257KB/s    eta 2m 32s 
+
+    
+aclImdb_v1.tar.gz    59%[==========>         ]  47.85M   256KB/s    eta 2m 32s 
+
+    
+aclImdb_v1.tar.gz    59%[==========>         ]  48.01M   263KB/s    eta 2m 30s 
+
+    
+aclImdb_v1.tar.gz    60%[===========>        ]  48.18M   262KB/s    eta 2m 30s 
+
+    
+aclImdb_v1.tar.gz    60%[===========>        ]  48.36M   260KB/s    eta 2m 29s 
+
+    
+aclImdb_v1.tar.gz    60%[===========>        ]  48.52M   254KB/s    eta 2m 29s 
+
+    
+aclImdb_v1.tar.gz    60%[===========>        ]  48.58M   255KB/s    eta 2m 28s 
+
+    
+aclImdb_v1.tar.gz    60%[===========>        ]  48.76M   257KB/s    eta 2m 28s 
+
+    
+aclImdb_v1.tar.gz    61%[===========>        ]  48.97M   261KB/s    eta 2m 25s 
+
+    
+aclImdb_v1.tar.gz    61%[===========>        ]  49.10M   258KB/s    eta 2m 25s 
+
+    
+aclImdb_v1.tar.gz    61%[===========>        ]  49.26M   257KB/s    eta 2m 24s 
+
+    
+aclImdb_v1.tar.gz    61%[===========>        ]  49.41M   264KB/s    eta 2m 24s 
+
+    
+aclImdb_v1.tar.gz    61%[===========>        ]  49.58M   262KB/s    eta 2m 22s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  49.75M   260KB/s    eta 2m 22s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  49.91M   253KB/s    eta 2m 21s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  49.98M   255KB/s    eta 2m 21s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  50.16M   258KB/s    eta 2m 21s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  50.36M   262KB/s    eta 2m 18s 
+
+    
+aclImdb_v1.tar.gz    62%[===========>        ]  50.49M   261KB/s    eta 2m 18s 
+
+    
+aclImdb_v1.tar.gz    63%[===========>        ]  50.63M   264KB/s    eta 2m 18s 
+
+    
+aclImdb_v1.tar.gz    63%[===========>        ]  50.78M   264KB/s    eta 2m 16s 
+
+    
+aclImdb_v1.tar.gz    63%[===========>        ]  50.94M   264KB/s    eta 2m 16s 
+
+    
+aclImdb_v1.tar.gz    63%[===========>        ]  51.09M   264KB/s    eta 2m 15s 
+
+    
+aclImdb_v1.tar.gz    63%[===========>        ]  51.24M   263KB/s    eta 2m 15s 
+
+    
+aclImdb_v1.tar.gz    64%[===========>        ]  51.41M   263KB/s    eta 2m 13s 
+
+    
+aclImdb_v1.tar.gz    64%[===========>        ]  51.57M   263KB/s    eta 2m 13s 
+
+    
+aclImdb_v1.tar.gz    64%[===========>        ]  51.73M   261KB/s    eta 2m 11s 
+
+    
+aclImdb_v1.tar.gz    64%[===========>        ]  51.89M   269KB/s    eta 2m 11s 
+
+    
+aclImdb_v1.tar.gz    64%[===========>        ]  52.05M   267KB/s    eta 2m 10s 
+
+    
+aclImdb_v1.tar.gz    65%[============>       ]  52.22M   265KB/s    eta 2m 10s 
+
+    
+aclImdb_v1.tar.gz    65%[============>       ]  52.38M   258KB/s    eta 2m 8s  
+
+    
+aclImdb_v1.tar.gz    65%[============>       ]  52.45M   259KB/s    eta 2m 8s  
+
+    
+aclImdb_v1.tar.gz    65%[============>       ]  52.63M   261KB/s    eta 2m 8s  
+
+    
+aclImdb_v1.tar.gz    65%[============>       ]  52.83M   265KB/s    eta 2m 6s  
+
+    
+aclImdb_v1.tar.gz    66%[============>       ]  52.96M   262KB/s    eta 2m 6s  
+
+    
+aclImdb_v1.tar.gz    66%[============>       ]  53.10M   260KB/s    eta 2m 5s  
+
+    
+aclImdb_v1.tar.gz    66%[============>       ]  53.26M   267KB/s    eta 2m 5s  
+
+    
+aclImdb_v1.tar.gz    66%[============>       ]  53.42M   271KB/s    eta 2m 5s  
+
+    
+aclImdb_v1.tar.gz    66%[============>       ]  53.58M   275KB/s    eta 2m 2s  
+
+    
+aclImdb_v1.tar.gz    67%[============>       ]  53.75M   286KB/s    eta 2m 2s  
+
+    
+aclImdb_v1.tar.gz    67%[============>       ]  53.94M   292KB/s    eta 2m 2s  
+
+    
+aclImdb_v1.tar.gz    67%[============>       ]  54.14M   299KB/s    eta 1m 59s 
+
+    
+aclImdb_v1.tar.gz    67%[============>       ]  54.30M   289KB/s    eta 1m 59s 
+
+    
+aclImdb_v1.tar.gz    67%[============>       ]  54.36M   290KB/s    eta 1m 58s 
+
+    
+aclImdb_v1.tar.gz    68%[============>       ]  54.61M   306KB/s    eta 1m 58s 
+
+    
+aclImdb_v1.tar.gz    68%[============>       ]  54.75M   313KB/s    eta 1m 58s 
+
+    
+aclImdb_v1.tar.gz    68%[============>       ]  54.90M   311KB/s    eta 1m 55s 
+
+    
+aclImdb_v1.tar.gz    68%[============>       ]  55.04M   313KB/s    eta 1m 55s 
+
+    
+aclImdb_v1.tar.gz    68%[============>       ]  55.21M   314KB/s    eta 1m 53s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  55.38M   315KB/s    eta 1m 53s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  55.54M   303KB/s    eta 1m 52s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  55.61M   304KB/s    eta 1m 52s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  55.78M   310KB/s    eta 1m 52s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  55.99M   325KB/s    eta 1m 49s 
+
+    
+aclImdb_v1.tar.gz    69%[============>       ]  56.12M   320KB/s    eta 1m 49s 
+
+    
+aclImdb_v1.tar.gz    70%[=============>      ]  56.26M   314KB/s    eta 1m 48s 
+
+    
+aclImdb_v1.tar.gz    70%[=============>      ]  56.40M   316KB/s    eta 1m 48s 
+
+    
+aclImdb_v1.tar.gz    70%[=============>      ]  56.55M   316KB/s    eta 1m 47s 
+
+    
+aclImdb_v1.tar.gz    70%[=============>      ]  56.69M   322KB/s    eta 1m 47s 
+
+    
+aclImdb_v1.tar.gz    70%[=============>      ]  56.86M   316KB/s    eta 1m 47s 
+
+    
+aclImdb_v1.tar.gz    71%[=============>      ]  57.01M   307KB/s    eta 1m 45s 
+
+    
+aclImdb_v1.tar.gz    71%[=============>      ]  57.17M   297KB/s    eta 1m 45s 
+
+    
+aclImdb_v1.tar.gz    71%[=============>      ]  57.32M   286KB/s    eta 1m 43s 
+
+    
+aclImdb_v1.tar.gz    71%[=============>      ]  57.48M   278KB/s    eta 1m 43s 
+
+    
+aclImdb_v1.tar.gz    71%[=============>      ]  57.63M   287KB/s    eta 1m 42s 
+
+    
+aclImdb_v1.tar.gz    72%[=============>      ]  57.80M   273KB/s    eta 1m 42s 
+
+    
+aclImdb_v1.tar.gz    72%[=============>      ]  57.97M   269KB/s    eta 1m 40s 
+
+    
+aclImdb_v1.tar.gz    72%[=============>      ]  58.14M   262KB/s    eta 1m 40s 
+
+    
+aclImdb_v1.tar.gz    72%[=============>      ]  58.14M   258KB/s    eta 99s    
+
+    
+aclImdb_v1.tar.gz    72%[=============>      ]  58.33M   259KB/s    eta 99s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.58M   272KB/s    eta 99s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.73M   270KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.88M   278KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.90M   260KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.93M   245KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  58.96M   237KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.00M   228KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.04M   220KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.07M   210KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.13M   199KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.19M   192KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.25M   187KB/s    eta 96s    
+
+    
+aclImdb_v1.tar.gz    73%[=============>      ]  59.31M   179KB/s    eta 95s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.40M   173KB/s    eta 95s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.49M   168KB/s    eta 94s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.58M   163KB/s    eta 94s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.69M   157KB/s    eta 94s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.80M   152KB/s    eta 94s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  59.91M   155KB/s    eta 93s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  60.04M   149KB/s    eta 93s    
+
+    
+aclImdb_v1.tar.gz    74%[=============>      ]  60.16M   135KB/s    eta 92s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.29M   133KB/s    eta 92s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.41M   131KB/s    eta 90s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.54M   140KB/s    eta 90s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.67M   152KB/s    eta 89s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.79M   159KB/s    eta 89s    
+
+    
+aclImdb_v1.tar.gz    75%[==============>     ]  60.93M   168KB/s    eta 88s    
+
+    
+aclImdb_v1.tar.gz    76%[==============>     ]  61.07M   177KB/s    eta 88s    
+
+    
+aclImdb_v1.tar.gz    76%[==============>     ]  61.21M   186KB/s    eta 87s    
+
+    
+aclImdb_v1.tar.gz    76%[==============>     ]  61.36M   194KB/s    eta 87s    
+
+    
+aclImdb_v1.tar.gz    76%[==============>     ]  61.52M   200KB/s    eta 85s    
+
+    
+aclImdb_v1.tar.gz    76%[==============>     ]  61.69M   206KB/s    eta 85s    
+
+    
+aclImdb_v1.tar.gz    77%[==============>     ]  61.92M   215KB/s    eta 83s    
+
+    
+aclImdb_v1.tar.gz    77%[==============>     ]  62.09M   223KB/s    eta 83s    
+
+    
+aclImdb_v1.tar.gz    77%[==============>     ]  62.30M   232KB/s    eta 82s    
+
+    
+aclImdb_v1.tar.gz    77%[==============>     ]  62.43M   235KB/s    eta 82s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  62.58M   239KB/s    eta 80s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  62.73M   242KB/s    eta 80s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  62.88M   245KB/s    eta 79s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  63.06M   250KB/s    eta 79s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  63.22M   244KB/s    eta 77s    
+
+    
+aclImdb_v1.tar.gz    78%[==============>     ]  63.28M   246KB/s    eta 77s    
+
+    
+aclImdb_v1.tar.gz    79%[==============>     ]  63.46M   250KB/s    eta 77s    
+
+    
+aclImdb_v1.tar.gz    79%[==============>     ]  63.66M   256KB/s    eta 75s    
+
+    
+aclImdb_v1.tar.gz    79%[==============>     ]  63.79M   256KB/s    eta 75s    
+
+    
+aclImdb_v1.tar.gz    79%[==============>     ]  63.93M   253KB/s    eta 74s    
+
+    
+aclImdb_v1.tar.gz    79%[==============>     ]  64.06M   254KB/s    eta 74s    
+
+    
+aclImdb_v1.tar.gz    80%[===============>    ]  64.23M   255KB/s    eta 73s    
+
+    
+aclImdb_v1.tar.gz    80%[===============>    ]  64.38M   257KB/s    eta 73s    
+
+    
+aclImdb_v1.tar.gz    80%[===============>    ]  64.53M   257KB/s    eta 71s    
+
+    
+aclImdb_v1.tar.gz    80%[===============>    ]  64.69M   258KB/s    eta 71s    
+
+    
+aclImdb_v1.tar.gz    80%[===============>    ]  64.84M   257KB/s    eta 70s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.00M   256KB/s    eta 70s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.15M   257KB/s    eta 68s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.32M   256KB/s    eta 68s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.49M   254KB/s    eta 67s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.65M   248KB/s    eta 67s    
+
+    
+aclImdb_v1.tar.gz    81%[===============>    ]  65.71M   248KB/s    eta 66s    
+
+    
+aclImdb_v1.tar.gz    82%[===============>    ]  65.89M   251KB/s    eta 66s    
+
+    
+aclImdb_v1.tar.gz    82%[===============>    ]  66.09M   255KB/s    eta 64s    
+
+    
+aclImdb_v1.tar.gz    82%[===============>    ]  66.23M   254KB/s    eta 64s    
+
+    
+aclImdb_v1.tar.gz    82%[===============>    ]  66.38M   251KB/s    eta 63s    
+
+    
+aclImdb_v1.tar.gz    82%[===============>    ]  66.53M   258KB/s    eta 63s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  66.69M   257KB/s    eta 61s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  66.85M   250KB/s    eta 61s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  66.86M   243KB/s    eta 60s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  67.05M   242KB/s    eta 60s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  67.09M   234KB/s    eta 60s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  67.22M   234KB/s    eta 60s    
+
+    
+aclImdb_v1.tar.gz    83%[===============>    ]  67.35M   231KB/s    eta 58s    
+
+    
+aclImdb_v1.tar.gz    84%[===============>    ]  67.49M   230KB/s    eta 58s    
+
+    
+aclImdb_v1.tar.gz    84%[===============>    ]  67.63M   230KB/s    eta 57s    
+
+    
+aclImdb_v1.tar.gz    84%[===============>    ]  67.78M   229KB/s    eta 57s    
+
+    
+aclImdb_v1.tar.gz    84%[===============>    ]  67.93M   229KB/s    eta 56s    
+
+    
+aclImdb_v1.tar.gz    84%[===============>    ]  68.09M   229KB/s    eta 56s    
+
+    
+aclImdb_v1.tar.gz    85%[================>   ]  68.24M   229KB/s    eta 54s    
+
+    
+aclImdb_v1.tar.gz    85%[================>   ]  68.38M   227KB/s    eta 54s    
+
+    
+aclImdb_v1.tar.gz    85%[================>   ]  68.55M   226KB/s    eta 53s    
+
+    
+aclImdb_v1.tar.gz    85%[================>   ]  68.71M   232KB/s    eta 53s    
+
+    
+aclImdb_v1.tar.gz    85%[================>   ]  68.88M   231KB/s    eta 51s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.04M   227KB/s    eta 51s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.10M   223KB/s    eta 50s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.28M   226KB/s    eta 50s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.48M   230KB/s    eta 49s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.61M   228KB/s    eta 49s    
+
+    
+aclImdb_v1.tar.gz    86%[================>   ]  69.76M   227KB/s    eta 47s    
+
+    
+aclImdb_v1.tar.gz    87%[================>   ]  69.92M   237KB/s    eta 47s    
+
+    
+aclImdb_v1.tar.gz    87%[================>   ]  70.08M   240KB/s    eta 46s    
+
+    
+aclImdb_v1.tar.gz    87%[================>   ]  70.25M   251KB/s    eta 46s    
+
+    
+aclImdb_v1.tar.gz    87%[================>   ]  70.41M   245KB/s    eta 44s    
+
+    
+aclImdb_v1.tar.gz    87%[================>   ]  70.47M   247KB/s    eta 44s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  70.65M   256KB/s    eta 44s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  70.84M   260KB/s    eta 42s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  70.98M   266KB/s    eta 42s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.01M   256KB/s    eta 42s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.03M   246KB/s    eta 42s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.07M   237KB/s    eta 42s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.11M   228KB/s    eta 41s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.16M   220KB/s    eta 41s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.20M   211KB/s    eta 41s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.26M   203KB/s    eta 41s    
+
+    
+aclImdb_v1.tar.gz    88%[================>   ]  71.33M   195KB/s    eta 40s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.40M   192KB/s    eta 40s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.48M   184KB/s    eta 40s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.59M   176KB/s    eta 40s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.69M   173KB/s    eta 39s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.79M   169KB/s    eta 39s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  71.90M   165KB/s    eta 38s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  72.01M   161KB/s    eta 38s    
+
+    
+aclImdb_v1.tar.gz    89%[================>   ]  72.12M   156KB/s    eta 37s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.23M   154KB/s    eta 37s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.35M   145KB/s    eta 36s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.45M   137KB/s    eta 36s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.57M   133KB/s    eta 35s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.69M   140KB/s    eta 35s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.82M   149KB/s    eta 34s    
+
+    
+aclImdb_v1.tar.gz    90%[=================>  ]  72.95M   156KB/s    eta 34s    
+
+    
+aclImdb_v1.tar.gz    91%[=================>  ]  73.09M   165KB/s    eta 33s    
+
+    
+aclImdb_v1.tar.gz    91%[=================>  ]  73.23M   173KB/s    eta 33s    
+
+    
+aclImdb_v1.tar.gz    91%[=================>  ]  73.39M   182KB/s    eta 31s    
+
+    
+aclImdb_v1.tar.gz    91%[=================>  ]  73.55M   191KB/s    eta 31s    
+
+    
+aclImdb_v1.tar.gz    91%[=================>  ]  73.72M   199KB/s    eta 30s    
+
+    
+aclImdb_v1.tar.gz    92%[=================>  ]  73.88M   196KB/s    eta 30s    
+
+    
+aclImdb_v1.tar.gz    92%[=================>  ]  74.12M   211KB/s    eta 28s    
+
+    
+aclImdb_v1.tar.gz    92%[=================>  ]  74.33M   219KB/s    eta 28s    
+
+    
+aclImdb_v1.tar.gz    92%[=================>  ]  74.46M   222KB/s    eta 26s    
+
+    
+aclImdb_v1.tar.gz    92%[=================>  ]  74.60M   225KB/s    eta 26s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  74.75M   234KB/s    eta 26s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  74.92M   238KB/s    eta 24s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.09M   243KB/s    eta 24s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.11M   242KB/s    eta 24s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.14M   235KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.19M   230KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.23M   228KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.29M   224KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.34M   223KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    93%[=================>  ]  75.40M   217KB/s    eta 23s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  75.49M   213KB/s    eta 22s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  75.57M   212KB/s    eta 22s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  75.67M   208KB/s    eta 22s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  75.78M   203KB/s    eta 20s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  75.90M   199KB/s    eta 20s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  76.03M   199KB/s    eta 19s    
+
+    
+aclImdb_v1.tar.gz    94%[=================>  ]  76.17M   195KB/s    eta 19s    
+
+    
+aclImdb_v1.tar.gz    95%[==================> ]  76.31M   189KB/s    eta 18s    
+
+    
+aclImdb_v1.tar.gz    95%[==================> ]  76.44M   194KB/s    eta 18s    
+
+    
+aclImdb_v1.tar.gz    95%[==================> ]  76.59M   196KB/s    eta 18s    
+
+    
+aclImdb_v1.tar.gz    95%[==================> ]  76.74M   189KB/s    eta 16s    
+
+    
+aclImdb_v1.tar.gz    95%[==================> ]  76.88M   187KB/s    eta 16s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.03M   185KB/s    eta 15s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.18M   191KB/s    eta 15s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.34M   204KB/s    eta 13s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.50M   214KB/s    eta 13s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.57M   212KB/s    eta 12s    
+
+    
+aclImdb_v1.tar.gz    96%[==================> ]  77.80M   226KB/s    eta 12s    
+
+    
+aclImdb_v1.tar.gz    97%[==================> ]  77.92M   227KB/s    eta 11s    
+
+    
+aclImdb_v1.tar.gz    97%[==================> ]  78.05M   233KB/s    eta 11s    
+
+    
+aclImdb_v1.tar.gz    97%[==================> ]  78.18M   238KB/s    eta 9s     
+
+    
+aclImdb_v1.tar.gz    97%[==================> ]  78.33M   239KB/s    eta 9s     
+
+    
+aclImdb_v1.tar.gz    97%[==================> ]  78.49M   243KB/s    eta 8s     
+
+    
+aclImdb_v1.tar.gz    98%[==================> ]  78.65M   248KB/s    eta 8s     
+
+    
+aclImdb_v1.tar.gz    98%[==================> ]  78.81M   251KB/s    eta 6s     
+
+    
+aclImdb_v1.tar.gz    98%[==================> ]  78.99M   255KB/s    eta 6s     
+
+    
+aclImdb_v1.tar.gz    98%[==================> ]  79.16M   258KB/s    eta 5s     
+
+    
+aclImdb_v1.tar.gz    98%[==================> ]  79.34M   261KB/s    eta 5s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  79.50M   264KB/s    eta 5s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  79.69M   267KB/s    eta 2s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  79.89M   265KB/s    eta 2s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  79.92M   256KB/s    eta 1s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  80.05M   253KB/s    eta 1s     
+
+    
+aclImdb_v1.tar.gz    99%[==================> ]  80.18M   253KB/s    eta 0s     
+aclImdb_v1.tar.gz   100%[===================>]  80.23M   256KB/s    in 6m 5s   
     
 <div class="k-default-codeblock">
 ```
-2023-11-22 17:59:34 (93.3 MB/s) - ‘aclImdb_v1.tar.gz’ saved [84125825/84125825]
+2025-01-06 21:38:16 (225 KB/s) - ‘aclImdb_v1.tar.gz’ saved [84125825/84125825]
 ```
 </div>
     
@@ -131,9 +1993,9 @@ print(os.listdir("./aclImdb/test"))
 
 <div class="k-default-codeblock">
 ```
-['README', 'imdb.vocab', 'imdbEr.txt', 'train', 'test']
-['neg', 'unsup', 'pos', 'unsupBow.feat', 'urls_unsup.txt', 'urls_neg.txt', 'urls_pos.txt', 'labeledBow.feat']
-['neg', 'pos', 'urls_neg.txt', 'urls_pos.txt', 'labeledBow.feat']
+['train', 'README', 'imdb.vocab', 'test', 'imdbEr.txt']
+['labeledBow.feat', 'urls_neg.txt', 'unsupBow.feat', 'urls_pos.txt', 'pos', 'urls_unsup.txt', 'neg', 'unsup']
+['labeledBow.feat', 'urls_neg.txt', 'urls_pos.txt', 'pos', 'neg']
 
 ```
 </div>
@@ -147,66 +2009,79 @@ folder since it has unlabelled samples.
 !rm -rf aclImdb/train/unsup
 ```
 
-We'll use the `keras.utils.text_dataset_from_directory` utility to generate
-our labelled `tf.data.Dataset` dataset from text files.
+We'll use Pandas to avoid dependency on `keras.utils.text_dataset_from_directory`
+since it is merely a wrapper that returns `tf.data.Dataset` and we wish to make
+this script backend-agnostic
 
 
 ```python
-train_ds = keras.utils.text_dataset_from_directory(
-    "aclImdb/train",
-    batch_size=BATCH_SIZE,
-    validation_split=0.2,
-    subset="training",
-    seed=42,
+
+# Function to read files and label them
+def load_data_from_directory(directory, label):
+    data = []
+    for filename in os.listdir(directory):
+        if filename.endswith(".txt"):
+            file_path = os.path.join(directory, filename)
+            with open(file_path, "r", encoding="utf-8") as file:
+                text = file.read().strip()
+                data.append((text, label))
+    return data
+
+
+# Function to create Pandas dataframes
+def create_df(directory_pos, directory_neg):
+
+    # Load data from both directories
+    pos_data = load_data_from_directory(directory_pos, label=1)
+    neg_data = load_data_from_directory(directory_neg, label=0)
+
+    # Combine data from both pos and neg
+    all_data = pos_data + neg_data
+
+    # Shuffle the data randomly
+    random.shuffle(all_data)
+
+    # Create a pandas DataFrame
+    df = pd.DataFrame(all_data, columns=["text", "label"])
+    return df
+
+
+# Create the train and test dataframes, iloc maybe adjusted to a desired size
+train_df = create_df("./aclImdb/train/pos", "./aclImdb/train/neg").iloc[0:5000]
+test_df = create_df("./aclImdb/test/pos", "./aclImdb/test/neg").iloc[0:2500]
+
+# Train and Validation splits, 5% for validation
+train_df, val_df = train_test_split(
+    train_df, test_size=0.05, stratify=train_df["label"].values, random_state=42
 )
-val_ds = keras.utils.text_dataset_from_directory(
-    "aclImdb/train",
-    batch_size=BATCH_SIZE,
-    validation_split=0.2,
-    subset="validation",
-    seed=42,
-)
-test_ds = keras.utils.text_dataset_from_directory("aclImdb/test", batch_size=BATCH_SIZE)
+
+# Data statistics
+print(f"Total training examples: {len(train_df)}")
+print(f"Total validation examples: {len(val_df)}")
+print(f"Total test examples: {len(test_df)}")
 ```
 
 <div class="k-default-codeblock">
 ```
-Found 25000 files belonging to 2 classes.
-Using 20000 files for training.
-Found 25000 files belonging to 2 classes.
-Using 5000 files for validation.
-Found 25000 files belonging to 2 classes.
+Total training examples: 4750
+Total validation examples: 250
+Total test examples: 2500
 
 ```
 </div>
-We will now convert the text to lowercase.
-
-
-```python
-train_ds = train_ds.map(lambda x, y: (tf.strings.lower(x), y))
-val_ds = val_ds.map(lambda x, y: (tf.strings.lower(x), y))
-test_ds = test_ds.map(lambda x, y: (tf.strings.lower(x), y))
-```
-
 Let's print a few samples.
 
 
 ```python
-for text_batch, label_batch in train_ds.take(1):
-    for i in range(3):
-        print(text_batch.numpy()[i])
-        print(label_batch.numpy()[i])
-
+for i in range(3):
+    print(f"text: {train_df['text'][i]}, label: {train_df['label'][i]}")
 ```
 
 <div class="k-default-codeblock">
 ```
-b'an illegal immigrant resists the social support system causing dire consequences for many. well filmed and acted even though the story is a bit forced, yet the slow pacing really sets off the conclusion. the feeling of being lost in the big city is effectively conveyed. the little person lost in the big society is something to which we can all relate, but i cannot endorse going out of your way to see this movie.'
-0
-b"to get in touch with the beauty of this film pay close attention to the sound track, not only the music, but the way all sounds help to weave the imagery. how beautifully the opening scene leading to the expulsion of gino establishes the theme of moral ambiguity! note the way music introduces the characters as we are led inside giovanna's marriage. don't expect to find much here of the political life of italy in 1943. that's not what this is about. on the other hand, if you are susceptible to the music of images and sounds, you will be led into a word that reaches beyond neo-realism. by the end of the film we there are moments antonioni-like landscape that has more to do with the inner life of the characters than with real places. this is one of my favorite visconti films."
-1
-b'"hollywood hotel" has relationships to many films like "ella cinders" and "merton of the movies" about someone winning a contest including a contract to make films in hollywood, only to find the road to stardom either paved with pitfalls or non-existent. in fact, as i was watching it tonight, on turner classic movies, i was considering whether or not the authors of the later musical classic "singing in the rain" may have taken some of their ideas from "hollywood hotel", most notably a temperamental leading lady star in a movie studio and a conclusion concerning one person singing a film score while another person got the credit by mouthing along on screen.<br /><br />"hollywood hotel" is a fascinating example of movie making in the 1930s. among the supporting players is louella parsons, playing herself (and, despite some negative comments i\'ve seen, she has a very ingratiating personality on screen and a natural command of her lines). she is not the only real person in the script. make-up specialist perc westmore briefly appears as himself to try to make one character resemble another.<br /><br />this film also was one of the first in the career of young mr. ronald reagan, playing a radio interviewer at a movie premiere. reagan actually does quite nicely in his brief scenes - particularly when he realizes that nobody dick powell is about to take over the microphone when it should be used with more important people.<br /><br />dick powell has won a hollywood contract in a contest, and is leaving his job as a saxophonist in benny goodman\'s band. the beginning of this film, by the way, is quite impressive, as the band drives in a parade of trucks to give a proper goodbye to powell. they end up singing "hooray for hollywood". the interesting thing about this wonderful number is that a lyric has been left out on purpose. throughout the johnny mercer lyrics are references to such hollywood as max factor the make-up king, rin tin tin, and even a hint of tarzan. but the original song lyric referred to looking like tyrone power. obviously jack warner and his brothers were not going to advertise the leading man of 20th century fox, and the name donald duck was substituted. in any event the number showed the singers and instrumentalists of goodman\'s orchestra at their best. so did a later five minute section of the film, where the band is rehearsing.<br /><br />powell leaves the band and his girl friend (frances langford) and goes to hollywood, only to find he is a contract player (most likely for musicals involving saxophonists). he is met by allen joslyn, the publicist of the studio (the owner is grant mitchell). joslyn is not a bad fellow, but he is busy and he tends to slough off people unless it is necessary to speak to them. he parks powell at a room at the hollywood hotel, which is also where the studio\'s temperamental star (lola lane) lives with her father (hugh herbert), her sister (mabel todd), and her sensible if cynical assistant (glenda farrell). lane is like jean hagen in "singing in the rain", except her speaking voice is good. her version of "dan lockwood" is one "alexander dupre" (alan mowbray, scene stealing with ease several times). the only difference is that mowbray is not a nice guy like gene kelly was, and lane (when not wrapped up in her ego) is fully aware of it. having a fit on being by-passed for an out-of-the ordinary role she wanted, she refuses to attend the premiere of her latest film. joslyn finds a double for her (lola\'s real life sister rosemary lane), and rosemary is made up to play the star at the premiere and the follow-up party. but she attends with powell (joslyn wanting someone who doesn\'t know the real lola). this leads to powell knocking down mowbray when the latter makes a pest of himself. but otherwise the evening is a success, and when the two are together they start finding each other attractive.<br /><br />the complications deal with lola coming back and slapping powell in the face, after mowbray complains he was attacked by powell ("and his gang of hoodlums"). powell\'s contract is bought out. working with photographer turned agent ted healey (actually not too bad in this film - he even tries to do a jolson imitation at one point), the two try to find work, ending up as employees at a hamburger stand run by bad tempered edgar kennedy (the number of broken dishes and singing customers in the restaurant give edgar plenty of time to do his slow burns with gusto). eventually powell gets a "break" by being hired to be dupre\'s singing voice in a rip-off of "gone with the wind". this leads to the final section of the film, when rosemary lane, herbert, and healey help give powell his chance to show it\'s his voice, not mowbrays.<br /><br />it\'s quite a cute and appealing film even now. the worst aspects are due to it\'s time. several jokes concerning african-americans are no longer tolerable (while trying to photograph powell as he arrives in hollywood, healey accidentally photographs a porter, and mentions to joslyn to watch out, powell photographs too darkly - get the point?). also a bit with curt bois as a fashion designer for lola lane, who is (shall we say) too high strung is not very tolerable either. herbert\'s "hoo-hoo"ing is a bit much (too much of the time) but it was really popular in 1937. and an incident where healey nearly gets into a brawl at the premiere (this was one of his last films) reminds people of the tragic, still mysterious end of the comedian in december 1937. but most of the film is quite good, and won\'t disappoint the viewer in 2008.'
-1
+text: Germans think smirking is funny (just like Americans think mumbling is sexy and that women with English accents are acting). I had to cross my eyes whenever the screen was filled yet again with a giant close-up of a smirking face. One of those 'housewife hacks corporate mainframe' tales where she defrauds a bank by tapping a few random keys on her home PC which is connected only to a power socket. The director obviously loves the rather large leading lady. Can't say I share his feelings. There's quite a funny bit when the entire family sit in front of the television chanting tonelessly along with the adverts. Apparently this review needs to be one line longer so here it is., label: 0
+text: I remember the original series vividly mostly due to it's unique blend of wry humor and macabre subject matter. Kolchak was hard-bitten newsman from the Ben Hecht school of big-city reporting, and his gritty determination and wise-ass demeanor made even the most mundane episode eminently watchable. My personal fave was "The Spanish Moss Murders" due to it's totally original storyline. A poor,troubled Cajun youth from Louisiana bayou country, takes part in a sleep research experiment, for the purpose of dream analysis. Something goes inexplicably wrong, and he literally dreams to life a swamp creature inhabiting the dark folk tales of his youth. This malevolent manifestation seeks out all persons who have wronged the dreamer in his conscious state, and brutally suffocates them to death. Kolchak investigates and uncovers this horrible truth, much to the chagrin of police captain Joe "Mad Dog" Siska(wonderfully essayed by a grumpy Keenan Wynn)and the head sleep researcher played by Second City improv founder, Severn Darden, to droll, understated perfection. The wickedly funny, harrowing finale takes place in the Chicago sewer system, and is a series highlight. Kolchak never got any better. Timeless., label: 1
+text: Believe it or not, at 12 minutes, this film (for 1912) is a full-length film. Very, very few films were longer than that back then, but that is definitely NOT what sets this odd little film apart from the rest! No, what's different is that all the actors (with the exception of one frog) are bugs...yes, bugs! This simple little domestic comedy could have looked much like productions starring the likes of Chaplin, Laurel and Hardy or Max Linder but instead this Russian production uses bugs (or, I think, models that looked just like bugs). Chaplin and Laurel and Hardy were yet to be discovered and I assume Linder was busy, so perhaps that's why they used bugs! Using stop-motion, the bugs moved and danced and fought amazingly well--and a heck of a lot more realistically than King Kong 21 years later! <br /><br />The film starts with Mr. Beetle sneaking off for a good time. He goes to a bawdy club while his wife supposedly waits at home. But, unfortunately for Mr. Beetle, he is caught on camera by a local film buff. Plus, he doesn't know it but Mrs. Beetle is also carrying on with a bohemian grasshopper painter. Of course, there's a lot more to this domestic comedy than this, but the plot is age-old and very entertaining for adults and kids alike.<br /><br />Weird but also very amazing and watchable., label: 1
 
 ```
 </div>
@@ -227,20 +2102,6 @@ makes it very simple to train WordPiece on a corpus with the
 
 Note: The official implementation of FNet uses the SentencePiece Tokenizer.
 
-
-```python
-
-def train_word_piece(ds, vocab_size, reserved_tokens):
-    word_piece_ds = ds.unbatch().map(lambda x, y: x)
-    vocab = keras_hub.tokenizers.compute_word_piece_vocabulary(
-        word_piece_ds.batch(1000).prefetch(2),
-        vocabulary_size=vocab_size,
-        reserved_tokens=reserved_tokens,
-    )
-    return vocab
-
-```
-
 Every vocabulary has a few special, reserved tokens. We have two such tokens:
 
 - `"[PAD]"` - Padding token. Padding tokens are appended to the input sequence length
@@ -250,8 +2111,19 @@ when the input sequence length is shorter than the maximum sequence length.
 
 ```python
 reserved_tokens = ["[PAD]", "[UNK]"]
-train_sentences = [element[0] for element in train_ds]
-vocab = train_word_piece(train_ds, VOCAB_SIZE, reserved_tokens)
+train_sentences = [element[0] for element in train_df]
+
+vocab = keras_hub.tokenizers.compute_word_piece_vocabulary(
+    data=[
+        "./aclImdb/train/pos/" + f
+        for f in os.listdir("./aclImdb/train/pos")
+        if os.path.isfile(os.path.join("./aclImdb/train/pos", f))
+    ],  # list of files in the specified directory used to create the vocab
+    vocabulary_size=VOCAB_SIZE,
+    reserved_tokens=reserved_tokens,
+    lowercase=True,
+)
+
 ```
 
 Let's see some tokens!
@@ -263,7 +2135,7 @@ print("Tokens: ", vocab[100:110])
 
 <div class="k-default-codeblock">
 ```
-Tokens:  ['à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é']
+Tokens:  ['ó', 'ô', 'õ', 'ö', 'ø', 'ú', 'ü', 'ý', '́', '̈']
 
 ```
 </div>
@@ -279,6 +2151,7 @@ tokenizer = keras_hub.tokenizers.WordPieceTokenizer(
     lowercase=False,
     sequence_length=MAX_SEQUENCE_LENGTH,
 )
+
 ```
 
 Let's try and tokenize a sample from our dataset! To verify whether the text has
@@ -287,7 +2160,7 @@ original text.
 
 
 ```python
-input_sentence_ex = train_ds.take(1).get_single_element()[0][0]
+input_sentence_ex = train_df["text"][0]
 input_tokens_ex = tokenizer(input_sentence_ex)
 
 print("Sentence: ", input_sentence_ex)
@@ -298,76 +2171,150 @@ print("Recovered text after detokenizing: ", tokenizer.detokenize(input_tokens_e
 
 <div class="k-default-codeblock">
 ```
-Sentence:  tf.Tensor(b'this picture seemed way to slanted, it\'s almost as bad as the drum beating of the right wing kooks who say everything is rosy in iraq. it paints a picture so unredeemable that i can\'t help but wonder about it\'s legitimacy and bias. also it seemed to meander from being about the murderous carnage of our troops to the lack of health care in the states for ptsd. to me the subject matter seemed confused, it only cared about portraying the military in a bad light, as a) an organzation that uses mind control to turn ordinary peace loving civilians into baby killers and b) an organization that once having used and spent the bodies of it\'s soldiers then discards them to the despotic bureacracy of the v.a. this is a legitimate argument, but felt off topic for me, almost like a movie in and of itself. i felt that "the war tapes" and "blood of my brother" were much more fair and let the viewer draw some conclusions of their own rather than be beaten over the head with the film makers viewpoint. f-', shape=(), dtype=string)
-Tokens:  [  145   576   608   228   140    58 13343    13   143     8    58   360
-   148   209   148   137  9759  3681   139   137   344  3276    50 12092
-   164   169   269   424   141    57  2093   292   144  5115    15   143
-  7890    40   576   170  2970  2459  2412 10452   146    48   184     8
-    59   478   152   733   177   143     8    58  4060  8069 13355   138
-  8557    15   214   143   608   140   526  2121   171   247   177   137
-  4726  7336   139   395  4985   140   137   711   139  3959   597   144
-   137  1844   149    55  1175   288    15   140   203   137  1009   686
-   608  1701    13   143   197  3979   177  2514   137  1442   144    40
-   209   776    13   148    40    10   168 14198 13928   146  1260   470
-  1300   140   604  2118  2836  1873  9991   217  1006  2318   138    41
-    10   168  8469   146   422   400   480   138  1213   137  2541   139
-   143     8    58  1487   227  4319 10720   229   140   137  6310  8532
-   862    41  2215  6547 10768   139   137    61    15    40    15   145
-   141    40  7738  4120    13   152   569   260  3297   149   203    13
-   360   172    40   150   144   138   139   561    15    48   569   146
-     3   137   466  6192     3   138     3   665   139   193   707     3
-   204   207   185  1447   138   417   137   643  2731   182  8421   139
-   199   342   385   206   161  3920   253   137   566   151   137   153
-  1340  8845    15    45    14     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0     0     0     0     0
-     0     0     0     0     0     0     0     0]
-Recovered text after detokenizing:  tf.Tensor(b'this picture seemed way to slanted , it \' s almost as bad as the drum beating of the right wing kooks who say everything is rosy in iraq . it paints a picture so unredeemable that i can \' t help but wonder about it \' s legitimacy and bias . also it seemed to meander from being about the murderous carnage of our troops to the lack of health care in the states for ptsd . to me the subject matter seemed confused , it only cared about portraying the military in a bad light , as a ) an organzation that uses mind control to turn ordinary peace loving civilians into baby killers and b ) an organization that once having used and spent the bodies of it \' s soldiers then discards them to the despotic bureacracy of the v . a . this is a legitimate argument , but felt off topic for me , almost like a movie in and of itself . i felt that " the war tapes " and " blood of my brother " were much more fair and let the viewer draw some conclusions of their own rather than be beaten over the head with the film makers viewpoint . f - [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD]', shape=(), dtype=string)
+Sentence:  Germans think smirking is funny (just like Americans think mumbling is sexy and that women with English accents are acting). I had to cross my eyes whenever the screen was filled yet again with a giant close-up of a smirking face. One of those 'housewife hacks corporate mainframe' tales where she defrauds a bank by tapping a few random keys on her home PC which is connected only to a power socket. The director obviously loves the rather large leading lady. Can't say I share his feelings. There's quite a funny bit when the entire family sit in front of the television chanting tonelessly along with the adverts. Apparently this review needs to be one line longer so here it is.
+Tokens:  tensor([    1,   214,    59,  5480,  4817,   223,   121,   295,    10,   167,
+          154,     1,   214,  5964,  5476,   121,  1388,   118,   125,   500,
+          128,     1,  3994,   138,   255,    11,    16,     1,   184,   120,
+         1827,   171,   609,  2364,   117,   378,   130,  1102,   341,   274,
+          128,    41,  2132,   588,    15,   174,   119,    41,    59,  5480,
+         4817,   223,   513,    16,     1,   119,   249,     9,  6062, 11135,
+          145,  4102,   434,  1384,  5897,   290,     9,  2723,   231,   159,
+        13412,  1413,  8535,   145,    41,  2540,   143, 10416,    41,   298,
+         3409,  8408,   135,   150,   437,     1,   175,   121,  3669,   185,
+          120,    41,   723,   153,  2030,  2264,    16,     1,   285,   854,
+         1318,   117,   369,  1162,  1006,   813,    16,     1,     9,    60,
+          259,     1,  1419,   134,  1189,    16,     1,     9,    59,   276,
+           41,   295,   311,   164,   117,   651,   286,  1296,   122,  1196,
+          119,   117,   721,  1874,  1229,  1199,  8278,   454,   128,   117,
+         4751,  5572,   145,    16,     1,   126,  1088,   841,   120,   142,
+          140,   506,  1382,   153,   241,   124,   121,    16,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+            0,     0], dtype=torch.int32)
+Recovered text after detokenizing:  [UNK] think smirking is funny ( just like [UNK] think mumbling is sexy and that women with [UNK] accents are acting ) . [UNK] had to cross my eyes whenever the screen was filled yet again with a giant close - up of a smirking face . [UNK] of those ' housewife hacks corporate mainframe ' tales where she defrauds a bank by tapping a few random keys on her home [UNK] which is connected only to a power socket . [UNK] director obviously loves the rather large leading lady . [UNK] ' t say [UNK] share his feelings . [UNK] ' s quite a funny bit when the entire family sit in front of the television chanting tonelessly along with the adverts . [UNK] this review needs to be one line longer so here it is . [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD] [PAD]
 
 ```
 </div>
----
-## Formatting the dataset
-
-Next, we'll format our datasets in the form that will be fed to the models. We
-need to tokenize the text.
+Create the final datasets, method adapted from `PyDataset` doc string
 
 
 ```python
 
-def format_dataset(sentence, label):
-    sentence = tokenizer(sentence)
-    return ({"input_ids": sentence}, label)
+class UnifiedPyDataset(keras.utils.PyDataset):
+    """A Keras-compatible dataset that processes a DataFrame for TensorFlow, JAX, and PyTorch."""
+
+    def __init__(
+        self,
+        df,
+        batch_size=BATCH_SIZE,
+        workers=4,
+        use_multiprocessing=True,
+        max_queue_size=10,
+        **kwargs,
+    ):
+        """
+        Args:
+            df: pandas DataFrame with data
+            batch_size: Batch size for dataset
+            workers: Number of workers to use for parallel loading (Keras)
+            use_multiprocessing: Whether to use multiprocessing
+            max_queue_size: Maximum size of the data queue for parallel loading
+        """
+        super().__init__(**kwargs)
+        self.dataframe = df
+        columns = ["text", "label"]
+
+        # text files
+        self.text_x = self.dataframe["text"]
+        self.text_y = self.dataframe["label"]
+
+        # general
+        self.batch_size = batch_size
+        self.workers = workers
+        self.use_multiprocessing = use_multiprocessing
+        self.max_queue_size = max_queue_size
+
+    def __getitem__(self, index):
+        """
+        Fetches a batch of data from the dataset at the given index.
+
+        Args:
+            index: position of the batch in the dataset
+        """
+
+        # Return x, y for batch idx.
+        low = index * self.batch_size
+        # Cap upper bound at array length; the last batch may be smaller
+        # if the total number of items is not a multiple of batch size.
+
+        high_text = min(low + self.batch_size, len(self.text_x))
+
+        # text files batches
+        batch_text_x = self.text_x[low:high_text]
+        batch_text_y = self.text_y[low:high_text]
+
+        # Tokenize the data in dataframe and stack them into an nd.array of axis_0=batch
+        text = np.array([[tokenizer(text) for text in batch_text_x]])
+        return (
+            {
+                "input_ids": keras.ops.squeeze(text),
+            },
+            # Target lables
+            np.array(batch_text_y),
+        )
+
+    def __len__(self):
+        """
+        Returns the number of batches in the dataset.
+        """
+        return math.ceil(len(self.dataframe) / self.batch_size)
 
 
-def make_dataset(dataset):
-    dataset = dataset.map(format_dataset, num_parallel_calls=tf.data.AUTOTUNE)
-    return dataset.shuffle(512).prefetch(16).cache()
+def prepare_dataset(dataframe, training=True):
+    ds = UnifiedPyDataset(
+        dataframe,
+        batch_size=32,
+        workers=4,
+    )
+    return ds
 
 
-train_ds = make_dataset(train_ds)
-val_ds = make_dataset(val_ds)
-test_ds = make_dataset(test_ds)
+train_ds = prepare_dataset(train_df)
+val_ds = prepare_dataset(val_df)
+test_ds = prepare_dataset(test_df)
 ```
 
 ---
@@ -412,7 +2359,7 @@ fnet_classifier = keras.Model(input_ids, outputs, name="fnet_classifier")
 
 <div class="k-default-codeblock">
 ```
-/home/matt/miniconda3/envs/keras-io/lib/python3.10/site-packages/keras/src/layers/layer.py:861: UserWarning: Layer 'f_net_encoder' (of type FNetEncoder) was passed an input with a mask attached to it. However, this layer does not support masking and will therefore destroy the mask information. Downstream layers will not see the mask.
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/layers/layer.py:932: UserWarning: Layer 'f_net_encoder' (of type FNetEncoder) was passed an input with a mask attached to it. However, this layer does not support masking and will therefore destroy the mask information. Downstream layers will not see the mask.
   warnings.warn(
 
 ```
@@ -441,27 +2388,27 @@ fnet_classifier.fit(train_ds, epochs=EPOCHS, validation_data=val_ds)
 
 
 
-<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-┃<span style="font-weight: bold"> Layer (type)                    </span>┃<span style="font-weight: bold"> Output Shape              </span>┃<span style="font-weight: bold">    Param # </span>┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
-│ input_ids (<span style="color: #0087ff; text-decoration-color: #0087ff">InputLayer</span>)          │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)              │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ token_and_position_embedding    │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)         │  <span style="color: #00af00; text-decoration-color: #00af00">1,985,536</span> │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TokenAndPositionEmbedding</span>)     │                           │            │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ f_net_encoder (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)     │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)         │    <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ f_net_encoder_1 (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)         │    <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ f_net_encoder_2 (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)         │    <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ global_average_pooling1d        │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)               │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">GlobalAveragePooling1D</span>)        │                           │            │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ dropout (<span style="color: #0087ff; text-decoration-color: #0087ff">Dropout</span>)               │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)               │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
-├─────────────────────────────────┼───────────────────────────┼────────────┤
-│ dense (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)                   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>)                 │        <span style="color: #00af00; text-decoration-color: #00af00">129</span> │
-└─────────────────────────────────┴───────────────────────────┴────────────┘
+<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃<span style="font-weight: bold"> Layer (type)                    </span>┃<span style="font-weight: bold"> Output Shape           </span>┃<span style="font-weight: bold">       Param # </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ input_ids (<span style="color: #0087ff; text-decoration-color: #0087ff">InputLayer</span>)          │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)           │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ token_and_position_embedding    │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)      │     <span style="color: #00af00; text-decoration-color: #00af00">1,985,536</span> │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TokenAndPositionEmbedding</span>)     │                        │               │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ f_net_encoder (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)     │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)      │       <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ f_net_encoder_1 (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)      │       <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ f_net_encoder_2 (<span style="color: #0087ff; text-decoration-color: #0087ff">FNetEncoder</span>)   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)      │       <span style="color: #00af00; text-decoration-color: #00af00">132,224</span> │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ global_average_pooling1d        │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)            │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">GlobalAveragePooling1D</span>)        │                        │               │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ dropout (<span style="color: #0087ff; text-decoration-color: #0087ff">Dropout</span>)               │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)            │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ dense (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)                   │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>)              │           <span style="color: #00af00; text-decoration-color: #00af00">129</span> │
+└─────────────────────────────────┴────────────────────────┴───────────────┘
 </pre>
 
 
@@ -486,18 +2433,1079 @@ fnet_classifier.fit(train_ds, epochs=EPOCHS, validation_data=val_ds)
 
 <div class="k-default-codeblock">
 ```
-Epoch 1/3
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/models/functional.py:248: UserWarning: The structure of `inputs` doesn't match the expected structure.
+Expected: input_ids
+Received: inputs=['Tensor(shape=torch.Size([32, 512]))']
+  warnings.warn(msg)
 
-/home/matt/miniconda3/envs/keras-io/lib/python3.10/site-packages/keras/src/backend/jax/core.py:64: UserWarning: Explicitly requested dtype int64 requested in array is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
-  return jnp.array(x, dtype=dtype)
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/layers/layer.py:932: UserWarning: Layer 'position_embedding' (of type PositionEmbedding) was passed an input with a mask attached to it. However, this layer does not support masking and will therefore destroy the mask information. Downstream layers will not see the mask.
+  warnings.warn(
 
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 8s 18ms/step - accuracy: 0.5916 - loss: 0.6542 - val_accuracy: 0.8479 - val_loss: 0.3536
-Epoch 2/3
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 4s 12ms/step - accuracy: 0.8776 - loss: 0.2916 - val_accuracy: 0.8532 - val_loss: 0.3387
-Epoch 3/3
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 4s 12ms/step - accuracy: 0.9442 - loss: 0.1543 - val_accuracy: 0.8534 - val_loss: 0.4018
+```
+</div>
+    
+   1/149 [37m━━━━━━━━━━━━━━━━━━━━  11:50 5s/step - accuracy: 0.4062 - loss: 0.6976
 
-<keras.src.callbacks.history.History at 0x7feb7169c0d0>
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   2/149 [37m━━━━━━━━━━━━━━━━━━━━  2:52 1s/step - accuracy: 0.4297 - loss: 0.8143 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   3/149 [37m━━━━━━━━━━━━━━━━━━━━  2:55 1s/step - accuracy: 0.4427 - loss: 0.8336
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   4/149 [37m━━━━━━━━━━━━━━━━━━━━  3:18 1s/step - accuracy: 0.4512 - loss: 0.8359
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   5/149 [37m━━━━━━━━━━━━━━━━━━━━  3:27 1s/step - accuracy: 0.4609 - loss: 0.8350
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   6/149 [37m━━━━━━━━━━━━━━━━━━━━  3:32 1s/step - accuracy: 0.4692 - loss: 0.8342
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   7/149 [37m━━━━━━━━━━━━━━━━━━━━  3:28 1s/step - accuracy: 0.4755 - loss: 0.8332
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   8/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:26 1s/step - accuracy: 0.4781 - loss: 0.8314
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   9/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:20 1s/step - accuracy: 0.4782 - loss: 0.8297
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  10/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:16 1s/step - accuracy: 0.4779 - loss: 0.8283
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  11/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:15 1s/step - accuracy: 0.4786 - loss: 0.8259
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  12/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:18 1s/step - accuracy: 0.4802 - loss: 0.8230
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  13/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:20 1s/step - accuracy: 0.4819 - loss: 0.8199
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  14/149 ━[37m━━━━━━━━━━━━━━━━━━━  3:22 2s/step - accuracy: 0.4835 - loss: 0.8168
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  15/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:24 2s/step - accuracy: 0.4846 - loss: 0.8138
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  16/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:25 2s/step - accuracy: 0.4854 - loss: 0.8109
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  17/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:25 2s/step - accuracy: 0.4866 - loss: 0.8080
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  18/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:26 2s/step - accuracy: 0.4875 - loss: 0.8053
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  19/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:25 2s/step - accuracy: 0.4882 - loss: 0.8030
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  20/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:24 2s/step - accuracy: 0.4888 - loss: 0.8007
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  21/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:23 2s/step - accuracy: 0.4891 - loss: 0.7986
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  22/149 ━━[37m━━━━━━━━━━━━━━━━━━  3:23 2s/step - accuracy: 0.4895 - loss: 0.7965
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  23/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:22 2s/step - accuracy: 0.4898 - loss: 0.7945
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  24/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:22 2s/step - accuracy: 0.4902 - loss: 0.7926
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  25/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:21 2s/step - accuracy: 0.4908 - loss: 0.7907
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  26/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:22 2s/step - accuracy: 0.4915 - loss: 0.7888
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  27/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:21 2s/step - accuracy: 0.4922 - loss: 0.7870
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  28/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:21 2s/step - accuracy: 0.4929 - loss: 0.7853
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  29/149 ━━━[37m━━━━━━━━━━━━━━━━━  3:20 2s/step - accuracy: 0.4935 - loss: 0.7837
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  30/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:19 2s/step - accuracy: 0.4941 - loss: 0.7821
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  31/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:17 2s/step - accuracy: 0.4945 - loss: 0.7806
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  32/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:16 2s/step - accuracy: 0.4948 - loss: 0.7792
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  33/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:15 2s/step - accuracy: 0.4952 - loss: 0.7778
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  34/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:15 2s/step - accuracy: 0.4956 - loss: 0.7765
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  35/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:14 2s/step - accuracy: 0.4961 - loss: 0.7752
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  36/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:13 2s/step - accuracy: 0.4964 - loss: 0.7739
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  37/149 ━━━━[37m━━━━━━━━━━━━━━━━  3:11 2s/step - accuracy: 0.4967 - loss: 0.7727
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  38/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:11 2s/step - accuracy: 0.4971 - loss: 0.7715
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  39/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:09 2s/step - accuracy: 0.4975 - loss: 0.7704
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  40/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:08 2s/step - accuracy: 0.4978 - loss: 0.7693
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  41/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:07 2s/step - accuracy: 0.4981 - loss: 0.7682
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  42/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:06 2s/step - accuracy: 0.4984 - loss: 0.7672
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  43/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:05 2s/step - accuracy: 0.4986 - loss: 0.7662
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  44/149 ━━━━━[37m━━━━━━━━━━━━━━━  3:03 2s/step - accuracy: 0.4988 - loss: 0.7653
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  45/149 ━━━━━━[37m━━━━━━━━━━━━━━  3:02 2s/step - accuracy: 0.4990 - loss: 0.7644
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  46/149 ━━━━━━[37m━━━━━━━━━━━━━━  3:01 2s/step - accuracy: 0.4992 - loss: 0.7635
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  47/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:59 2s/step - accuracy: 0.4993 - loss: 0.7626
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  48/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:58 2s/step - accuracy: 0.4996 - loss: 0.7617
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  49/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:56 2s/step - accuracy: 0.4998 - loss: 0.7609
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  50/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:55 2s/step - accuracy: 0.5000 - loss: 0.7601
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  51/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:54 2s/step - accuracy: 0.5003 - loss: 0.7593
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  52/149 ━━━━━━[37m━━━━━━━━━━━━━━  2:52 2s/step - accuracy: 0.5004 - loss: 0.7585
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  53/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:51 2s/step - accuracy: 0.5007 - loss: 0.7578
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  54/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:49 2s/step - accuracy: 0.5008 - loss: 0.7571
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  55/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:48 2s/step - accuracy: 0.5011 - loss: 0.7564
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  56/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:46 2s/step - accuracy: 0.5013 - loss: 0.7557
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  57/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:45 2s/step - accuracy: 0.5015 - loss: 0.7550
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  58/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:43 2s/step - accuracy: 0.5016 - loss: 0.7543
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  59/149 ━━━━━━━[37m━━━━━━━━━━━━━  2:42 2s/step - accuracy: 0.5018 - loss: 0.7537
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  60/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:40 2s/step - accuracy: 0.5020 - loss: 0.7531
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  61/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:38 2s/step - accuracy: 0.5023 - loss: 0.7525
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  62/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:37 2s/step - accuracy: 0.5025 - loss: 0.7519
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  63/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:36 2s/step - accuracy: 0.5027 - loss: 0.7513
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  64/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:34 2s/step - accuracy: 0.5029 - loss: 0.7507
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  65/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:32 2s/step - accuracy: 0.5032 - loss: 0.7501
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  66/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:31 2s/step - accuracy: 0.5034 - loss: 0.7496
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  67/149 ━━━━━━━━[37m━━━━━━━━━━━━  2:30 2s/step - accuracy: 0.5037 - loss: 0.7490
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  68/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:28 2s/step - accuracy: 0.5039 - loss: 0.7484
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  69/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:26 2s/step - accuracy: 0.5041 - loss: 0.7479
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  70/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:25 2s/step - accuracy: 0.5043 - loss: 0.7474
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  71/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:23 2s/step - accuracy: 0.5045 - loss: 0.7469
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  72/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:22 2s/step - accuracy: 0.5046 - loss: 0.7464
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  73/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:20 2s/step - accuracy: 0.5048 - loss: 0.7460
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  74/149 ━━━━━━━━━[37m━━━━━━━━━━━  2:18 2s/step - accuracy: 0.5050 - loss: 0.7455
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  75/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:17 2s/step - accuracy: 0.5052 - loss: 0.7451
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  76/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:15 2s/step - accuracy: 0.5053 - loss: 0.7447
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  77/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:13 2s/step - accuracy: 0.5055 - loss: 0.7443
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  78/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:11 2s/step - accuracy: 0.5056 - loss: 0.7439
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  79/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:10 2s/step - accuracy: 0.5058 - loss: 0.7435
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  80/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:08 2s/step - accuracy: 0.5059 - loss: 0.7431
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  81/149 ━━━━━━━━━━[37m━━━━━━━━━━  2:06 2s/step - accuracy: 0.5061 - loss: 0.7428
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  82/149 ━━━━━━━━━━━[37m━━━━━━━━━  2:04 2s/step - accuracy: 0.5062 - loss: 0.7424
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  83/149 ━━━━━━━━━━━[37m━━━━━━━━━  2:02 2s/step - accuracy: 0.5063 - loss: 0.7420
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  84/149 ━━━━━━━━━━━[37m━━━━━━━━━  2:01 2s/step - accuracy: 0.5065 - loss: 0.7417
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  85/149 ━━━━━━━━━━━[37m━━━━━━━━━  1:59 2s/step - accuracy: 0.5066 - loss: 0.7413
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  86/149 ━━━━━━━━━━━[37m━━━━━━━━━  1:57 2s/step - accuracy: 0.5068 - loss: 0.7410
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  87/149 ━━━━━━━━━━━[37m━━━━━━━━━  1:56 2s/step - accuracy: 0.5070 - loss: 0.7406
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  88/149 ━━━━━━━━━━━[37m━━━━━━━━━  1:54 2s/step - accuracy: 0.5071 - loss: 0.7403
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  89/149 ━━━━━━━━━━━[37m━━━━━━━━━  1:52 2s/step - accuracy: 0.5073 - loss: 0.7399
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  90/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:51 2s/step - accuracy: 0.5075 - loss: 0.7396
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  91/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:49 2s/step - accuracy: 0.5077 - loss: 0.7392
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  92/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:47 2s/step - accuracy: 0.5079 - loss: 0.7389
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  93/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:45 2s/step - accuracy: 0.5081 - loss: 0.7385
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  94/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:44 2s/step - accuracy: 0.5083 - loss: 0.7382
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  95/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:42 2s/step - accuracy: 0.5085 - loss: 0.7379
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  96/149 ━━━━━━━━━━━━[37m━━━━━━━━  1:40 2s/step - accuracy: 0.5087 - loss: 0.7376
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  97/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:38 2s/step - accuracy: 0.5088 - loss: 0.7373
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  98/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:37 2s/step - accuracy: 0.5089 - loss: 0.7370
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  99/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:35 2s/step - accuracy: 0.5091 - loss: 0.7367
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 100/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:33 2s/step - accuracy: 0.5092 - loss: 0.7364
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 101/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:31 2s/step - accuracy: 0.5093 - loss: 0.7362
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 102/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:29 2s/step - accuracy: 0.5095 - loss: 0.7359
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 103/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:28 2s/step - accuracy: 0.5096 - loss: 0.7356
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 104/149 ━━━━━━━━━━━━━[37m━━━━━━━  1:26 2s/step - accuracy: 0.5097 - loss: 0.7353
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 105/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:24 2s/step - accuracy: 0.5099 - loss: 0.7351
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 106/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:22 2s/step - accuracy: 0.5100 - loss: 0.7348
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 107/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:20 2s/step - accuracy: 0.5102 - loss: 0.7345
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 108/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:18 2s/step - accuracy: 0.5104 - loss: 0.7342
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 109/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:16 2s/step - accuracy: 0.5105 - loss: 0.7340
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 110/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:15 2s/step - accuracy: 0.5107 - loss: 0.7337
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 111/149 ━━━━━━━━━━━━━━[37m━━━━━━  1:13 2s/step - accuracy: 0.5109 - loss: 0.7334
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 112/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:11 2s/step - accuracy: 0.5111 - loss: 0.7332
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 113/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:09 2s/step - accuracy: 0.5113 - loss: 0.7329
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 114/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:07 2s/step - accuracy: 0.5114 - loss: 0.7327
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 115/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:05 2s/step - accuracy: 0.5116 - loss: 0.7324
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 116/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:03 2s/step - accuracy: 0.5118 - loss: 0.7322
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 117/149 ━━━━━━━━━━━━━━━[37m━━━━━  1:01 2s/step - accuracy: 0.5120 - loss: 0.7319
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 118/149 ━━━━━━━━━━━━━━━[37m━━━━━  59s 2s/step - accuracy: 0.5121 - loss: 0.7317 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 119/149 ━━━━━━━━━━━━━━━[37m━━━━━  58s 2s/step - accuracy: 0.5123 - loss: 0.7314
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 120/149 ━━━━━━━━━━━━━━━━[37m━━━━  56s 2s/step - accuracy: 0.5125 - loss: 0.7311
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 121/149 ━━━━━━━━━━━━━━━━[37m━━━━  54s 2s/step - accuracy: 0.5127 - loss: 0.7309
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 122/149 ━━━━━━━━━━━━━━━━[37m━━━━  52s 2s/step - accuracy: 0.5129 - loss: 0.7306
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 123/149 ━━━━━━━━━━━━━━━━[37m━━━━  50s 2s/step - accuracy: 0.5131 - loss: 0.7304
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 124/149 ━━━━━━━━━━━━━━━━[37m━━━━  48s 2s/step - accuracy: 0.5133 - loss: 0.7302
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 125/149 ━━━━━━━━━━━━━━━━[37m━━━━  46s 2s/step - accuracy: 0.5135 - loss: 0.7299
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 126/149 ━━━━━━━━━━━━━━━━[37m━━━━  44s 2s/step - accuracy: 0.5137 - loss: 0.7296
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 127/149 ━━━━━━━━━━━━━━━━━[37m━━━  42s 2s/step - accuracy: 0.5139 - loss: 0.7294
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 128/149 ━━━━━━━━━━━━━━━━━[37m━━━  40s 2s/step - accuracy: 0.5142 - loss: 0.7291
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 129/149 ━━━━━━━━━━━━━━━━━[37m━━━  38s 2s/step - accuracy: 0.5144 - loss: 0.7289
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 130/149 ━━━━━━━━━━━━━━━━━[37m━━━  36s 2s/step - accuracy: 0.5147 - loss: 0.7286
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 131/149 ━━━━━━━━━━━━━━━━━[37m━━━  35s 2s/step - accuracy: 0.5149 - loss: 0.7284
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 132/149 ━━━━━━━━━━━━━━━━━[37m━━━  33s 2s/step - accuracy: 0.5152 - loss: 0.7281
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 133/149 ━━━━━━━━━━━━━━━━━[37m━━━  31s 2s/step - accuracy: 0.5154 - loss: 0.7279
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 134/149 ━━━━━━━━━━━━━━━━━[37m━━━  29s 2s/step - accuracy: 0.5157 - loss: 0.7276
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 135/149 ━━━━━━━━━━━━━━━━━━[37m━━  27s 2s/step - accuracy: 0.5159 - loss: 0.7274
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 136/149 ━━━━━━━━━━━━━━━━━━[37m━━  25s 2s/step - accuracy: 0.5162 - loss: 0.7271
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 137/149 ━━━━━━━━━━━━━━━━━━[37m━━  23s 2s/step - accuracy: 0.5165 - loss: 0.7268
+
+<div class="k-default-codeblock">
+```
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/models/functional.py:248: UserWarning: The structure of `inputs` doesn't match the expected structure.
+Expected: input_ids
+Received: inputs=['Tensor(shape=torch.Size([14, 512]))']
+  warnings.warn(msg)
+
+
+```
+</div>
+ 138/149 ━━━━━━━━━━━━━━━━━━[37m━━  21s 2s/step - accuracy: 0.5167 - loss: 0.7266
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 139/149 ━━━━━━━━━━━━━━━━━━[37m━━  19s 2s/step - accuracy: 0.5170 - loss: 0.7263
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 140/149 ━━━━━━━━━━━━━━━━━━[37m━━  17s 2s/step - accuracy: 0.5173 - loss: 0.7261
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 141/149 ━━━━━━━━━━━━━━━━━━[37m━━  15s 2s/step - accuracy: 0.5175 - loss: 0.7258
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 142/149 ━━━━━━━━━━━━━━━━━━━[37m━  13s 2s/step - accuracy: 0.5178 - loss: 0.7255
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 143/149 ━━━━━━━━━━━━━━━━━━━[37m━  11s 2s/step - accuracy: 0.5181 - loss: 0.7253
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 144/149 ━━━━━━━━━━━━━━━━━━━[37m━  9s 2s/step - accuracy: 0.5184 - loss: 0.7250 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 145/149 ━━━━━━━━━━━━━━━━━━━[37m━  7s 2s/step - accuracy: 0.5187 - loss: 0.7248
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 146/149 ━━━━━━━━━━━━━━━━━━━[37m━  5s 2s/step - accuracy: 0.5190 - loss: 0.7245
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 147/149 ━━━━━━━━━━━━━━━━━━━[37m━  3s 2s/step - accuracy: 0.5192 - loss: 0.7242
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 148/149 ━━━━━━━━━━━━━━━━━━━[37m━  1s 2s/step - accuracy: 0.5195 - loss: 0.7240
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 149/149 ━━━━━━━━━━━━━━━━━━━━ 0s 2s/step - accuracy: 0.5198 - loss: 0.7237
+
+<div class="k-default-codeblock">
+```
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/models/functional.py:248: UserWarning: The structure of `inputs` doesn't match the expected structure.
+Expected: input_ids
+Received: inputs=['Tensor(shape=torch.Size([26, 512]))']
+  warnings.warn(msg)
+
+
+```
+</div>
+ 149/149 ━━━━━━━━━━━━━━━━━━━━ 305s 2s/step - accuracy: 0.5201 - loss: 0.7234 - val_accuracy: 0.7400 - val_loss: 0.5591
+
+
+
+
+
+<div class="k-default-codeblock">
+```
+<keras.src.callbacks.history.History at 0x7c51e823fd10>
 
 ```
 </div>
@@ -513,11 +3521,574 @@ fnet_classifier.evaluate(test_ds, batch_size=BATCH_SIZE)
 
 ```
 
+    
+  1/79 [37m━━━━━━━━━━━━━━━━━━━━  5:55 5s/step - accuracy: 0.6875 - loss: 0.5899
+
 <div class="k-default-codeblock">
 ```
- 391/391 ━━━━━━━━━━━━━━━━━━━━ 3s 5ms/step - accuracy: 0.8412 - loss: 0.4281
+
+```
+</div>
+  2/79 [37m━━━━━━━━━━━━━━━━━━━━  1:21 1s/step - accuracy: 0.6641 - loss: 0.5981
 
-[0.4198716878890991, 0.8427909016609192]
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  3/79 [37m━━━━━━━━━━━━━━━━━━━━  1:16 1s/step - accuracy: 0.6788 - loss: 0.5866
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  4/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:14 996ms/step - accuracy: 0.6888 - loss: 0.5795
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  5/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:12 985ms/step - accuracy: 0.6885 - loss: 0.5754
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  6/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:11 982ms/step - accuracy: 0.6918 - loss: 0.5718
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  7/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:10 981ms/step - accuracy: 0.6950 - loss: 0.5693
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  8/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:09 985ms/step - accuracy: 0.6961 - loss: 0.5685
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  9/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:08 978ms/step - accuracy: 0.6963 - loss: 0.5682
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 10/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:08 987ms/step - accuracy: 0.6963 - loss: 0.5681
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 11/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:06 978ms/step - accuracy: 0.6978 - loss: 0.5673
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 12/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:05 979ms/step - accuracy: 0.6998 - loss: 0.5666
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 13/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:04 983ms/step - accuracy: 0.7016 - loss: 0.5662
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 14/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:03 981ms/step - accuracy: 0.7025 - loss: 0.5661
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 15/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:02 982ms/step - accuracy: 0.7035 - loss: 0.5661
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 16/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:01 982ms/step - accuracy: 0.7043 - loss: 0.5662
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 17/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:00 982ms/step - accuracy: 0.7053 - loss: 0.5663
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 18/79 ━━━━[37m━━━━━━━━━━━━━━━━  59s 979ms/step - accuracy: 0.7064 - loss: 0.5662 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 19/79 ━━━━[37m━━━━━━━━━━━━━━━━  58s 975ms/step - accuracy: 0.7074 - loss: 0.5662
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 20/79 ━━━━━[37m━━━━━━━━━━━━━━━  57s 975ms/step - accuracy: 0.7082 - loss: 0.5662
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 21/79 ━━━━━[37m━━━━━━━━━━━━━━━  56s 973ms/step - accuracy: 0.7092 - loss: 0.5663
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 22/79 ━━━━━[37m━━━━━━━━━━━━━━━  55s 975ms/step - accuracy: 0.7098 - loss: 0.5665
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 23/79 ━━━━━[37m━━━━━━━━━━━━━━━  54s 977ms/step - accuracy: 0.7103 - loss: 0.5668
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 24/79 ━━━━━━[37m━━━━━━━━━━━━━━  53s 979ms/step - accuracy: 0.7107 - loss: 0.5670
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 25/79 ━━━━━━[37m━━━━━━━━━━━━━━  52s 978ms/step - accuracy: 0.7110 - loss: 0.5671
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 26/79 ━━━━━━[37m━━━━━━━━━━━━━━  51s 978ms/step - accuracy: 0.7113 - loss: 0.5673
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 27/79 ━━━━━━[37m━━━━━━━━━━━━━━  50s 977ms/step - accuracy: 0.7117 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 28/79 ━━━━━━━[37m━━━━━━━━━━━━━  49s 974ms/step - accuracy: 0.7121 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 29/79 ━━━━━━━[37m━━━━━━━━━━━━━  48s 973ms/step - accuracy: 0.7126 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 30/79 ━━━━━━━[37m━━━━━━━━━━━━━  47s 972ms/step - accuracy: 0.7130 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 31/79 ━━━━━━━[37m━━━━━━━━━━━━━  46s 971ms/step - accuracy: 0.7136 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 32/79 ━━━━━━━━[37m━━━━━━━━━━━━  45s 972ms/step - accuracy: 0.7140 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 33/79 ━━━━━━━━[37m━━━━━━━━━━━━  44s 973ms/step - accuracy: 0.7145 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 34/79 ━━━━━━━━[37m━━━━━━━━━━━━  43s 973ms/step - accuracy: 0.7148 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 35/79 ━━━━━━━━[37m━━━━━━━━━━━━  43s 992ms/step - accuracy: 0.7152 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 36/79 ━━━━━━━━━[37m━━━━━━━━━━━  42s 999ms/step - accuracy: 0.7157 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 37/79 ━━━━━━━━━[37m━━━━━━━━━━━  41s 1000ms/step - accuracy: 0.7160 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 38/79 ━━━━━━━━━[37m━━━━━━━━━━━  40s 998ms/step - accuracy: 0.7163 - loss: 0.5673 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 39/79 ━━━━━━━━━[37m━━━━━━━━━━━  39s 998ms/step - accuracy: 0.7166 - loss: 0.5673
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 40/79 ━━━━━━━━━━[37m━━━━━━━━━━  38s 998ms/step - accuracy: 0.7168 - loss: 0.5673
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 41/79 ━━━━━━━━━━[37m━━━━━━━━━━  37s 999ms/step - accuracy: 0.7169 - loss: 0.5673
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 42/79 ━━━━━━━━━━[37m━━━━━━━━━━  36s 997ms/step - accuracy: 0.7170 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 43/79 ━━━━━━━━━━[37m━━━━━━━━━━  35s 996ms/step - accuracy: 0.7171 - loss: 0.5674
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 44/79 ━━━━━━━━━━━[37m━━━━━━━━━  34s 995ms/step - accuracy: 0.7171 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 45/79 ━━━━━━━━━━━[37m━━━━━━━━━  33s 994ms/step - accuracy: 0.7171 - loss: 0.5675
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 46/79 ━━━━━━━━━━━[37m━━━━━━━━━  32s 994ms/step - accuracy: 0.7172 - loss: 0.5676
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 47/79 ━━━━━━━━━━━[37m━━━━━━━━━  31s 992ms/step - accuracy: 0.7173 - loss: 0.5676
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 48/79 ━━━━━━━━━━━━[37m━━━━━━━━  30s 991ms/step - accuracy: 0.7174 - loss: 0.5676
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 49/79 ━━━━━━━━━━━━[37m━━━━━━━━  29s 990ms/step - accuracy: 0.7175 - loss: 0.5676
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 50/79 ━━━━━━━━━━━━[37m━━━━━━━━  28s 990ms/step - accuracy: 0.7176 - loss: 0.5677
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 51/79 ━━━━━━━━━━━━[37m━━━━━━━━  27s 989ms/step - accuracy: 0.7176 - loss: 0.5677
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 52/79 ━━━━━━━━━━━━━[37m━━━━━━━  26s 989ms/step - accuracy: 0.7176 - loss: 0.5677
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 53/79 ━━━━━━━━━━━━━[37m━━━━━━━  25s 989ms/step - accuracy: 0.7176 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 54/79 ━━━━━━━━━━━━━[37m━━━━━━━  24s 989ms/step - accuracy: 0.7176 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 55/79 ━━━━━━━━━━━━━[37m━━━━━━━  23s 988ms/step - accuracy: 0.7177 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 56/79 ━━━━━━━━━━━━━━[37m━━━━━━  22s 988ms/step - accuracy: 0.7177 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 57/79 ━━━━━━━━━━━━━━[37m━━━━━━  21s 988ms/step - accuracy: 0.7178 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 58/79 ━━━━━━━━━━━━━━[37m━━━━━━  20s 986ms/step - accuracy: 0.7179 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 59/79 ━━━━━━━━━━━━━━[37m━━━━━━  19s 985ms/step - accuracy: 0.7180 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 60/79 ━━━━━━━━━━━━━━━[37m━━━━━  18s 985ms/step - accuracy: 0.7181 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 61/79 ━━━━━━━━━━━━━━━[37m━━━━━  17s 984ms/step - accuracy: 0.7182 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 62/79 ━━━━━━━━━━━━━━━[37m━━━━━  16s 984ms/step - accuracy: 0.7182 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 63/79 ━━━━━━━━━━━━━━━[37m━━━━━  15s 984ms/step - accuracy: 0.7183 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 64/79 ━━━━━━━━━━━━━━━━[37m━━━━  14s 984ms/step - accuracy: 0.7184 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 65/79 ━━━━━━━━━━━━━━━━[37m━━━━  13s 983ms/step - accuracy: 0.7185 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 66/79 ━━━━━━━━━━━━━━━━[37m━━━━  12s 983ms/step - accuracy: 0.7187 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 67/79 ━━━━━━━━━━━━━━━━[37m━━━━  11s 994ms/step - accuracy: 0.7188 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 68/79 ━━━━━━━━━━━━━━━━━[37m━━━  10s 995ms/step - accuracy: 0.7189 - loss: 0.5680
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 69/79 ━━━━━━━━━━━━━━━━━[37m━━━  9s 992ms/step - accuracy: 0.7190 - loss: 0.5680 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 70/79 ━━━━━━━━━━━━━━━━━[37m━━━  8s 987ms/step - accuracy: 0.7192 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 71/79 ━━━━━━━━━━━━━━━━━[37m━━━  7s 982ms/step - accuracy: 0.7194 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 72/79 ━━━━━━━━━━━━━━━━━━[37m━━  6s 977ms/step - accuracy: 0.7195 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 73/79 ━━━━━━━━━━━━━━━━━━[37m━━  5s 974ms/step - accuracy: 0.7197 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 74/79 ━━━━━━━━━━━━━━━━━━[37m━━  4s 969ms/step - accuracy: 0.7198 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 75/79 ━━━━━━━━━━━━━━━━━━[37m━━  3s 964ms/step - accuracy: 0.7200 - loss: 0.5679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 76/79 ━━━━━━━━━━━━━━━━━━━[37m━  2s 960ms/step - accuracy: 0.7201 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 77/79 ━━━━━━━━━━━━━━━━━━━[37m━  1s 957ms/step - accuracy: 0.7203 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 78/79 ━━━━━━━━━━━━━━━━━━━[37m━  0s 954ms/step - accuracy: 0.7205 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 79/79 ━━━━━━━━━━━━━━━━━━━━ 0s 944ms/step - accuracy: 0.7206 - loss: 0.5678
+
+<div class="k-default-codeblock">
+```
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/models/functional.py:248: UserWarning: The structure of `inputs` doesn't match the expected structure.
+Expected: input_ids
+Received: inputs=['Tensor(shape=torch.Size([4, 512]))']
+  warnings.warn(msg)
+
+
+```
+</div>
+ 79/79 ━━━━━━━━━━━━━━━━━━━━ 78s 945ms/step - accuracy: 0.7208 - loss: 0.5678
+
+
+
+
+
+<div class="k-default-codeblock">
+```
+[0.5670130252838135, 0.7336000204086304]
 
 ```
 </div>
@@ -577,34 +4148,34 @@ transformer_classifier.fit(train_ds, epochs=EPOCHS, validation_data=val_ds)
 
 
 
-<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
-┃<span style="font-weight: bold"> Layer (type)        </span>┃<span style="font-weight: bold"> Output Shape      </span>┃<span style="font-weight: bold"> Param # </span>┃<span style="font-weight: bold"> Connected to         </span>┃
-┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
-│ input_ids           │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)      │       <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ -                    │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">InputLayer</span>)        │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ token_and_position… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │ <span style="color: #00af00; text-decoration-color: #00af00">1,985,…</span> │ input_ids[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]      │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TokenAndPositionE…</span> │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ transformer_encoder │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │ <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ token_and_position_… │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ transformer_encode… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │ <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ transformer_encoder… │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ transformer_encode… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │ <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ transformer_encoder… │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ not_equal_1         │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)      │       <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ input_ids[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]      │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">NotEqual</span>)          │                   │         │                      │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ global_average_poo… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)       │       <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ transformer_encoder… │
-│ (<span style="color: #0087ff; text-decoration-color: #0087ff">GlobalAveragePool…</span> │                   │         │ not_equal_1[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]    │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ dropout_4 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dropout</span>) │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)       │       <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ global_average_pool… │
-├─────────────────────┼───────────────────┼─────────┼──────────────────────┤
-│ dense_1 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)     │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>)         │     <span style="color: #00af00; text-decoration-color: #00af00">129</span> │ dropout_4[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]      │
-└─────────────────────┴───────────────────┴─────────┴──────────────────────┘
+<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃<span style="font-weight: bold"> Layer (type)        </span>┃<span style="font-weight: bold"> Output Shape      </span>┃<span style="font-weight: bold">    Param # </span>┃<span style="font-weight: bold"> Connected to      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│ input_ids           │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)      │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ -                 │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">InputLayer</span>)        │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ token_and_position… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │  <span style="color: #00af00; text-decoration-color: #00af00">1,985,536</span> │ input_ids[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]   │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TokenAndPositionE…</span> │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ transformer_encoder │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │    <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ token_and_positi… │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ transformer_encode… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │    <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ transformer_enco… │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ transformer_encode… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>) │    <span style="color: #00af00; text-decoration-color: #00af00">198,272</span> │ transformer_enco… │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">TransformerEncode…</span> │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ not_equal_1         │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>)      │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ input_ids[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]   │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">NotEqual</span>)          │                   │            │                   │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ global_average_poo… │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)       │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ transformer_enco… │
+│ (<span style="color: #0087ff; text-decoration-color: #0087ff">GlobalAveragePool…</span> │                   │            │ not_equal_1[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>] │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ dropout_4 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dropout</span>) │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">128</span>)       │          <span style="color: #00af00; text-decoration-color: #00af00">0</span> │ global_average_p… │
+├─────────────────────┼───────────────────┼────────────┼───────────────────┤
+│ dense_1 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)     │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>)         │        <span style="color: #00af00; text-decoration-color: #00af00">129</span> │ dropout_4[<span style="color: #00af00; text-decoration-color: #00af00">0</span>][<span style="color: #00af00; text-decoration-color: #00af00">0</span>]   │
+└─────────────────────┴───────────────────┴────────────┴───────────────────┘
 </pre>
 
 
@@ -627,16 +4198,1059 @@ transformer_classifier.fit(train_ds, epochs=EPOCHS, validation_data=val_ds)
 
 
 
+    
+   1/149 [37m━━━━━━━━━━━━━━━━━━━━  19:16 8s/step - accuracy: 0.4375 - loss: 0.7813
+
 <div class="k-default-codeblock">
 ```
-Epoch 1/3
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 14s 38ms/step - accuracy: 0.5895 - loss: 0.7401 - val_accuracy: 0.8912 - val_loss: 0.2694
-Epoch 2/3
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 9s 29ms/step - accuracy: 0.9051 - loss: 0.2382 - val_accuracy: 0.8853 - val_loss: 0.2984
-Epoch 3/3
- 313/313 ━━━━━━━━━━━━━━━━━━━━ 9s 29ms/step - accuracy: 0.9496 - loss: 0.1366 - val_accuracy: 0.8730 - val_loss: 0.3607
+
+```
+</div>
+   2/149 [37m━━━━━━━━━━━━━━━━━━━━  9:50 4s/step - accuracy: 0.4531 - loss: 1.3017 
 
-<keras.src.callbacks.history.History at 0x7feaf9c56ad0>
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   3/149 [37m━━━━━━━━━━━━━━━━━━━━  9:32 4s/step - accuracy: 0.4618 - loss: 1.4133
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   4/149 [37m━━━━━━━━━━━━━━━━━━━━  9:45 4s/step - accuracy: 0.4616 - loss: 1.4361
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   5/149 [37m━━━━━━━━━━━━━━━━━━━━  9:36 4s/step - accuracy: 0.4605 - loss: 1.4379
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   6/149 [37m━━━━━━━━━━━━━━━━━━━━  9:34 4s/step - accuracy: 0.4593 - loss: 1.4202
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   7/149 [37m━━━━━━━━━━━━━━━━━━━━  9:32 4s/step - accuracy: 0.4619 - loss: 1.3940
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   8/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:24 4s/step - accuracy: 0.4633 - loss: 1.3713
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+   9/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:08 4s/step - accuracy: 0.4662 - loss: 1.3476
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  10/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:00 4s/step - accuracy: 0.4686 - loss: 1.3250
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  11/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:01 4s/step - accuracy: 0.4702 - loss: 1.3035
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  12/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:01 4s/step - accuracy: 0.4733 - loss: 1.2824
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  13/149 ━[37m━━━━━━━━━━━━━━━━━━━  9:00 4s/step - accuracy: 0.4759 - loss: 1.2641
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  14/149 ━[37m━━━━━━━━━━━━━━━━━━━  8:58 4s/step - accuracy: 0.4783 - loss: 1.2478
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  15/149 ━━[37m━━━━━━━━━━━━━━━━━━  8:58 4s/step - accuracy: 0.4808 - loss: 1.2323
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  16/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:04 4s/step - accuracy: 0.4840 - loss: 1.2169
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  17/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:03 4s/step - accuracy: 0.4867 - loss: 1.2025
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  18/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:01 4s/step - accuracy: 0.4890 - loss: 1.1889
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  19/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:06 4s/step - accuracy: 0.4913 - loss: 1.1760
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  20/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:06 4s/step - accuracy: 0.4932 - loss: 1.1638
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  21/149 ━━[37m━━━━━━━━━━━━━━━━━━  9:04 4s/step - accuracy: 0.4952 - loss: 1.1521
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  22/149 ━━[37m━━━━━━━━━━━━━━━━━━  8:59 4s/step - accuracy: 0.4973 - loss: 1.1409
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  23/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:52 4s/step - accuracy: 0.4991 - loss: 1.1304
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  24/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:47 4s/step - accuracy: 0.5009 - loss: 1.1205
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  25/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:50 4s/step - accuracy: 0.5025 - loss: 1.1111
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  26/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:48 4s/step - accuracy: 0.5040 - loss: 1.1022
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  27/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:43 4s/step - accuracy: 0.5053 - loss: 1.0936
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  28/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:40 4s/step - accuracy: 0.5066 - loss: 1.0855
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  29/149 ━━━[37m━━━━━━━━━━━━━━━━━  8:36 4s/step - accuracy: 0.5076 - loss: 1.0778
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  30/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:33 4s/step - accuracy: 0.5086 - loss: 1.0703
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  31/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:27 4s/step - accuracy: 0.5095 - loss: 1.0633
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  32/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:22 4s/step - accuracy: 0.5104 - loss: 1.0565
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  33/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:18 4s/step - accuracy: 0.5112 - loss: 1.0501
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  34/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:13 4s/step - accuracy: 0.5119 - loss: 1.0438
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  35/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:07 4s/step - accuracy: 0.5126 - loss: 1.0379
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  36/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:02 4s/step - accuracy: 0.5133 - loss: 1.0321
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  37/149 ━━━━[37m━━━━━━━━━━━━━━━━  8:00 4s/step - accuracy: 0.5140 - loss: 1.0265
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  38/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:56 4s/step - accuracy: 0.5146 - loss: 1.0212
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  39/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:52 4s/step - accuracy: 0.5152 - loss: 1.0161
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  40/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:47 4s/step - accuracy: 0.5157 - loss: 1.0112
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  41/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:42 4s/step - accuracy: 0.5161 - loss: 1.0065
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  42/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:41 4s/step - accuracy: 0.5164 - loss: 1.0020
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  43/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:37 4s/step - accuracy: 0.5167 - loss: 0.9976
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  44/149 ━━━━━[37m━━━━━━━━━━━━━━━  7:32 4s/step - accuracy: 0.5170 - loss: 0.9934
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  45/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:27 4s/step - accuracy: 0.5173 - loss: 0.9893
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  46/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:24 4s/step - accuracy: 0.5175 - loss: 0.9854
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  47/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:19 4s/step - accuracy: 0.5177 - loss: 0.9818
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  48/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:14 4s/step - accuracy: 0.5178 - loss: 0.9781
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  49/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:12 4s/step - accuracy: 0.5180 - loss: 0.9746
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  50/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:07 4s/step - accuracy: 0.5181 - loss: 0.9713
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  51/149 ━━━━━━[37m━━━━━━━━━━━━━━  7:03 4s/step - accuracy: 0.5182 - loss: 0.9679
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  52/149 ━━━━━━[37m━━━━━━━━━━━━━━  6:59 4s/step - accuracy: 0.5183 - loss: 0.9647
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  53/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:53 4s/step - accuracy: 0.5184 - loss: 0.9616
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  54/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:51 4s/step - accuracy: 0.5184 - loss: 0.9586
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  55/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:47 4s/step - accuracy: 0.5185 - loss: 0.9556
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  56/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:45 4s/step - accuracy: 0.5186 - loss: 0.9527
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  57/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:40 4s/step - accuracy: 0.5187 - loss: 0.9499
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  58/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:36 4s/step - accuracy: 0.5189 - loss: 0.9471
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  59/149 ━━━━━━━[37m━━━━━━━━━━━━━  6:32 4s/step - accuracy: 0.5191 - loss: 0.9444
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  60/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:27 4s/step - accuracy: 0.5191 - loss: 0.9418
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  61/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:23 4s/step - accuracy: 0.5192 - loss: 0.9392
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  62/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:18 4s/step - accuracy: 0.5193 - loss: 0.9367
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  63/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:13 4s/step - accuracy: 0.5193 - loss: 0.9342
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  64/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:09 4s/step - accuracy: 0.5194 - loss: 0.9318
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  65/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:05 4s/step - accuracy: 0.5194 - loss: 0.9295
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  66/149 ━━━━━━━━[37m━━━━━━━━━━━━  6:00 4s/step - accuracy: 0.5194 - loss: 0.9272
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  67/149 ━━━━━━━━[37m━━━━━━━━━━━━  5:56 4s/step - accuracy: 0.5195 - loss: 0.9250
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  68/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:52 4s/step - accuracy: 0.5195 - loss: 0.9228
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  69/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:48 4s/step - accuracy: 0.5195 - loss: 0.9207
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  70/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:43 4s/step - accuracy: 0.5196 - loss: 0.9186
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  71/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:40 4s/step - accuracy: 0.5196 - loss: 0.9165
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  72/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:36 4s/step - accuracy: 0.5197 - loss: 0.9145
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  73/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:31 4s/step - accuracy: 0.5197 - loss: 0.9126
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  74/149 ━━━━━━━━━[37m━━━━━━━━━━━  5:27 4s/step - accuracy: 0.5197 - loss: 0.9107
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  75/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:23 4s/step - accuracy: 0.5197 - loss: 0.9088
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  76/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:19 4s/step - accuracy: 0.5197 - loss: 0.9069
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  77/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:15 4s/step - accuracy: 0.5197 - loss: 0.9052
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  78/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:11 4s/step - accuracy: 0.5197 - loss: 0.9034
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  79/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:08 4s/step - accuracy: 0.5197 - loss: 0.9017
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  80/149 ━━━━━━━━━━[37m━━━━━━━━━━  5:01 4s/step - accuracy: 0.5197 - loss: 0.9000
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  81/149 ━━━━━━━━━━[37m━━━━━━━━━━  4:57 4s/step - accuracy: 0.5197 - loss: 0.8983
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  82/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:53 4s/step - accuracy: 0.5197 - loss: 0.8967
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  83/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:48 4s/step - accuracy: 0.5197 - loss: 0.8951
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  84/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:44 4s/step - accuracy: 0.5197 - loss: 0.8935
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  85/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:40 4s/step - accuracy: 0.5198 - loss: 0.8919
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  86/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:36 4s/step - accuracy: 0.5199 - loss: 0.8903
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  87/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:31 4s/step - accuracy: 0.5200 - loss: 0.8888
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  88/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:27 4s/step - accuracy: 0.5200 - loss: 0.8873
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  89/149 ━━━━━━━━━━━[37m━━━━━━━━━  4:23 4s/step - accuracy: 0.5201 - loss: 0.8858
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  90/149 ━━━━━━━━━━━━[37m━━━━━━━━  4:19 4s/step - accuracy: 0.5202 - loss: 0.8843
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  91/149 ━━━━━━━━━━━━[37m━━━━━━━━  4:14 4s/step - accuracy: 0.5204 - loss: 0.8829
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  92/149 ━━━━━━━━━━━━[37m━━━━━━━━  4:10 4s/step - accuracy: 0.5205 - loss: 0.8815
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  93/149 ━━━━━━━━━━━━[37m━━━━━━━━  4:05 4s/step - accuracy: 0.5206 - loss: 0.8800
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  94/149 ━━━━━━━━━━━━[37m━━━━━━━━  4:02 4s/step - accuracy: 0.5208 - loss: 0.8786
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  95/149 ━━━━━━━━━━━━[37m━━━━━━━━  3:57 4s/step - accuracy: 0.5209 - loss: 0.8772
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  96/149 ━━━━━━━━━━━━[37m━━━━━━━━  3:53 4s/step - accuracy: 0.5211 - loss: 0.8758
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  97/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:49 4s/step - accuracy: 0.5213 - loss: 0.8744
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  98/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:44 4s/step - accuracy: 0.5215 - loss: 0.8731
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  99/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:40 4s/step - accuracy: 0.5218 - loss: 0.8717
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 100/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:36 4s/step - accuracy: 0.5220 - loss: 0.8704
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 101/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:32 4s/step - accuracy: 0.5223 - loss: 0.8690
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 102/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:27 4s/step - accuracy: 0.5225 - loss: 0.8677
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 103/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:23 4s/step - accuracy: 0.5228 - loss: 0.8664
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 104/149 ━━━━━━━━━━━━━[37m━━━━━━━  3:19 4s/step - accuracy: 0.5231 - loss: 0.8651
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 105/149 ━━━━━━━━━━━━━━[37m━━━━━━  3:15 4s/step - accuracy: 0.5234 - loss: 0.8638
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 106/149 ━━━━━━━━━━━━━━[37m━━━━━━  3:11 4s/step - accuracy: 0.5236 - loss: 0.8626
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 107/149 ━━━━━━━━━━━━━━[37m━━━━━━  3:06 4s/step - accuracy: 0.5239 - loss: 0.8614
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 108/149 ━━━━━━━━━━━━━━[37m━━━━━━  3:02 4s/step - accuracy: 0.5242 - loss: 0.8601
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 109/149 ━━━━━━━━━━━━━━[37m━━━━━━  2:57 4s/step - accuracy: 0.5245 - loss: 0.8589
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 110/149 ━━━━━━━━━━━━━━[37m━━━━━━  2:53 4s/step - accuracy: 0.5249 - loss: 0.8577
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 111/149 ━━━━━━━━━━━━━━[37m━━━━━━  2:48 4s/step - accuracy: 0.5252 - loss: 0.8565
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 112/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:44 4s/step - accuracy: 0.5255 - loss: 0.8553
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 113/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:40 4s/step - accuracy: 0.5259 - loss: 0.8541
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 114/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:35 4s/step - accuracy: 0.5262 - loss: 0.8530
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 115/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:31 4s/step - accuracy: 0.5265 - loss: 0.8518
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 116/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:26 4s/step - accuracy: 0.5269 - loss: 0.8507
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 117/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:22 4s/step - accuracy: 0.5272 - loss: 0.8495
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 118/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:18 4s/step - accuracy: 0.5276 - loss: 0.8484
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 119/149 ━━━━━━━━━━━━━━━[37m━━━━━  2:13 4s/step - accuracy: 0.5279 - loss: 0.8473
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 120/149 ━━━━━━━━━━━━━━━━[37m━━━━  2:09 4s/step - accuracy: 0.5283 - loss: 0.8462
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 121/149 ━━━━━━━━━━━━━━━━[37m━━━━  2:05 4s/step - accuracy: 0.5287 - loss: 0.8450
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 122/149 ━━━━━━━━━━━━━━━━[37m━━━━  2:00 4s/step - accuracy: 0.5291 - loss: 0.8439
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 123/149 ━━━━━━━━━━━━━━━━[37m━━━━  1:56 4s/step - accuracy: 0.5295 - loss: 0.8428
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 124/149 ━━━━━━━━━━━━━━━━[37m━━━━  1:51 4s/step - accuracy: 0.5299 - loss: 0.8417
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 125/149 ━━━━━━━━━━━━━━━━[37m━━━━  1:47 4s/step - accuracy: 0.5303 - loss: 0.8405
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 126/149 ━━━━━━━━━━━━━━━━[37m━━━━  1:42 4s/step - accuracy: 0.5307 - loss: 0.8394
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 127/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:38 4s/step - accuracy: 0.5311 - loss: 0.8383
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 128/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:33 4s/step - accuracy: 0.5316 - loss: 0.8372
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 129/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:29 4s/step - accuracy: 0.5320 - loss: 0.8361
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 130/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:24 4s/step - accuracy: 0.5325 - loss: 0.8350
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 131/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:20 4s/step - accuracy: 0.5329 - loss: 0.8340
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 132/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:15 4s/step - accuracy: 0.5334 - loss: 0.8329
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 133/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:11 4s/step - accuracy: 0.5338 - loss: 0.8318
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 134/149 ━━━━━━━━━━━━━━━━━[37m━━━  1:06 4s/step - accuracy: 0.5343 - loss: 0.8308
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 135/149 ━━━━━━━━━━━━━━━━━━[37m━━  1:02 4s/step - accuracy: 0.5347 - loss: 0.8297
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 136/149 ━━━━━━━━━━━━━━━━━━[37m━━  58s 4s/step - accuracy: 0.5352 - loss: 0.8287 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 137/149 ━━━━━━━━━━━━━━━━━━[37m━━  53s 4s/step - accuracy: 0.5356 - loss: 0.8276
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 138/149 ━━━━━━━━━━━━━━━━━━[37m━━  49s 4s/step - accuracy: 0.5361 - loss: 0.8266
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 139/149 ━━━━━━━━━━━━━━━━━━[37m━━  44s 4s/step - accuracy: 0.5366 - loss: 0.8255
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 140/149 ━━━━━━━━━━━━━━━━━━[37m━━  40s 4s/step - accuracy: 0.5370 - loss: 0.8245
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 141/149 ━━━━━━━━━━━━━━━━━━[37m━━  35s 4s/step - accuracy: 0.5375 - loss: 0.8235
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 142/149 ━━━━━━━━━━━━━━━━━━━[37m━  31s 4s/step - accuracy: 0.5380 - loss: 0.8224
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 143/149 ━━━━━━━━━━━━━━━━━━━[37m━  26s 4s/step - accuracy: 0.5385 - loss: 0.8214
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 144/149 ━━━━━━━━━━━━━━━━━━━[37m━  22s 4s/step - accuracy: 0.5390 - loss: 0.8204
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 145/149 ━━━━━━━━━━━━━━━━━━━[37m━  17s 4s/step - accuracy: 0.5395 - loss: 0.8193
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 146/149 ━━━━━━━━━━━━━━━━━━━[37m━  13s 4s/step - accuracy: 0.5400 - loss: 0.8183
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 147/149 ━━━━━━━━━━━━━━━━━━━[37m━  8s 4s/step - accuracy: 0.5405 - loss: 0.8173 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 148/149 ━━━━━━━━━━━━━━━━━━━[37m━  4s 4s/step - accuracy: 0.5410 - loss: 0.8163
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 149/149 ━━━━━━━━━━━━━━━━━━━━ 0s 4s/step - accuracy: 0.5415 - loss: 0.8152
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 149/149 ━━━━━━━━━━━━━━━━━━━━ 684s 5s/step - accuracy: 0.5420 - loss: 0.8142 - val_accuracy: 0.8560 - val_loss: 0.3914
+
+
+
+
+
+<div class="k-default-codeblock">
+```
+<keras.src.callbacks.history.History at 0x7c51ab962990>
 
 ```
 </div>
@@ -651,11 +5265,569 @@ Let's calculate the test accuracy.
 transformer_classifier.evaluate(test_ds, batch_size=BATCH_SIZE)
 ```
 
+    
+  1/79 [37m━━━━━━━━━━━━━━━━━━━━  7:39 6s/step - accuracy: 0.8125 - loss: 0.3880
+
 <div class="k-default-codeblock">
 ```
- 391/391 ━━━━━━━━━━━━━━━━━━━━ 4s 11ms/step - accuracy: 0.8399 - loss: 0.4579
+
+```
+</div>
+  2/79 [37m━━━━━━━━━━━━━━━━━━━━  1:58 2s/step - accuracy: 0.8047 - loss: 0.4233
 
-[0.4496161639690399, 0.8423193097114563]
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  3/79 [37m━━━━━━━━━━━━━━━━━━━━  1:57 2s/step - accuracy: 0.8212 - loss: 0.4146
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  4/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:55 2s/step - accuracy: 0.8268 - loss: 0.4106
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  5/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:53 2s/step - accuracy: 0.8340 - loss: 0.4023
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  6/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:51 2s/step - accuracy: 0.8399 - loss: 0.3957
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  7/79 ━[37m━━━━━━━━━━━━━━━━━━━  1:49 2s/step - accuracy: 0.8437 - loss: 0.3908
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  8/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:47 2s/step - accuracy: 0.8437 - loss: 0.3906
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+  9/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:45 2s/step - accuracy: 0.8433 - loss: 0.3911
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 10/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:44 2s/step - accuracy: 0.8418 - loss: 0.3920
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 11/79 ━━[37m━━━━━━━━━━━━━━━━━━  1:49 2s/step - accuracy: 0.8414 - loss: 0.3910
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 12/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:48 2s/step - accuracy: 0.8412 - loss: 0.3896
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 13/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:48 2s/step - accuracy: 0.8405 - loss: 0.3891
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 14/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:46 2s/step - accuracy: 0.8398 - loss: 0.3898
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 15/79 ━━━[37m━━━━━━━━━━━━━━━━━  1:44 2s/step - accuracy: 0.8386 - loss: 0.3912
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 16/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:42 2s/step - accuracy: 0.8376 - loss: 0.3924
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 17/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:43 2s/step - accuracy: 0.8366 - loss: 0.3935
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 18/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:41 2s/step - accuracy: 0.8357 - loss: 0.3940
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 19/79 ━━━━[37m━━━━━━━━━━━━━━━━  1:39 2s/step - accuracy: 0.8347 - loss: 0.3946
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 20/79 ━━━━━[37m━━━━━━━━━━━━━━━  1:37 2s/step - accuracy: 0.8338 - loss: 0.3956
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 21/79 ━━━━━[37m━━━━━━━━━━━━━━━  1:38 2s/step - accuracy: 0.8328 - loss: 0.3967
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 22/79 ━━━━━[37m━━━━━━━━━━━━━━━  1:36 2s/step - accuracy: 0.8317 - loss: 0.3979
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 23/79 ━━━━━[37m━━━━━━━━━━━━━━━  1:34 2s/step - accuracy: 0.8308 - loss: 0.3990
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 24/79 ━━━━━━[37m━━━━━━━━━━━━━━  1:32 2s/step - accuracy: 0.8301 - loss: 0.3996
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 25/79 ━━━━━━[37m━━━━━━━━━━━━━━  1:32 2s/step - accuracy: 0.8297 - loss: 0.3999
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 26/79 ━━━━━━[37m━━━━━━━━━━━━━━  1:30 2s/step - accuracy: 0.8293 - loss: 0.4000
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 27/79 ━━━━━━[37m━━━━━━━━━━━━━━  1:28 2s/step - accuracy: 0.8292 - loss: 0.3999
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 28/79 ━━━━━━━[37m━━━━━━━━━━━━━  1:26 2s/step - accuracy: 0.8291 - loss: 0.3998
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 29/79 ━━━━━━━[37m━━━━━━━━━━━━━  1:26 2s/step - accuracy: 0.8292 - loss: 0.3994
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 30/79 ━━━━━━━[37m━━━━━━━━━━━━━  1:24 2s/step - accuracy: 0.8292 - loss: 0.3992
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 31/79 ━━━━━━━[37m━━━━━━━━━━━━━  1:22 2s/step - accuracy: 0.8293 - loss: 0.3989
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 32/79 ━━━━━━━━[37m━━━━━━━━━━━━  1:21 2s/step - accuracy: 0.8294 - loss: 0.3987
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 33/79 ━━━━━━━━[37m━━━━━━━━━━━━  1:19 2s/step - accuracy: 0.8295 - loss: 0.3985
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 34/79 ━━━━━━━━[37m━━━━━━━━━━━━  1:17 2s/step - accuracy: 0.8294 - loss: 0.3986
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 35/79 ━━━━━━━━[37m━━━━━━━━━━━━  1:15 2s/step - accuracy: 0.8295 - loss: 0.3986
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 36/79 ━━━━━━━━━[37m━━━━━━━━━━━  1:14 2s/step - accuracy: 0.8296 - loss: 0.3985
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 37/79 ━━━━━━━━━[37m━━━━━━━━━━━  1:12 2s/step - accuracy: 0.8295 - loss: 0.3986
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 38/79 ━━━━━━━━━[37m━━━━━━━━━━━  1:11 2s/step - accuracy: 0.8295 - loss: 0.3986
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 39/79 ━━━━━━━━━[37m━━━━━━━━━━━  1:09 2s/step - accuracy: 0.8294 - loss: 0.3987
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 40/79 ━━━━━━━━━━[37m━━━━━━━━━━  1:07 2s/step - accuracy: 0.8292 - loss: 0.3989
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 41/79 ━━━━━━━━━━[37m━━━━━━━━━━  1:06 2s/step - accuracy: 0.8290 - loss: 0.3992
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 42/79 ━━━━━━━━━━[37m━━━━━━━━━━  1:04 2s/step - accuracy: 0.8287 - loss: 0.3995
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 43/79 ━━━━━━━━━━[37m━━━━━━━━━━  1:02 2s/step - accuracy: 0.8285 - loss: 0.3998
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 44/79 ━━━━━━━━━━━[37m━━━━━━━━━  1:01 2s/step - accuracy: 0.8283 - loss: 0.4001
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 45/79 ━━━━━━━━━━━[37m━━━━━━━━━  59s 2s/step - accuracy: 0.8280 - loss: 0.4004 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 46/79 ━━━━━━━━━━━[37m━━━━━━━━━  57s 2s/step - accuracy: 0.8278 - loss: 0.4007
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 47/79 ━━━━━━━━━━━[37m━━━━━━━━━  56s 2s/step - accuracy: 0.8275 - loss: 0.4010
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 48/79 ━━━━━━━━━━━━[37m━━━━━━━━  54s 2s/step - accuracy: 0.8272 - loss: 0.4013
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 49/79 ━━━━━━━━━━━━[37m━━━━━━━━  52s 2s/step - accuracy: 0.8270 - loss: 0.4016
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 50/79 ━━━━━━━━━━━━[37m━━━━━━━━  50s 2s/step - accuracy: 0.8267 - loss: 0.4020
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 51/79 ━━━━━━━━━━━━[37m━━━━━━━━  49s 2s/step - accuracy: 0.8263 - loss: 0.4025
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 52/79 ━━━━━━━━━━━━━[37m━━━━━━━  47s 2s/step - accuracy: 0.8260 - loss: 0.4028
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 53/79 ━━━━━━━━━━━━━[37m━━━━━━━  45s 2s/step - accuracy: 0.8257 - loss: 0.4032
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 54/79 ━━━━━━━━━━━━━[37m━━━━━━━  43s 2s/step - accuracy: 0.8254 - loss: 0.4036
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 55/79 ━━━━━━━━━━━━━[37m━━━━━━━  41s 2s/step - accuracy: 0.8252 - loss: 0.4040
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 56/79 ━━━━━━━━━━━━━━[37m━━━━━━  40s 2s/step - accuracy: 0.8249 - loss: 0.4043
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 57/79 ━━━━━━━━━━━━━━[37m━━━━━━  38s 2s/step - accuracy: 0.8247 - loss: 0.4046
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 58/79 ━━━━━━━━━━━━━━[37m━━━━━━  36s 2s/step - accuracy: 0.8245 - loss: 0.4049
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 59/79 ━━━━━━━━━━━━━━[37m━━━━━━  34s 2s/step - accuracy: 0.8243 - loss: 0.4052
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 60/79 ━━━━━━━━━━━━━━━[37m━━━━━  33s 2s/step - accuracy: 0.8242 - loss: 0.4055
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 61/79 ━━━━━━━━━━━━━━━[37m━━━━━  31s 2s/step - accuracy: 0.8240 - loss: 0.4057
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 62/79 ━━━━━━━━━━━━━━━[37m━━━━━  29s 2s/step - accuracy: 0.8239 - loss: 0.4059
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 63/79 ━━━━━━━━━━━━━━━[37m━━━━━  28s 2s/step - accuracy: 0.8238 - loss: 0.4061
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 64/79 ━━━━━━━━━━━━━━━━[37m━━━━  26s 2s/step - accuracy: 0.8236 - loss: 0.4063
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 65/79 ━━━━━━━━━━━━━━━━[37m━━━━  24s 2s/step - accuracy: 0.8235 - loss: 0.4065
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 66/79 ━━━━━━━━━━━━━━━━[37m━━━━  22s 2s/step - accuracy: 0.8234 - loss: 0.4066
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 67/79 ━━━━━━━━━━━━━━━━[37m━━━━  21s 2s/step - accuracy: 0.8233 - loss: 0.4068
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 68/79 ━━━━━━━━━━━━━━━━━[37m━━━  19s 2s/step - accuracy: 0.8231 - loss: 0.4070
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 69/79 ━━━━━━━━━━━━━━━━━[37m━━━  17s 2s/step - accuracy: 0.8230 - loss: 0.4072
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 70/79 ━━━━━━━━━━━━━━━━━[37m━━━  15s 2s/step - accuracy: 0.8228 - loss: 0.4073
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 71/79 ━━━━━━━━━━━━━━━━━[37m━━━  13s 2s/step - accuracy: 0.8227 - loss: 0.4075
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 72/79 ━━━━━━━━━━━━━━━━━━[37m━━  12s 2s/step - accuracy: 0.8226 - loss: 0.4076
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 73/79 ━━━━━━━━━━━━━━━━━━[37m━━  10s 2s/step - accuracy: 0.8225 - loss: 0.4077
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 74/79 ━━━━━━━━━━━━━━━━━━[37m━━  8s 2s/step - accuracy: 0.8224 - loss: 0.4078 
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 75/79 ━━━━━━━━━━━━━━━━━━[37m━━  6s 2s/step - accuracy: 0.8223 - loss: 0.4079
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 76/79 ━━━━━━━━━━━━━━━━━━━[37m━  5s 2s/step - accuracy: 0.8223 - loss: 0.4080
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 77/79 ━━━━━━━━━━━━━━━━━━━[37m━  3s 2s/step - accuracy: 0.8222 - loss: 0.4080
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 78/79 ━━━━━━━━━━━━━━━━━━━[37m━  1s 2s/step - accuracy: 0.8221 - loss: 0.4081
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 79/79 ━━━━━━━━━━━━━━━━━━━━ 0s 2s/step - accuracy: 0.8220 - loss: 0.4081
+
+<div class="k-default-codeblock">
+```
+
+```
+</div>
+ 79/79 ━━━━━━━━━━━━━━━━━━━━ 138s 2s/step - accuracy: 0.8219 - loss: 0.4082
+
+
+
+
+
+<div class="k-default-codeblock">
+```
+[0.41192713379859924, 0.8163999915122986]
 
 ```
 </div>

--- a/examples/structured_data/classification_with_grn_and_vsn.py
+++ b/examples/structured_data/classification_with_grn_and_vsn.py
@@ -2,7 +2,7 @@
 Title: Classification with Gated Residual and Variable Selection Networks
 Author: [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)
 Date created: 2021/02/10
-Last modified: 2021/02/10
+Last modified: 2025/01/03
 Description: Using Gated Residual and Variable Selection Networks for income level prediction.
 Accelerator: GPU
 """
@@ -123,16 +123,24 @@ extracted_path = os.path.join(
 )
 for root, dirs, files in os.walk(extracted_path):
     for file in files:
-        if file.endswith('.tar.gz'):
+        if file.endswith(".tar.gz"):
             tar_gz_path = os.path.join(root, file)
-            with tarfile.open(tar_gz_path, 'r:gz') as tar:
+            with tarfile.open(tar_gz_path, "r:gz") as tar:
                 tar.extractall(path=root)
 
 train_data_path = os.path.join(
-    os.path.expanduser("~"), ".keras", "datasets", "census+income+kdd.zip", "census-income.data"
+    os.path.expanduser("~"),
+    ".keras",
+    "datasets",
+    "census+income+kdd.zip",
+    "census-income.data",
 )
 test_data_path = os.path.join(
-    os.path.expanduser("~"), ".keras", "datasets", "census+income+kdd.zip", "census-income.test"
+    os.path.expanduser("~"),
+    ".keras",
+    "datasets",
+    "census+income+kdd.zip",
+    "census-income.test",
 )
 
 data = pd.read_csv(train_data_path, header=None, names=CSV_HEADER)
@@ -181,8 +189,14 @@ clean the directory for the downloaded files except the .tar.gz file and
 also remove the empty directories
 """
 
-subprocess.run(f'find {extracted_path} -type f ! -name "*.tar.gz" -exec rm -f {{}} +', shell=True, check=True)
-subprocess.run(f'find {extracted_path} -type d -empty -exec rmdir {{}} +', shell=True, check=True)
+subprocess.run(
+    f'find {extracted_path} -type f ! -name "*.tar.gz" -exec rm -f {{}} +',
+    shell=True,
+    check=True,
+)
+subprocess.run(
+    f"find {extracted_path} -type d -empty -exec rmdir {{}} +", shell=True, check=True
+)
 
 """
 ## Define dataset metadata
@@ -338,10 +352,10 @@ class GatedLinearUnit(layers.Layer):
 
     def call(self, inputs):
         return self.linear(inputs) * self.sigmoid(inputs)
-    
+
     # to remove the build warnings
     def build(self):
-        self.built=True
+        self.built = True
 
 
 """
@@ -380,7 +394,7 @@ class GatedResidualNetwork(layers.Layer):
 
     # to remove the build warnings
     def build(self):
-        self.build=True
+        self.build = True
 
 
 """
@@ -425,7 +439,7 @@ class VariableSelection(layers.Layer):
 
     # to remove the build warnings
     def build(self):
-        self.built=True
+        self.built = True
 
 
 """
@@ -454,7 +468,7 @@ def create_model(encoding_size):
 learning_rate = 0.001
 dropout_rate = 0.15
 batch_size = 265
-num_epochs = 20
+num_epochs = 1
 encoding_size = 16
 
 model = create_model(encoding_size)
@@ -472,7 +486,9 @@ early_stopping = keras.callbacks.EarlyStopping(
 
 print("Start training the model...")
 train_dataset = get_dataset_from_csv(
-    train_data_file, batch_size=batch_size, shuffle=True,
+    train_data_file,
+    batch_size=batch_size,
+    shuffle=True,
 )
 valid_dataset = get_dataset_from_csv(valid_data_file, batch_size=batch_size)
 model.fit(

--- a/examples/structured_data/ipynb/classification_with_grn_and_vsn.ipynb
+++ b/examples/structured_data/ipynb/classification_with_grn_and_vsn.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)<br>\n",
     "**Date created:** 2021/02/10<br>\n",
-    "**Last modified:** 2021/02/10<br>\n",
+    "**Last modified:** 2025/01/03<br>\n",
     "**Description:** Using Gated Residual and Variable Selection Networks for income level prediction."
    ]
   },
@@ -76,6 +76,8 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import subprocess\n",
+    "import tarfile\n",
     "\n",
     "# Only the TensorFlow backend supports string inputs.\n",
     "os.environ[\"KERAS_BACKEND\"] = \"tensorflow\"\n",
@@ -152,11 +154,55 @@
     "    \"income_level\",\n",
     "]\n",
     "\n",
-    "data_url = \"https://archive.ics.uci.edu/ml/machine-learning-databases/census-income-mld/census-income.data.gz\"\n",
-    "data = pd.read_csv(data_url, header=None, names=CSV_HEADER)\n",
+    "data_url = \"https://archive.ics.uci.edu/static/public/117/census+income+kdd.zip\"\n",
+    "keras.utils.get_file(origin=data_url, extract=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "determine the downloaded .tar.gz file path and\n",
+    "extract the files from the downloaded .tar.gz file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "extracted_path = os.path.join(\n",
+    "    os.path.expanduser(\"~\"), \".keras\", \"datasets\", \"census+income+kdd.zip\"\n",
+    ")\n",
+    "for root, dirs, files in os.walk(extracted_path):\n",
+    "    for file in files:\n",
+    "        if file.endswith(\".tar.gz\"):\n",
+    "            tar_gz_path = os.path.join(root, file)\n",
+    "            with tarfile.open(tar_gz_path, \"r:gz\") as tar:\n",
+    "                tar.extractall(path=root)\n",
     "\n",
-    "test_data_url = \"https://archive.ics.uci.edu/ml/machine-learning-databases/census-income-mld/census-income.test.gz\"\n",
-    "test_data = pd.read_csv(test_data_url, header=None, names=CSV_HEADER)\n",
+    "train_data_path = os.path.join(\n",
+    "    os.path.expanduser(\"~\"),\n",
+    "    \".keras\",\n",
+    "    \"datasets\",\n",
+    "    \"census+income+kdd.zip\",\n",
+    "    \"census-income.data\",\n",
+    ")\n",
+    "test_data_path = os.path.join(\n",
+    "    os.path.expanduser(\"~\"),\n",
+    "    \".keras\",\n",
+    "    \"datasets\",\n",
+    "    \"census+income+kdd.zip\",\n",
+    "    \"census-income.test\",\n",
+    ")\n",
+    "\n",
+    "data = pd.read_csv(train_data_path, header=None, names=CSV_HEADER)\n",
+    "test_data = pd.read_csv(test_data_path, header=None, names=CSV_HEADER)\n",
     "\n",
     "print(f\"Data shape: {data.shape}\")\n",
     "print(f\"Test data shape: {test_data.shape}\")\n",
@@ -235,7 +281,36 @@
     "\n",
     "train_data.to_csv(train_data_file, index=False, header=False)\n",
     "valid_data.to_csv(valid_data_file, index=False, header=False)\n",
-    "test_data.to_csv(test_data_file, index=False, header=False)"
+    "test_data.to_csv(test_data_file, index=False, header=False)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "clean the directory for the downloaded files except the .tar.gz file and\n",
+    "also remove the empty directories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "subprocess.run(\n",
+    "    f'find {extracted_path} -type f ! -name \"*.tar.gz\" -exec rm -f {{}} +',\n",
+    "    shell=True,\n",
+    "    check=True,\n",
+    ")\n",
+    "subprocess.run(\n",
+    "    f\"find {extracted_path} -type d -empty -exec rmdir {{}} +\", shell=True, check=True\n",
+    ")"
    ]
   },
   {
@@ -288,9 +363,12 @@
     ")\n",
     "# Feature default values.\n",
     "COLUMN_DEFAULTS = [\n",
-    "    [0.0]\n",
-    "    if feature_name in NUMERIC_FEATURE_NAMES + [TARGET_FEATURE_NAME, WEIGHT_COLUMN_NAME]\n",
-    "    else [\"NA\"]\n",
+    "    (\n",
+    "        [0.0]\n",
+    "        if feature_name\n",
+    "        in NUMERIC_FEATURE_NAMES + [TARGET_FEATURE_NAME, WEIGHT_COLUMN_NAME]\n",
+    "        else [\"NA\"]\n",
+    "    )\n",
     "    for feature_name in CSV_HEADER\n",
     "]"
    ]
@@ -324,10 +402,10 @@
     "            features[feature_name] = keras.ops.cast(features[feature_name], \"string\")\n",
     "    # Get the instance weight.\n",
     "    weight = features.pop(WEIGHT_COLUMN_NAME)\n",
-    "    return features, target, weight\n",
+    "    return dict(features), target, weight\n",
     "\n",
     "\n",
-    "def get_dataset_from_csv(csv_file_path, shuffle=False, batch_size=128):\n",
+    "def get_dataset_from_csv(csv_file_path, batch_size, shuffle=False):\n",
     "    dataset = tf.data.experimental.make_csv_dataset(\n",
     "        csv_file_path,\n",
     "        batch_size=batch_size,\n",
@@ -409,7 +487,7 @@
     "            # Since we are not using a mask token nor expecting any out of vocabulary\n",
     "            # (oov) token, we set mask_token to None and  num_oov_indices to 0.\n",
     "            index = layers.StringLookup(\n",
-    "                vocabulary=vocabulary, mask_token=None, num_oov_indices=0\n",
+    "                vocabulary=vocabulary, mask_token=None, num_oov_indices=1\n",
     "            )\n",
     "            # Convert the string input values into integer indices.\n",
     "            value_index = index(inputs[feature_name])\n",
@@ -457,6 +535,10 @@
     "\n",
     "    def call(self, inputs):\n",
     "        return self.linear(inputs) * self.sigmoid(inputs)\n",
+    "\n",
+    "    # to remove the build warnings\n",
+    "    def build(self):\n",
+    "        self.built = True\n",
     ""
    ]
   },
@@ -506,6 +588,10 @@
     "        x = inputs + self.gated_linear_unit(x)\n",
     "        x = self.layer_norm(x)\n",
     "        return x\n",
+    "\n",
+    "    # to remove the build warnings\n",
+    "    def build(self):\n",
+    "        self.build = True\n",
     ""
    ]
   },
@@ -561,6 +647,10 @@
     "\n",
     "        outputs = keras.ops.squeeze(tf.matmul(v, x, transpose_a=True), axis=1)\n",
     "        return outputs\n",
+    "\n",
+    "    # to remove the build warnings\n",
+    "    def build(self):\n",
+    "        self.built = True\n",
     ""
    ]
   },
@@ -617,7 +707,7 @@
     "learning_rate = 0.001\n",
     "dropout_rate = 0.15\n",
     "batch_size = 265\n",
-    "num_epochs = 20\n",
+    "num_epochs = 1\n",
     "encoding_size = 16\n",
     "\n",
     "model = create_model(encoding_size)\n",
@@ -635,7 +725,9 @@
     "\n",
     "print(\"Start training the model...\")\n",
     "train_dataset = get_dataset_from_csv(\n",
-    "    train_data_file, shuffle=True, batch_size=batch_size\n",
+    "    train_data_file,\n",
+    "    batch_size=batch_size,\n",
+    "    shuffle=True,\n",
     ")\n",
     "valid_dataset = get_dataset_from_csv(valid_data_file, batch_size=batch_size)\n",
     "model.fit(\n",

--- a/examples/structured_data/md/classification_with_grn_and_vsn.md
+++ b/examples/structured_data/md/classification_with_grn_and_vsn.md
@@ -2,7 +2,7 @@
 
 **Author:** [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)<br>
 **Date created:** 2021/02/10<br>
-**Last modified:** 2021/02/10<br>
+**Last modified:** 2025/01/03<br>
 **Description:** Using Gated Residual and Variable Selection Networks for income level prediction.
 
 
@@ -47,12 +47,18 @@ and 34 categorical features.
 
 
 ```python
-import math
+import os
+import subprocess
+import tarfile
+
+# Only the TensorFlow backend supports string inputs.
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+import keras
+from keras import layers
 ```
 
 ---
@@ -108,11 +114,51 @@ CSV_HEADER = [
     "income_level",
 ]
 
-data_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/census-income-mld/census-income.data.gz"
-data = pd.read_csv(data_url, header=None, names=CSV_HEADER)
+data_url = "https://archive.ics.uci.edu/static/public/117/census+income+kdd.zip"
+keras.utils.get_file(origin=data_url, extract=True)
+```
 
-test_data_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/census-income-mld/census-income.test.gz"
-test_data = pd.read_csv(test_data_url, header=None, names=CSV_HEADER)
+
+
+
+<div class="k-default-codeblock">
+```
+'/home/humbulani/.keras/datasets/census+income+kdd.zip'
+
+```
+</div>
+determine the downloaded .tar.gz file path and
+extract the files from the downloaded .tar.gz file
+
+
+```python
+extracted_path = os.path.join(
+    os.path.expanduser("~"), ".keras", "datasets", "census+income+kdd.zip"
+)
+for root, dirs, files in os.walk(extracted_path):
+    for file in files:
+        if file.endswith(".tar.gz"):
+            tar_gz_path = os.path.join(root, file)
+            with tarfile.open(tar_gz_path, "r:gz") as tar:
+                tar.extractall(path=root)
+
+train_data_path = os.path.join(
+    os.path.expanduser("~"),
+    ".keras",
+    "datasets",
+    "census+income+kdd.zip",
+    "census-income.data",
+)
+test_data_path = os.path.join(
+    os.path.expanduser("~"),
+    ".keras",
+    "datasets",
+    "census+income+kdd.zip",
+    "census-income.test",
+)
+
+data = pd.read_csv(train_data_path, header=None, names=CSV_HEADER)
+test_data = pd.read_csv(test_data_path, header=None, names=CSV_HEADER)
 
 print(f"Data shape: {data.shape}")
 print(f"Test data shape: {test_data.shape}")
@@ -160,8 +206,33 @@ test_data_file = "test_data.csv"
 train_data.to_csv(train_data_file, index=False, header=False)
 valid_data.to_csv(valid_data_file, index=False, header=False)
 test_data.to_csv(test_data_file, index=False, header=False)
+
 ```
 
+clean the directory for the downloaded files except the .tar.gz file and
+also remove the empty directories
+
+
+```python
+subprocess.run(
+    f'find {extracted_path} -type f ! -name "*.tar.gz" -exec rm -f {{}} +',
+    shell=True,
+    check=True,
+)
+subprocess.run(
+    f"find {extracted_path} -type d -empty -exec rmdir {{}} +", shell=True, check=True
+)
+```
+
+
+
+
+<div class="k-default-codeblock">
+```
+CompletedProcess(args='find /home/humbulani/.keras/datasets/census+income+kdd.zip -type d -empty -exec rmdir {} +', returncode=0)
+
+```
+</div>
 ---
 ## Define dataset metadata
 
@@ -200,9 +271,12 @@ FEATURE_NAMES = NUMERIC_FEATURE_NAMES + list(
 )
 # Feature default values.
 COLUMN_DEFAULTS = [
-    [0.0]
-    if feature_name in NUMERIC_FEATURE_NAMES + [TARGET_FEATURE_NAME, WEIGHT_COLUMN_NAME]
-    else ["NA"]
+    (
+        [0.0]
+        if feature_name
+        in NUMERIC_FEATURE_NAMES + [TARGET_FEATURE_NAME, WEIGHT_COLUMN_NAME]
+        else ["NA"]
+    )
     for feature_name in CSV_HEADER
 ]
 ```
@@ -216,21 +290,18 @@ training and evaluation.
 
 
 ```python
-from tensorflow.keras.layers import StringLookup
-
 
 def process(features, target):
     for feature_name in features:
         if feature_name in CATEGORICAL_FEATURES_WITH_VOCABULARY:
             # Cast categorical feature values to string.
-            features[feature_name] = tf.cast(features[feature_name], tf.dtypes.string)
+            features[feature_name] = keras.ops.cast(features[feature_name], "string")
     # Get the instance weight.
     weight = features.pop(WEIGHT_COLUMN_NAME)
-    return features, target, weight
+    return dict(features), target, weight
 
 
-def get_dataset_from_csv(csv_file_path, shuffle=False, batch_size=128):
-
+def get_dataset_from_csv(csv_file_path, batch_size, shuffle=False):
     dataset = tf.data.experimental.make_csv_dataset(
         csv_file_path,
         batch_size=batch_size,
@@ -257,11 +328,11 @@ def create_model_inputs():
     for feature_name in FEATURE_NAMES:
         if feature_name in NUMERIC_FEATURE_NAMES:
             inputs[feature_name] = layers.Input(
-                name=feature_name, shape=(), dtype=tf.float32
+                name=feature_name, shape=(), dtype="float32"
             )
         else:
             inputs[feature_name] = layers.Input(
-                name=feature_name, shape=(), dtype=tf.string
+                name=feature_name, shape=(), dtype="string"
             )
     return inputs
 
@@ -287,8 +358,8 @@ def encode_inputs(inputs, encoding_size):
             # Create a lookup to convert a string values to an integer indices.
             # Since we are not using a mask token nor expecting any out of vocabulary
             # (oov) token, we set mask_token to None and  num_oov_indices to 0.
-            index = StringLookup(
-                vocabulary=vocabulary, mask_token=None, num_oov_indices=0
+            index = layers.StringLookup(
+                vocabulary=vocabulary, mask_token=None, num_oov_indices=1
             )
             # Convert the string input values into integer indices.
             value_index = index(inputs[feature_name])
@@ -300,7 +371,7 @@ def encode_inputs(inputs, encoding_size):
             encoded_feature = embedding_ecoder(value_index)
         else:
             # Project the numeric feature to encoding_size using linear transformation.
-            encoded_feature = tf.expand_dims(inputs[feature_name], -1)
+            encoded_feature = keras.ops.expand_dims(inputs[feature_name], -1)
             encoded_feature = layers.Dense(units=encoding_size)(encoded_feature)
         encoded_features.append(encoded_feature)
     return encoded_features
@@ -324,6 +395,10 @@ class GatedLinearUnit(layers.Layer):
 
     def call(self, inputs):
         return self.linear(inputs) * self.sigmoid(inputs)
+
+    # to remove the build warnings
+    def build(self):
+        self.built = True
 
 ```
 
@@ -362,6 +437,10 @@ class GatedResidualNetwork(layers.Layer):
         x = self.layer_norm(x)
         return x
 
+    # to remove the build warnings
+    def build(self):
+        self.build = True
+
 ```
 
 ---
@@ -395,15 +474,19 @@ class VariableSelection(layers.Layer):
     def call(self, inputs):
         v = layers.concatenate(inputs)
         v = self.grn_concat(v)
-        v = tf.expand_dims(self.softmax(v), axis=-1)
+        v = keras.ops.expand_dims(self.softmax(v), axis=-1)
 
         x = []
         for idx, input in enumerate(inputs):
             x.append(self.grns[idx](input))
-        x = tf.stack(x, axis=1)
+        x = keras.ops.stack(x, axis=1)
 
-        outputs = tf.squeeze(tf.matmul(v, x, transpose_a=True), axis=1)
+        outputs = keras.ops.squeeze(tf.matmul(v, x, transpose_a=True), axis=1)
         return outputs
+
+    # to remove the build warnings
+    def build(self):
+        self.built = True
 
 ```
 
@@ -436,7 +519,7 @@ def create_model(encoding_size):
 learning_rate = 0.001
 dropout_rate = 0.15
 batch_size = 265
-num_epochs = 20
+num_epochs = 1
 encoding_size = 16
 
 model = create_model(encoding_size)
@@ -448,13 +531,15 @@ model.compile(
 
 
 # Create an early stopping callback.
-early_stopping = tf.keras.callbacks.EarlyStopping(
+early_stopping = keras.callbacks.EarlyStopping(
     monitor="val_loss", patience=5, restore_best_weights=True
 )
 
 print("Start training the model...")
 train_dataset = get_dataset_from_csv(
-    train_data_file, shuffle=True, batch_size=batch_size
+    train_data_file,
+    batch_size=batch_size,
+    shuffle=True,
 )
 valid_dataset = get_dataset_from_csv(valid_data_file, batch_size=batch_size)
 model.fit(
@@ -473,52 +558,3093 @@ print(f"Test accuracy: {round(accuracy * 100, 2)}%")
 
 <div class="k-default-codeblock">
 ```
-
 Start training the model...
-Epoch 1/20
-640/640 [==============================] - 31s 29ms/step - loss: 253.8570 - accuracy: 0.9468 - val_loss: 229.4024 - val_accuracy: 0.9495
-Epoch 2/20
-640/640 [==============================] - 17s 25ms/step - loss: 229.9359 - accuracy: 0.9497 - val_loss: 223.4970 - val_accuracy: 0.9505
-Epoch 3/20
-640/640 [==============================] - 17s 25ms/step - loss: 225.5644 - accuracy: 0.9504 - val_loss: 222.0078 - val_accuracy: 0.9515
-Epoch 4/20
-640/640 [==============================] - 16s 25ms/step - loss: 222.2086 - accuracy: 0.9512 - val_loss: 218.2707 - val_accuracy: 0.9522
-Epoch 5/20
-640/640 [==============================] - 17s 25ms/step - loss: 218.0359 - accuracy: 0.9523 - val_loss: 217.3721 - val_accuracy: 0.9528
-Epoch 6/20
-640/640 [==============================] - 17s 26ms/step - loss: 214.8348 - accuracy: 0.9529 - val_loss: 210.3546 - val_accuracy: 0.9543
-Epoch 7/20
-640/640 [==============================] - 17s 26ms/step - loss: 213.0984 - accuracy: 0.9534 - val_loss: 210.2881 - val_accuracy: 0.9544
-Epoch 8/20
-640/640 [==============================] - 17s 26ms/step - loss: 211.6379 - accuracy: 0.9538 - val_loss: 209.3327 - val_accuracy: 0.9550
-Epoch 9/20
-640/640 [==============================] - 17s 26ms/step - loss: 210.7283 - accuracy: 0.9541 - val_loss: 209.5862 - val_accuracy: 0.9543
-Epoch 10/20
-640/640 [==============================] - 17s 26ms/step - loss: 209.9062 - accuracy: 0.9538 - val_loss: 210.1662 - val_accuracy: 0.9537
-Epoch 11/20
-640/640 [==============================] - 16s 25ms/step - loss: 209.6323 - accuracy: 0.9540 - val_loss: 207.9528 - val_accuracy: 0.9552
-Epoch 12/20
-640/640 [==============================] - 16s 25ms/step - loss: 208.7843 - accuracy: 0.9544 - val_loss: 207.5303 - val_accuracy: 0.9550
-Epoch 13/20
-640/640 [==============================] - 21s 32ms/step - loss: 207.9983 - accuracy: 0.9544 - val_loss: 206.8800 - val_accuracy: 0.9557
-Epoch 14/20
-640/640 [==============================] - 18s 28ms/step - loss: 207.2104 - accuracy: 0.9544 - val_loss: 216.0859 - val_accuracy: 0.9535
-Epoch 15/20
-640/640 [==============================] - 16s 25ms/step - loss: 207.2254 - accuracy: 0.9543 - val_loss: 206.7765 - val_accuracy: 0.9555
-Epoch 16/20
-640/640 [==============================] - 16s 25ms/step - loss: 206.6704 - accuracy: 0.9546 - val_loss: 206.7508 - val_accuracy: 0.9560
-Epoch 17/20
-640/640 [==============================] - 19s 30ms/step - loss: 206.1322 - accuracy: 0.9545 - val_loss: 205.9638 - val_accuracy: 0.9562
-Epoch 18/20
-640/640 [==============================] - 21s 31ms/step - loss: 205.4764 - accuracy: 0.9545 - val_loss: 206.0258 - val_accuracy: 0.9561
-Epoch 19/20
-640/640 [==============================] - 16s 25ms/step - loss: 204.3614 - accuracy: 0.9550 - val_loss: 207.1424 - val_accuracy: 0.9560
-Epoch 20/20
-640/640 [==============================] - 16s 25ms/step - loss: 203.9543 - accuracy: 0.9550 - val_loss: 206.4697 - val_accuracy: 0.9554
+
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+  1/Unknown  10s 10s/step - accuracy: 0.3660 - loss: 1207.7571
+
+
+  2/Unknown  14s 4s/step - accuracy: 0.5075 - loss: 1102.4080 
+
+
+  3/Unknown  18s 4s/step - accuracy: 0.5870 - loss: 1019.7374
+
+
+  4/Unknown  22s 4s/step - accuracy: 0.6410 - loss: 949.8593 
+
+
+  5/Unknown  26s 4s/step - accuracy: 0.6782 - loss: 895.4934
+
+
+  6/Unknown  30s 4s/step - accuracy: 0.7066 - loss: 849.8503
+
+
+  7/Unknown  34s 4s/step - accuracy: 0.7285 - loss: 813.4320
+
+
+  8/Unknown  38s 4s/step - accuracy: 0.7457 - loss: 785.3990
+
+
+  9/Unknown  43s 4s/step - accuracy: 0.7602 - loss: 760.9548
+
+
+ 10/Unknown  47s 4s/step - accuracy: 0.7725 - loss: 738.8033
+
+
+ 11/Unknown  51s 4s/step - accuracy: 0.7829 - loss: 719.7887
+
+
+ 12/Unknown  56s 4s/step - accuracy: 0.7918 - loss: 702.8824
+
+
+ 13/Unknown  60s 4s/step - accuracy: 0.7996 - loss: 688.2739
+
+
+ 14/Unknown  64s 4s/step - accuracy: 0.8065 - loss: 675.0721
+
+
+ 15/Unknown  69s 4s/step - accuracy: 0.8126 - loss: 662.8633
+
+
+ 16/Unknown  73s 4s/step - accuracy: 0.8181 - loss: 651.6475
+
+
+ 17/Unknown  77s 4s/step - accuracy: 0.8231 - loss: 640.9540
+
+
+ 18/Unknown  82s 4s/step - accuracy: 0.8277 - loss: 631.2631
+
+
+ 19/Unknown  86s 4s/step - accuracy: 0.8320 - loss: 622.0033
+
+
+ 20/Unknown  91s 4s/step - accuracy: 0.8358 - loss: 613.5731
+
+
+ 21/Unknown  95s 4s/step - accuracy: 0.8394 - loss: 605.6331
+
+
+ 22/Unknown  99s 4s/step - accuracy: 0.8427 - loss: 598.0710
+
+
+ 23/Unknown  104s 4s/step - accuracy: 0.8458 - loss: 590.9688
+
+
+ 24/Unknown  109s 4s/step - accuracy: 0.8487 - loss: 584.1125
+
+
+ 25/Unknown  114s 4s/step - accuracy: 0.8514 - loss: 577.9108
+
+
+ 26/Unknown  118s 4s/step - accuracy: 0.8539 - loss: 572.1182
+
+
+ 27/Unknown  123s 4s/step - accuracy: 0.8563 - loss: 566.6541
+
+
+ 28/Unknown  128s 4s/step - accuracy: 0.8584 - loss: 561.5195
+
+
+ 29/Unknown  132s 4s/step - accuracy: 0.8605 - loss: 556.6824
+
+
+ 30/Unknown  137s 4s/step - accuracy: 0.8624 - loss: 551.9829
+
+
+ 31/Unknown  141s 4s/step - accuracy: 0.8642 - loss: 547.4396
+
+
+ 32/Unknown  146s 4s/step - accuracy: 0.8660 - loss: 543.0052
+
+
+ 33/Unknown  151s 4s/step - accuracy: 0.8677 - loss: 538.6678
+
+
+ 34/Unknown  155s 4s/step - accuracy: 0.8692 - loss: 534.5511
+
+
+ 35/Unknown  159s 4s/step - accuracy: 0.8707 - loss: 530.6713
+
+
+ 36/Unknown  164s 4s/step - accuracy: 0.8721 - loss: 526.8998
+
+
+ 37/Unknown  169s 4s/step - accuracy: 0.8734 - loss: 523.2978
+
+
+ 38/Unknown  173s 4s/step - accuracy: 0.8747 - loss: 519.7983
+
+
+ 39/Unknown  178s 4s/step - accuracy: 0.8760 - loss: 516.3888
+
+
+ 40/Unknown  183s 4s/step - accuracy: 0.8772 - loss: 513.1334
+
+
+ 41/Unknown  188s 4s/step - accuracy: 0.8783 - loss: 509.9753
+
+
+ 42/Unknown  193s 4s/step - accuracy: 0.8794 - loss: 506.8998
+
+
+ 43/Unknown  197s 4s/step - accuracy: 0.8805 - loss: 503.8833
+
+
+ 44/Unknown  202s 4s/step - accuracy: 0.8815 - loss: 500.9615
+
+
+ 45/Unknown  208s 4s/step - accuracy: 0.8824 - loss: 498.1530
+
+
+ 46/Unknown  213s 4s/step - accuracy: 0.8834 - loss: 495.3979
+
+
+ 47/Unknown  217s 4s/step - accuracy: 0.8843 - loss: 492.7300
+
+
+ 48/Unknown  222s 5s/step - accuracy: 0.8852 - loss: 490.1727
+
+
+ 49/Unknown  227s 5s/step - accuracy: 0.8860 - loss: 487.6551
+
+
+ 50/Unknown  231s 5s/step - accuracy: 0.8868 - loss: 485.1848
+
+
+ 51/Unknown  236s 5s/step - accuracy: 0.8876 - loss: 482.7541
+
+
+ 52/Unknown  241s 5s/step - accuracy: 0.8884 - loss: 480.3756
+
+
+ 53/Unknown  246s 5s/step - accuracy: 0.8892 - loss: 478.0660
+
+
+ 54/Unknown  251s 5s/step - accuracy: 0.8899 - loss: 475.8299
+
+
+ 55/Unknown  256s 5s/step - accuracy: 0.8906 - loss: 473.6529
+
+
+ 56/Unknown  260s 5s/step - accuracy: 0.8913 - loss: 471.5191
+
+
+ 57/Unknown  265s 5s/step - accuracy: 0.8919 - loss: 469.4434
+
+
+ 58/Unknown  270s 5s/step - accuracy: 0.8926 - loss: 467.4065
+
+
+ 59/Unknown  276s 5s/step - accuracy: 0.8932 - loss: 465.4138
+
+
+ 60/Unknown  281s 5s/step - accuracy: 0.8938 - loss: 463.4726
+
+
+ 61/Unknown  286s 5s/step - accuracy: 0.8944 - loss: 461.6012
+
+
+ 62/Unknown  291s 5s/step - accuracy: 0.8949 - loss: 459.7856
+
+
+ 63/Unknown  296s 5s/step - accuracy: 0.8955 - loss: 457.9802
+
+
+ 64/Unknown  301s 5s/step - accuracy: 0.8960 - loss: 456.1978
+
+
+ 65/Unknown  305s 5s/step - accuracy: 0.8966 - loss: 454.4304
+
+
+ 66/Unknown  310s 5s/step - accuracy: 0.8971 - loss: 452.6868
+
+
+ 67/Unknown  314s 5s/step - accuracy: 0.8976 - loss: 450.9761
+
+
+ 68/Unknown  319s 5s/step - accuracy: 0.8981 - loss: 449.3022
+
+
+ 69/Unknown  324s 5s/step - accuracy: 0.8986 - loss: 447.6501
+
+
+ 70/Unknown  328s 5s/step - accuracy: 0.8991 - loss: 446.0159
+
+
+ 71/Unknown  333s 5s/step - accuracy: 0.8996 - loss: 444.4040
+
+
+ 72/Unknown  337s 5s/step - accuracy: 0.9000 - loss: 442.8098
+
+
+ 73/Unknown  342s 5s/step - accuracy: 0.9005 - loss: 441.2607
+
+
+ 74/Unknown  347s 5s/step - accuracy: 0.9009 - loss: 439.7383
+
+
+ 75/Unknown  351s 5s/step - accuracy: 0.9014 - loss: 438.2570
+
+
+ 76/Unknown  356s 5s/step - accuracy: 0.9018 - loss: 436.8094
+
+
+ 77/Unknown  360s 5s/step - accuracy: 0.9022 - loss: 435.3762
+
+
+ 78/Unknown  365s 5s/step - accuracy: 0.9026 - loss: 433.9661
+
+
+ 79/Unknown  369s 5s/step - accuracy: 0.9031 - loss: 432.5754
+
+
+ 80/Unknown  374s 5s/step - accuracy: 0.9035 - loss: 431.2206
+
+
+ 81/Unknown  379s 5s/step - accuracy: 0.9038 - loss: 429.8713
+
+
+ 82/Unknown  383s 5s/step - accuracy: 0.9042 - loss: 428.5655
+
+
+ 83/Unknown  388s 5s/step - accuracy: 0.9046 - loss: 427.2886
+
+
+ 84/Unknown  392s 5s/step - accuracy: 0.9050 - loss: 426.0367
+
+
+ 85/Unknown  397s 5s/step - accuracy: 0.9053 - loss: 424.7995
+
+
+ 86/Unknown  402s 5s/step - accuracy: 0.9057 - loss: 423.5760
+
+
+ 87/Unknown  406s 5s/step - accuracy: 0.9060 - loss: 422.3595
+
+
+ 88/Unknown  411s 5s/step - accuracy: 0.9064 - loss: 421.1734
+
+
+ 89/Unknown  416s 5s/step - accuracy: 0.9067 - loss: 420.0010
+
+
+ 90/Unknown  420s 5s/step - accuracy: 0.9070 - loss: 418.8433
+
+
+ 91/Unknown  425s 5s/step - accuracy: 0.9073 - loss: 417.7053
+
+
+ 92/Unknown  430s 5s/step - accuracy: 0.9077 - loss: 416.5843
+
+
+ 93/Unknown  434s 5s/step - accuracy: 0.9080 - loss: 415.4904
+
+
+ 94/Unknown  439s 5s/step - accuracy: 0.9083 - loss: 414.4215
+
+
+ 95/Unknown  443s 5s/step - accuracy: 0.9086 - loss: 413.3767
+
+
+ 96/Unknown  448s 5s/step - accuracy: 0.9089 - loss: 412.3375
+
+
+ 97/Unknown  453s 5s/step - accuracy: 0.9092 - loss: 411.3148
+
+
+ 98/Unknown  457s 5s/step - accuracy: 0.9094 - loss: 410.3085
+
+
+ 99/Unknown  462s 5s/step - accuracy: 0.9097 - loss: 409.3198
+
+
+100/Unknown  466s 5s/step - accuracy: 0.9100 - loss: 408.3477
+
+
+101/Unknown  471s 5s/step - accuracy: 0.9103 - loss: 407.3878
+
+
+102/Unknown  476s 5s/step - accuracy: 0.9105 - loss: 406.4406
+
+
+103/Unknown  481s 5s/step - accuracy: 0.9108 - loss: 405.5037
+
+
+104/Unknown  486s 5s/step - accuracy: 0.9110 - loss: 404.5758
+
+
+105/Unknown  490s 5s/step - accuracy: 0.9113 - loss: 403.6591
+
+
+106/Unknown  495s 5s/step - accuracy: 0.9115 - loss: 402.7492
+
+
+107/Unknown  500s 5s/step - accuracy: 0.9118 - loss: 401.8447
+
+
+108/Unknown  504s 5s/step - accuracy: 0.9120 - loss: 400.9514
+
+
+109/Unknown  509s 5s/step - accuracy: 0.9123 - loss: 400.0719
+
+
+110/Unknown  514s 5s/step - accuracy: 0.9125 - loss: 399.2086
+
+
+111/Unknown  518s 5s/step - accuracy: 0.9127 - loss: 398.3539
+
+
+112/Unknown  523s 5s/step - accuracy: 0.9130 - loss: 397.5079
+
+
+113/Unknown  528s 5s/step - accuracy: 0.9132 - loss: 396.6739
+
+
+114/Unknown  533s 5s/step - accuracy: 0.9134 - loss: 395.8583
+
+
+115/Unknown  538s 5s/step - accuracy: 0.9136 - loss: 395.0499
+
+
+116/Unknown  542s 5s/step - accuracy: 0.9138 - loss: 394.2525
+
+
+117/Unknown  547s 5s/step - accuracy: 0.9141 - loss: 393.4650
+
+
+118/Unknown  552s 5s/step - accuracy: 0.9143 - loss: 392.6905
+
+
+119/Unknown  556s 5s/step - accuracy: 0.9145 - loss: 391.9308
+
+
+120/Unknown  561s 5s/step - accuracy: 0.9147 - loss: 391.1761
+
+
+121/Unknown  566s 5s/step - accuracy: 0.9149 - loss: 390.4323
+
+
+122/Unknown  570s 5s/step - accuracy: 0.9151 - loss: 389.6927
+
+
+123/Unknown  575s 5s/step - accuracy: 0.9153 - loss: 388.9673
+
+
+124/Unknown  580s 5s/step - accuracy: 0.9154 - loss: 388.2496
+
+
+125/Unknown  585s 5s/step - accuracy: 0.9156 - loss: 387.5363
+
+
+126/Unknown  590s 5s/step - accuracy: 0.9158 - loss: 386.8299
+
+
+127/Unknown  595s 5s/step - accuracy: 0.9160 - loss: 386.1295
+
+
+128/Unknown  599s 5s/step - accuracy: 0.9162 - loss: 385.4340
+
+
+129/Unknown  604s 5s/step - accuracy: 0.9164 - loss: 384.7438
+
+
+130/Unknown  609s 5s/step - accuracy: 0.9165 - loss: 384.0630
+
+
+131/Unknown  613s 5s/step - accuracy: 0.9167 - loss: 383.3891
+
+
+132/Unknown  618s 5s/step - accuracy: 0.9169 - loss: 382.7205
+
+
+133/Unknown  622s 5s/step - accuracy: 0.9171 - loss: 382.0653
+
+
+134/Unknown  627s 5s/step - accuracy: 0.9172 - loss: 381.4217
+
+
+135/Unknown  632s 5s/step - accuracy: 0.9174 - loss: 380.7866
+
+
+136/Unknown  637s 5s/step - accuracy: 0.9176 - loss: 380.1596
+
+
+137/Unknown  641s 5s/step - accuracy: 0.9177 - loss: 379.5403
+
+
+138/Unknown  646s 5s/step - accuracy: 0.9179 - loss: 378.9232
+
+
+139/Unknown  650s 5s/step - accuracy: 0.9181 - loss: 378.3159
+
+
+140/Unknown  655s 5s/step - accuracy: 0.9182 - loss: 377.7125
+
+
+141/Unknown  660s 5s/step - accuracy: 0.9184 - loss: 377.1123
+
+
+142/Unknown  665s 5s/step - accuracy: 0.9185 - loss: 376.5167
+
+
+143/Unknown  669s 5s/step - accuracy: 0.9187 - loss: 375.9280
+
+
+144/Unknown  674s 5s/step - accuracy: 0.9188 - loss: 375.3439
+
+
+145/Unknown  678s 5s/step - accuracy: 0.9190 - loss: 374.7696
+
+
+146/Unknown  683s 5s/step - accuracy: 0.9191 - loss: 374.2022
+
+
+147/Unknown  687s 5s/step - accuracy: 0.9192 - loss: 373.6388
+
+
+148/Unknown  692s 5s/step - accuracy: 0.9194 - loss: 373.0820
+
+
+149/Unknown  697s 5s/step - accuracy: 0.9195 - loss: 372.5319
+
+
+150/Unknown  701s 5s/step - accuracy: 0.9197 - loss: 371.9951
+
+
+151/Unknown  706s 5s/step - accuracy: 0.9198 - loss: 371.4630
+
+
+152/Unknown  710s 5s/step - accuracy: 0.9199 - loss: 370.9363
+
+
+153/Unknown  715s 5s/step - accuracy: 0.9201 - loss: 370.4174
+
+
+154/Unknown  720s 5s/step - accuracy: 0.9202 - loss: 369.9002
+
+
+155/Unknown  725s 5s/step - accuracy: 0.9203 - loss: 369.3880
+
+
+156/Unknown  729s 5s/step - accuracy: 0.9204 - loss: 368.8798
+
+
+157/Unknown  734s 5s/step - accuracy: 0.9206 - loss: 368.3802
+
+
+158/Unknown  739s 5s/step - accuracy: 0.9207 - loss: 367.8825
+
+
+159/Unknown  743s 5s/step - accuracy: 0.9208 - loss: 367.3949
+
+
+160/Unknown  748s 5s/step - accuracy: 0.9209 - loss: 366.9076
+
+
+161/Unknown  752s 5s/step - accuracy: 0.9211 - loss: 366.4265
+
+
+162/Unknown  757s 5s/step - accuracy: 0.9212 - loss: 365.9467
+
+
+163/Unknown  762s 5s/step - accuracy: 0.9213 - loss: 365.4701
+
+
+164/Unknown  766s 5s/step - accuracy: 0.9214 - loss: 364.9950
+
+
+165/Unknown  770s 5s/step - accuracy: 0.9215 - loss: 364.5236
+
+
+166/Unknown  775s 5s/step - accuracy: 0.9217 - loss: 364.0565
+
+
+167/Unknown  780s 5s/step - accuracy: 0.9218 - loss: 363.5902
+
+
+168/Unknown  784s 5s/step - accuracy: 0.9219 - loss: 363.1264
+
+
+169/Unknown  789s 5s/step - accuracy: 0.9220 - loss: 362.6704
+
+
+170/Unknown  794s 5s/step - accuracy: 0.9221 - loss: 362.2173
+
+
+171/Unknown  799s 5s/step - accuracy: 0.9222 - loss: 361.7654
+
+
+172/Unknown  803s 5s/step - accuracy: 0.9223 - loss: 361.3171
+
+
+173/Unknown  808s 5s/step - accuracy: 0.9225 - loss: 360.8713
+
+
+174/Unknown  813s 5s/step - accuracy: 0.9226 - loss: 360.4279
+
+
+175/Unknown  818s 5s/step - accuracy: 0.9227 - loss: 359.9890
+
+
+176/Unknown  823s 5s/step - accuracy: 0.9228 - loss: 359.5543
+
+
+177/Unknown  827s 5s/step - accuracy: 0.9229 - loss: 359.1236
+
+
+178/Unknown  832s 5s/step - accuracy: 0.9230 - loss: 358.6957
+
+
+179/Unknown  837s 5s/step - accuracy: 0.9231 - loss: 358.2695
+
+
+180/Unknown  842s 5s/step - accuracy: 0.9232 - loss: 357.8491
+
+
+181/Unknown  847s 5s/step - accuracy: 0.9233 - loss: 357.4330
+
+
+182/Unknown  851s 5s/step - accuracy: 0.9234 - loss: 357.0235
+
+
+183/Unknown  856s 5s/step - accuracy: 0.9235 - loss: 356.6167
+
+
+184/Unknown  861s 5s/step - accuracy: 0.9236 - loss: 356.2136
+
+
+185/Unknown  865s 5s/step - accuracy: 0.9237 - loss: 355.8134
+
+
+186/Unknown  870s 5s/step - accuracy: 0.9238 - loss: 355.4167
+
+
+187/Unknown  875s 5s/step - accuracy: 0.9239 - loss: 355.0250
+
+
+188/Unknown  879s 5s/step - accuracy: 0.9240 - loss: 354.6354
+
+
+189/Unknown  884s 5s/step - accuracy: 0.9241 - loss: 354.2495
+
+
+190/Unknown  889s 5s/step - accuracy: 0.9242 - loss: 353.8654
+
+
+191/Unknown  893s 5s/step - accuracy: 0.9243 - loss: 353.4833
+
+
+192/Unknown  898s 5s/step - accuracy: 0.9244 - loss: 353.1022
+
+
+193/Unknown  902s 5s/step - accuracy: 0.9245 - loss: 352.7214
+
+
+194/Unknown  907s 5s/step - accuracy: 0.9246 - loss: 352.3439
+
+
+195/Unknown  911s 5s/step - accuracy: 0.9246 - loss: 351.9707
+
+
+196/Unknown  916s 5s/step - accuracy: 0.9247 - loss: 351.5989
+
+
+197/Unknown  920s 5s/step - accuracy: 0.9248 - loss: 351.2298
+
+
+198/Unknown  925s 5s/step - accuracy: 0.9249 - loss: 350.8626
+
+
+199/Unknown  930s 5s/step - accuracy: 0.9250 - loss: 350.4981
+
+
+200/Unknown  935s 5s/step - accuracy: 0.9251 - loss: 350.1355
+
+
+201/Unknown  939s 5s/step - accuracy: 0.9252 - loss: 349.7766
+
+
+202/Unknown  944s 5s/step - accuracy: 0.9253 - loss: 349.4206
+
+
+203/Unknown  949s 5s/step - accuracy: 0.9253 - loss: 349.0690
+
+
+204/Unknown  954s 5s/step - accuracy: 0.9254 - loss: 348.7199
+
+
+205/Unknown  958s 5s/step - accuracy: 0.9255 - loss: 348.3728
+
+
+206/Unknown  964s 5s/step - accuracy: 0.9256 - loss: 348.0292
+
+
+207/Unknown  968s 5s/step - accuracy: 0.9257 - loss: 347.6898
+
+
+208/Unknown  973s 5s/step - accuracy: 0.9258 - loss: 347.3521
+
+
+209/Unknown  978s 5s/step - accuracy: 0.9258 - loss: 347.0195
+
+
+210/Unknown  983s 5s/step - accuracy: 0.9259 - loss: 346.6897
+
+
+211/Unknown  987s 5s/step - accuracy: 0.9260 - loss: 346.3630
+
+
+212/Unknown  992s 5s/step - accuracy: 0.9261 - loss: 346.0395
+
+
+213/Unknown  997s 5s/step - accuracy: 0.9261 - loss: 345.7180
+
+
+214/Unknown  1002s 5s/step - accuracy: 0.9262 - loss: 345.3971
+
+
+215/Unknown  1007s 5s/step - accuracy: 0.9263 - loss: 345.0785
+
+
+216/Unknown  1012s 5s/step - accuracy: 0.9264 - loss: 344.7623
+
+
+217/Unknown  1017s 5s/step - accuracy: 0.9264 - loss: 344.4494
+
+
+218/Unknown  1022s 5s/step - accuracy: 0.9265 - loss: 344.1385
+
+
+219/Unknown  1027s 5s/step - accuracy: 0.9266 - loss: 343.8289
+
+
+220/Unknown  1032s 5s/step - accuracy: 0.9267 - loss: 343.5211
+
+
+221/Unknown  1037s 5s/step - accuracy: 0.9267 - loss: 343.2156
+
+
+222/Unknown  1042s 5s/step - accuracy: 0.9268 - loss: 342.9126
+
+
+223/Unknown  1047s 5s/step - accuracy: 0.9269 - loss: 342.6116
+
+
+224/Unknown  1052s 5s/step - accuracy: 0.9270 - loss: 342.3128
+
+
+225/Unknown  1057s 5s/step - accuracy: 0.9270 - loss: 342.0152
+
+
+226/Unknown  1062s 5s/step - accuracy: 0.9271 - loss: 341.7184
+
+
+227/Unknown  1067s 5s/step - accuracy: 0.9272 - loss: 341.4229
+
+
+228/Unknown  1072s 5s/step - accuracy: 0.9272 - loss: 341.1292
+
+
+229/Unknown  1076s 5s/step - accuracy: 0.9273 - loss: 340.8392
+
+
+230/Unknown  1081s 5s/step - accuracy: 0.9274 - loss: 340.5511
+
+
+231/Unknown  1086s 5s/step - accuracy: 0.9274 - loss: 340.2639
+
+
+232/Unknown  1092s 5s/step - accuracy: 0.9275 - loss: 339.9771
+
+
+233/Unknown  1096s 5s/step - accuracy: 0.9276 - loss: 339.6896
+
+
+234/Unknown  1101s 5s/step - accuracy: 0.9276 - loss: 339.4058
+
+
+235/Unknown  1106s 5s/step - accuracy: 0.9277 - loss: 339.1237
+
+
+236/Unknown  1111s 5s/step - accuracy: 0.9278 - loss: 338.8431
+
+
+237/Unknown  1116s 5s/step - accuracy: 0.9278 - loss: 338.5645
+
+
+238/Unknown  1121s 5s/step - accuracy: 0.9279 - loss: 338.2875
+
+
+239/Unknown  1126s 5s/step - accuracy: 0.9280 - loss: 338.0133
+
+
+240/Unknown  1131s 5s/step - accuracy: 0.9280 - loss: 337.7398
+
+
+241/Unknown  1136s 5s/step - accuracy: 0.9281 - loss: 337.4683
+
+
+242/Unknown  1141s 5s/step - accuracy: 0.9282 - loss: 337.1974
+
+
+243/Unknown  1146s 5s/step - accuracy: 0.9282 - loss: 336.9279
+
+
+244/Unknown  1151s 5s/step - accuracy: 0.9283 - loss: 336.6605
+
+
+245/Unknown  1157s 5s/step - accuracy: 0.9283 - loss: 336.3942
+
+
+246/Unknown  1162s 5s/step - accuracy: 0.9284 - loss: 336.1295
+
+
+247/Unknown  1167s 5s/step - accuracy: 0.9285 - loss: 335.8667
+
+
+248/Unknown  1172s 5s/step - accuracy: 0.9285 - loss: 335.6055
+
+
+249/Unknown  1177s 5s/step - accuracy: 0.9286 - loss: 335.3467
+
+
+250/Unknown  1182s 5s/step - accuracy: 0.9286 - loss: 335.0888
+
+
+251/Unknown  1187s 5s/step - accuracy: 0.9287 - loss: 334.8347
+
+
+252/Unknown  1192s 5s/step - accuracy: 0.9288 - loss: 334.5807
+
+
+253/Unknown  1197s 5s/step - accuracy: 0.9288 - loss: 334.3291
+
+
+254/Unknown  1202s 5s/step - accuracy: 0.9289 - loss: 334.0790
+
+
+255/Unknown  1208s 5s/step - accuracy: 0.9289 - loss: 333.8303
+
+
+256/Unknown  1213s 5s/step - accuracy: 0.9290 - loss: 333.5836
+
+
+257/Unknown  1219s 5s/step - accuracy: 0.9290 - loss: 333.3395
+
+
+258/Unknown  1224s 5s/step - accuracy: 0.9291 - loss: 333.0960
+
+
+259/Unknown  1229s 5s/step - accuracy: 0.9292 - loss: 332.8548
+
+
+260/Unknown  1234s 5s/step - accuracy: 0.9292 - loss: 332.6145
+
+
+261/Unknown  1239s 5s/step - accuracy: 0.9293 - loss: 332.3764
+
+
+262/Unknown  1244s 5s/step - accuracy: 0.9293 - loss: 332.1390
+
+
+263/Unknown  1249s 5s/step - accuracy: 0.9294 - loss: 331.9027
+
+
+264/Unknown  1254s 5s/step - accuracy: 0.9294 - loss: 331.6683
+
+
+265/Unknown  1259s 5s/step - accuracy: 0.9295 - loss: 331.4364
+
+
+266/Unknown  1264s 5s/step - accuracy: 0.9295 - loss: 331.2059
+
+
+267/Unknown  1269s 5s/step - accuracy: 0.9296 - loss: 330.9770
+
+
+268/Unknown  1274s 5s/step - accuracy: 0.9296 - loss: 330.7490
+
+
+269/Unknown  1279s 5s/step - accuracy: 0.9297 - loss: 330.5221
+
+
+270/Unknown  1284s 5s/step - accuracy: 0.9297 - loss: 330.2965
+
+
+271/Unknown  1289s 5s/step - accuracy: 0.9298 - loss: 330.0719
+
+
+272/Unknown  1294s 5s/step - accuracy: 0.9298 - loss: 329.8488
+
+
+273/Unknown  1299s 5s/step - accuracy: 0.9299 - loss: 329.6284
+
+
+274/Unknown  1304s 5s/step - accuracy: 0.9300 - loss: 329.4088
+
+
+275/Unknown  1310s 5s/step - accuracy: 0.9300 - loss: 329.1902
+
+
+276/Unknown  1315s 5s/step - accuracy: 0.9301 - loss: 328.9727
+
+
+277/Unknown  1320s 5s/step - accuracy: 0.9301 - loss: 328.7570
+
+
+278/Unknown  1326s 5s/step - accuracy: 0.9301 - loss: 328.5421
+
+
+279/Unknown  1331s 5s/step - accuracy: 0.9302 - loss: 328.3284
+
+
+280/Unknown  1336s 5s/step - accuracy: 0.9302 - loss: 328.1152
+
+
+281/Unknown  1341s 5s/step - accuracy: 0.9303 - loss: 327.9040
+
+
+282/Unknown  1347s 5s/step - accuracy: 0.9303 - loss: 327.6935
+
+
+283/Unknown  1353s 5s/step - accuracy: 0.9304 - loss: 327.4832
+
+
+284/Unknown  1359s 5s/step - accuracy: 0.9304 - loss: 327.2734
+
+
+285/Unknown  1364s 5s/step - accuracy: 0.9305 - loss: 327.0658
+
+
+286/Unknown  1370s 5s/step - accuracy: 0.9305 - loss: 326.8585
+
+
+287/Unknown  1375s 5s/step - accuracy: 0.9306 - loss: 326.6521
+
+
+288/Unknown  1381s 5s/step - accuracy: 0.9306 - loss: 326.4481
+
+
+289/Unknown  1387s 5s/step - accuracy: 0.9307 - loss: 326.2443
+
+
+290/Unknown  1393s 5s/step - accuracy: 0.9307 - loss: 326.0433
+
+
+291/Unknown  1399s 5s/step - accuracy: 0.9308 - loss: 325.8439
+
+
+292/Unknown  1405s 5s/step - accuracy: 0.9308 - loss: 325.6450
+
+
+293/Unknown  1411s 5s/step - accuracy: 0.9309 - loss: 325.4478
+
+
+294/Unknown  1418s 5s/step - accuracy: 0.9309 - loss: 325.2528
+
+
+295/Unknown  1426s 5s/step - accuracy: 0.9309 - loss: 325.0590
+
+
+296/Unknown  1431s 5s/step - accuracy: 0.9310 - loss: 324.8657
+
+
+297/Unknown  1436s 5s/step - accuracy: 0.9310 - loss: 324.6730
+
+
+298/Unknown  1441s 5s/step - accuracy: 0.9311 - loss: 324.4815
+
+
+299/Unknown  1446s 5s/step - accuracy: 0.9311 - loss: 324.2902
+
+
+300/Unknown  1451s 5s/step - accuracy: 0.9312 - loss: 324.1008
+
+
+301/Unknown  1458s 5s/step - accuracy: 0.9312 - loss: 323.9124
+
+
+302/Unknown  1463s 5s/step - accuracy: 0.9312 - loss: 323.7238
+
+
+303/Unknown  1467s 5s/step - accuracy: 0.9313 - loss: 323.5364
+
+
+304/Unknown  1472s 5s/step - accuracy: 0.9313 - loss: 323.3500
+
+
+305/Unknown  1477s 5s/step - accuracy: 0.9314 - loss: 323.1646
+
+
+306/Unknown  1482s 5s/step - accuracy: 0.9314 - loss: 322.9795
+
+
+307/Unknown  1487s 5s/step - accuracy: 0.9314 - loss: 322.7953
+
+
+308/Unknown  1491s 5s/step - accuracy: 0.9315 - loss: 322.6122
+
+
+309/Unknown  1495s 5s/step - accuracy: 0.9315 - loss: 322.4298
+
+
+310/Unknown  1500s 5s/step - accuracy: 0.9316 - loss: 322.2483
+
+
+311/Unknown  1504s 5s/step - accuracy: 0.9316 - loss: 322.0682
+
+
+312/Unknown  1508s 5s/step - accuracy: 0.9316 - loss: 321.8883
+
+
+313/Unknown  1513s 5s/step - accuracy: 0.9317 - loss: 321.7096
+
+
+314/Unknown  1518s 5s/step - accuracy: 0.9317 - loss: 321.5312
+
+
+315/Unknown  1523s 5s/step - accuracy: 0.9318 - loss: 321.3531
+
+
+316/Unknown  1527s 5s/step - accuracy: 0.9318 - loss: 321.1761
+
+
+317/Unknown  1532s 5s/step - accuracy: 0.9318 - loss: 321.0012
+
+
+318/Unknown  1536s 5s/step - accuracy: 0.9319 - loss: 320.8268
+
+
+319/Unknown  1542s 5s/step - accuracy: 0.9319 - loss: 320.6526
+
+
+320/Unknown  1547s 5s/step - accuracy: 0.9320 - loss: 320.4793
+
+
+321/Unknown  1552s 5s/step - accuracy: 0.9320 - loss: 320.3062
+
+
+322/Unknown  1556s 5s/step - accuracy: 0.9320 - loss: 320.1337
+
+
+323/Unknown  1561s 5s/step - accuracy: 0.9321 - loss: 319.9617
+
+
+324/Unknown  1566s 5s/step - accuracy: 0.9321 - loss: 319.7900
+
+
+325/Unknown  1571s 5s/step - accuracy: 0.9321 - loss: 319.6192
+
+
+326/Unknown  1575s 5s/step - accuracy: 0.9322 - loss: 319.4486
+
+
+327/Unknown  1580s 5s/step - accuracy: 0.9322 - loss: 319.2791
+
+
+328/Unknown  1584s 5s/step - accuracy: 0.9323 - loss: 319.1109
+
+
+329/Unknown  1588s 5s/step - accuracy: 0.9323 - loss: 318.9430
+
+
+330/Unknown  1593s 5s/step - accuracy: 0.9323 - loss: 318.7765
+
+
+331/Unknown  1597s 5s/step - accuracy: 0.9324 - loss: 318.6100
+
+
+332/Unknown  1602s 5s/step - accuracy: 0.9324 - loss: 318.4451
+
+
+333/Unknown  1606s 5s/step - accuracy: 0.9324 - loss: 318.2813
+
+
+334/Unknown  1610s 5s/step - accuracy: 0.9325 - loss: 318.1185
+
+
+335/Unknown  1615s 5s/step - accuracy: 0.9325 - loss: 317.9565
+
+
+336/Unknown  1620s 5s/step - accuracy: 0.9325 - loss: 317.7953
+
+
+337/Unknown  1625s 5s/step - accuracy: 0.9326 - loss: 317.6343
+
+
+338/Unknown  1629s 5s/step - accuracy: 0.9326 - loss: 317.4747
+
+
+339/Unknown  1633s 5s/step - accuracy: 0.9326 - loss: 317.3152
+
+
+340/Unknown  1637s 5s/step - accuracy: 0.9327 - loss: 317.1561
+
+
+341/Unknown  1642s 5s/step - accuracy: 0.9327 - loss: 316.9976
+
+
+342/Unknown  1646s 5s/step - accuracy: 0.9328 - loss: 316.8401
+
+
+343/Unknown  1651s 5s/step - accuracy: 0.9328 - loss: 316.6830
+
+
+344/Unknown  1655s 5s/step - accuracy: 0.9328 - loss: 316.5267
+
+
+345/Unknown  1659s 5s/step - accuracy: 0.9329 - loss: 316.3714
+
+
+346/Unknown  1664s 5s/step - accuracy: 0.9329 - loss: 316.2170
+
+
+347/Unknown  1668s 5s/step - accuracy: 0.9329 - loss: 316.0630
+
+
+348/Unknown  1672s 5s/step - accuracy: 0.9330 - loss: 315.9096
+
+
+349/Unknown  1677s 5s/step - accuracy: 0.9330 - loss: 315.7571
+
+
+350/Unknown  1681s 5s/step - accuracy: 0.9330 - loss: 315.6042
+
+
+351/Unknown  1686s 5s/step - accuracy: 0.9331 - loss: 315.4518
+
+
+352/Unknown  1690s 5s/step - accuracy: 0.9331 - loss: 315.3003
+
+
+353/Unknown  1695s 5s/step - accuracy: 0.9331 - loss: 315.1490
+
+
+354/Unknown  1700s 5s/step - accuracy: 0.9331 - loss: 314.9982
+
+
+355/Unknown  1705s 5s/step - accuracy: 0.9332 - loss: 314.8481
+
+
+356/Unknown  1710s 5s/step - accuracy: 0.9332 - loss: 314.6982
+
+
+357/Unknown  1715s 5s/step - accuracy: 0.9332 - loss: 314.5501
+
+
+358/Unknown  1720s 5s/step - accuracy: 0.9333 - loss: 314.4027
+
+
+359/Unknown  1725s 5s/step - accuracy: 0.9333 - loss: 314.2560
+
+
+360/Unknown  1729s 5s/step - accuracy: 0.9333 - loss: 314.1105
+
+
+361/Unknown  1734s 5s/step - accuracy: 0.9334 - loss: 313.9658
+
+
+362/Unknown  1739s 5s/step - accuracy: 0.9334 - loss: 313.8213
+
+
+363/Unknown  1744s 5s/step - accuracy: 0.9334 - loss: 313.6775
+
+
+364/Unknown  1749s 5s/step - accuracy: 0.9335 - loss: 313.5339
+
+
+365/Unknown  1754s 5s/step - accuracy: 0.9335 - loss: 313.3907
+
+
+366/Unknown  1760s 5s/step - accuracy: 0.9335 - loss: 313.2493
+
+
+367/Unknown  1765s 5s/step - accuracy: 0.9336 - loss: 313.1085
+
+
+368/Unknown  1770s 5s/step - accuracy: 0.9336 - loss: 312.9681
+
+
+369/Unknown  1774s 5s/step - accuracy: 0.9336 - loss: 312.8284
+
+
+370/Unknown  1779s 5s/step - accuracy: 0.9336 - loss: 312.6895
+
+
+371/Unknown  1784s 5s/step - accuracy: 0.9337 - loss: 312.5517
+
+
+372/Unknown  1790s 5s/step - accuracy: 0.9337 - loss: 312.4143
+
+
+373/Unknown  1795s 5s/step - accuracy: 0.9337 - loss: 312.2771
+
+
+374/Unknown  1800s 5s/step - accuracy: 0.9338 - loss: 312.1399
+
+
+375/Unknown  1805s 5s/step - accuracy: 0.9338 - loss: 312.0028
+
+
+376/Unknown  1810s 5s/step - accuracy: 0.9338 - loss: 311.8658
+
+
+377/Unknown  1816s 5s/step - accuracy: 0.9338 - loss: 311.7296
+
+
+378/Unknown  1821s 5s/step - accuracy: 0.9339 - loss: 311.5934
+
+
+379/Unknown  1827s 5s/step - accuracy: 0.9339 - loss: 311.4581
+
+
+380/Unknown  1832s 5s/step - accuracy: 0.9339 - loss: 311.3236
+
+
+381/Unknown  1837s 5s/step - accuracy: 0.9340 - loss: 311.1892
+
+
+382/Unknown  1842s 5s/step - accuracy: 0.9340 - loss: 311.0562
+
+
+383/Unknown  1847s 5s/step - accuracy: 0.9340 - loss: 310.9238
+
+
+384/Unknown  1852s 5s/step - accuracy: 0.9340 - loss: 310.7918
+
+
+385/Unknown  1857s 5s/step - accuracy: 0.9341 - loss: 310.6603
+
+
+386/Unknown  1863s 5s/step - accuracy: 0.9341 - loss: 310.5298
+
+
+387/Unknown  1868s 5s/step - accuracy: 0.9341 - loss: 310.3997
+
+
+388/Unknown  1873s 5s/step - accuracy: 0.9342 - loss: 310.2701
+
+
+389/Unknown  1879s 5s/step - accuracy: 0.9342 - loss: 310.1407
+
+
+390/Unknown  1884s 5s/step - accuracy: 0.9342 - loss: 310.0117
+
+
+391/Unknown  1889s 5s/step - accuracy: 0.9342 - loss: 309.8839
+
+
+392/Unknown  1894s 5s/step - accuracy: 0.9343 - loss: 309.7567
+
+
+393/Unknown  1900s 5s/step - accuracy: 0.9343 - loss: 309.6298
+
+
+394/Unknown  1905s 5s/step - accuracy: 0.9343 - loss: 309.5036
+
+
+395/Unknown  1910s 5s/step - accuracy: 0.9343 - loss: 309.3778
+
+
+396/Unknown  1915s 5s/step - accuracy: 0.9344 - loss: 309.2533
+
+
+397/Unknown  1920s 5s/step - accuracy: 0.9344 - loss: 309.1294
+
+
+398/Unknown  1925s 5s/step - accuracy: 0.9344 - loss: 309.0062
+
+
+399/Unknown  1931s 5s/step - accuracy: 0.9345 - loss: 308.8835
+
+
+400/Unknown  1936s 5s/step - accuracy: 0.9345 - loss: 308.7615
+
+
+401/Unknown  1941s 5s/step - accuracy: 0.9345 - loss: 308.6405
+
+
+402/Unknown  1946s 5s/step - accuracy: 0.9345 - loss: 308.5200
+
+
+403/Unknown  1951s 5s/step - accuracy: 0.9346 - loss: 308.4001
+
+
+404/Unknown  1957s 5s/step - accuracy: 0.9346 - loss: 308.2805
+
+
+405/Unknown  1962s 5s/step - accuracy: 0.9346 - loss: 308.1610
+
+
+406/Unknown  1968s 5s/step - accuracy: 0.9346 - loss: 308.0417
+
+
+407/Unknown  1973s 5s/step - accuracy: 0.9347 - loss: 307.9226
+
+
+408/Unknown  1978s 5s/step - accuracy: 0.9347 - loss: 307.8040
+
+
+409/Unknown  1983s 5s/step - accuracy: 0.9347 - loss: 307.6858
+
+
+410/Unknown  1989s 5s/step - accuracy: 0.9347 - loss: 307.5679
+
+
+411/Unknown  1994s 5s/step - accuracy: 0.9348 - loss: 307.4503
+
+
+412/Unknown  2000s 5s/step - accuracy: 0.9348 - loss: 307.3333
+
+
+413/Unknown  2005s 5s/step - accuracy: 0.9348 - loss: 307.2177
+
+
+414/Unknown  2010s 5s/step - accuracy: 0.9348 - loss: 307.1020
+
+
+415/Unknown  2015s 5s/step - accuracy: 0.9349 - loss: 306.9868
+
+
+416/Unknown  2021s 5s/step - accuracy: 0.9349 - loss: 306.8718
+
+
+417/Unknown  2025s 5s/step - accuracy: 0.9349 - loss: 306.7578
+
+
+418/Unknown  2031s 5s/step - accuracy: 0.9349 - loss: 306.6442
+
+
+419/Unknown  2036s 5s/step - accuracy: 0.9350 - loss: 306.5310
+
+
+420/Unknown  2041s 5s/step - accuracy: 0.9350 - loss: 306.4184
+
+
+421/Unknown  2046s 5s/step - accuracy: 0.9350 - loss: 306.3060
+
+
+422/Unknown  2052s 5s/step - accuracy: 0.9350 - loss: 306.1940
+
+
+423/Unknown  2057s 5s/step - accuracy: 0.9350 - loss: 306.0820
+
+
+424/Unknown  2062s 5s/step - accuracy: 0.9351 - loss: 305.9709
+
+
+425/Unknown  2068s 5s/step - accuracy: 0.9351 - loss: 305.8597
+
+
+426/Unknown  2073s 5s/step - accuracy: 0.9351 - loss: 305.7486
+
+
+427/Unknown  2079s 5s/step - accuracy: 0.9351 - loss: 305.6375
+
+
+428/Unknown  2083s 5s/step - accuracy: 0.9352 - loss: 305.5270
+
+
+429/Unknown  2089s 5s/step - accuracy: 0.9352 - loss: 305.4171
+
+
+430/Unknown  2094s 5s/step - accuracy: 0.9352 - loss: 305.3074
+
+
+431/Unknown  2100s 5s/step - accuracy: 0.9352 - loss: 305.1978
+
+
+432/Unknown  2105s 5s/step - accuracy: 0.9353 - loss: 305.0883
+
+
+433/Unknown  2110s 5s/step - accuracy: 0.9353 - loss: 304.9792
+
+
+434/Unknown  2116s 5s/step - accuracy: 0.9353 - loss: 304.8710
+
+
+435/Unknown  2121s 5s/step - accuracy: 0.9353 - loss: 304.7630
+
+
+436/Unknown  2127s 5s/step - accuracy: 0.9353 - loss: 304.6555
+
+
+437/Unknown  2132s 5s/step - accuracy: 0.9354 - loss: 304.5482
+
+
+438/Unknown  2137s 5s/step - accuracy: 0.9354 - loss: 304.4412
+
+
+439/Unknown  2143s 5s/step - accuracy: 0.9354 - loss: 304.3348
+
+
+440/Unknown  2148s 5s/step - accuracy: 0.9354 - loss: 304.2284
+
+
+441/Unknown  2154s 5s/step - accuracy: 0.9355 - loss: 304.1221
+
+
+442/Unknown  2159s 5s/step - accuracy: 0.9355 - loss: 304.0159
+
+
+443/Unknown  2164s 5s/step - accuracy: 0.9355 - loss: 303.9098
+
+
+444/Unknown  2170s 5s/step - accuracy: 0.9355 - loss: 303.8045
+
+
+445/Unknown  2175s 5s/step - accuracy: 0.9355 - loss: 303.6997
+
+
+446/Unknown  2181s 5s/step - accuracy: 0.9356 - loss: 303.5954
+
+
+447/Unknown  2186s 5s/step - accuracy: 0.9356 - loss: 303.4915
+
+
+448/Unknown  2191s 5s/step - accuracy: 0.9356 - loss: 303.3879
+
+
+449/Unknown  2197s 5s/step - accuracy: 0.9356 - loss: 303.2853
+
+
+450/Unknown  2202s 5s/step - accuracy: 0.9357 - loss: 303.1830
+
+
+451/Unknown  2208s 5s/step - accuracy: 0.9357 - loss: 303.0814
+
+
+452/Unknown  2213s 5s/step - accuracy: 0.9357 - loss: 302.9807
+
+
+453/Unknown  2219s 5s/step - accuracy: 0.9357 - loss: 302.8800
+
+
+454/Unknown  2224s 5s/step - accuracy: 0.9357 - loss: 302.7801
+
+
+455/Unknown  2229s 5s/step - accuracy: 0.9358 - loss: 302.6810
+
+
+456/Unknown  2235s 5s/step - accuracy: 0.9358 - loss: 302.5824
+
+
+457/Unknown  2241s 5s/step - accuracy: 0.9358 - loss: 302.4843
+
+
+458/Unknown  2246s 5s/step - accuracy: 0.9358 - loss: 302.3867
+
+
+459/Unknown  2252s 5s/step - accuracy: 0.9358 - loss: 302.2893
+
+
+460/Unknown  2257s 5s/step - accuracy: 0.9359 - loss: 302.1924
+
+
+461/Unknown  2262s 5s/step - accuracy: 0.9359 - loss: 302.0958
+
+
+462/Unknown  2268s 5s/step - accuracy: 0.9359 - loss: 301.9993
+
+
+463/Unknown  2273s 5s/step - accuracy: 0.9359 - loss: 301.9033
+
+
+464/Unknown  2279s 5s/step - accuracy: 0.9359 - loss: 301.8077
+
+
+465/Unknown  2284s 5s/step - accuracy: 0.9360 - loss: 301.7121
+
+
+466/Unknown  2289s 5s/step - accuracy: 0.9360 - loss: 301.6171
+
+
+467/Unknown  2295s 5s/step - accuracy: 0.9360 - loss: 301.5226
+
+
+468/Unknown  2300s 5s/step - accuracy: 0.9360 - loss: 301.4286
+
+
+469/Unknown  2306s 5s/step - accuracy: 0.9360 - loss: 301.3351
+
+
+470/Unknown  2311s 5s/step - accuracy: 0.9361 - loss: 301.2416
+
+
+471/Unknown  2317s 5s/step - accuracy: 0.9361 - loss: 301.1487
+
+
+472/Unknown  2322s 5s/step - accuracy: 0.9361 - loss: 301.0562
+
+
+473/Unknown  2328s 5s/step - accuracy: 0.9361 - loss: 300.9637
+
+
+474/Unknown  2334s 5s/step - accuracy: 0.9361 - loss: 300.8715
+
+
+475/Unknown  2339s 5s/step - accuracy: 0.9361 - loss: 300.7798
+
+
+476/Unknown  2344s 5s/step - accuracy: 0.9362 - loss: 300.6884
+
+
+477/Unknown  2350s 5s/step - accuracy: 0.9362 - loss: 300.5971
+
+
+478/Unknown  2355s 5s/step - accuracy: 0.9362 - loss: 300.5059
+
+
+479/Unknown  2361s 5s/step - accuracy: 0.9362 - loss: 300.4148
+
+
+480/Unknown  2367s 5s/step - accuracy: 0.9362 - loss: 300.3242
+
+
+481/Unknown  2372s 5s/step - accuracy: 0.9363 - loss: 300.2337
+
+
+482/Unknown  2378s 5s/step - accuracy: 0.9363 - loss: 300.1434
+
+
+483/Unknown  2383s 5s/step - accuracy: 0.9363 - loss: 300.0537
+
+
+484/Unknown  2389s 5s/step - accuracy: 0.9363 - loss: 299.9649
+
+
+485/Unknown  2395s 5s/step - accuracy: 0.9363 - loss: 299.8761
+
+
+486/Unknown  2400s 5s/step - accuracy: 0.9364 - loss: 299.7877
+
+
+487/Unknown  2406s 5s/step - accuracy: 0.9364 - loss: 299.6995
+
+
+488/Unknown  2412s 5s/step - accuracy: 0.9364 - loss: 299.6112
+
+
+489/Unknown  2417s 5s/step - accuracy: 0.9364 - loss: 299.5231
+
+
+490/Unknown  2423s 5s/step - accuracy: 0.9364 - loss: 299.4352
+
+
+491/Unknown  2428s 5s/step - accuracy: 0.9364 - loss: 299.3475
+
+
+492/Unknown  2434s 5s/step - accuracy: 0.9365 - loss: 299.2601
+
+
+493/Unknown  2440s 5s/step - accuracy: 0.9365 - loss: 299.1726
+
+
+494/Unknown  2445s 5s/step - accuracy: 0.9365 - loss: 299.0855
+
+
+495/Unknown  2451s 5s/step - accuracy: 0.9365 - loss: 298.9986
+
+
+496/Unknown  2456s 5s/step - accuracy: 0.9365 - loss: 298.9120
+
+
+497/Unknown  2462s 5s/step - accuracy: 0.9366 - loss: 298.8255
+
+
+498/Unknown  2467s 5s/step - accuracy: 0.9366 - loss: 298.7390
+
+
+499/Unknown  2473s 5s/step - accuracy: 0.9366 - loss: 298.6525
+
+
+500/Unknown  2479s 5s/step - accuracy: 0.9366 - loss: 298.5663
+
+
+501/Unknown  2484s 5s/step - accuracy: 0.9366 - loss: 298.4802
+
+
+502/Unknown  2489s 5s/step - accuracy: 0.9366 - loss: 298.3942
+
+
+503/Unknown  2495s 5s/step - accuracy: 0.9367 - loss: 298.3082
+
+
+504/Unknown  2500s 5s/step - accuracy: 0.9367 - loss: 298.2220
+
+
+505/Unknown  2506s 5s/step - accuracy: 0.9367 - loss: 298.1357
+
+
+506/Unknown  2512s 5s/step - accuracy: 0.9367 - loss: 298.0498
+
+
+507/Unknown  2518s 5s/step - accuracy: 0.9367 - loss: 297.9643
+
+
+508/Unknown  2524s 5s/step - accuracy: 0.9367 - loss: 297.8791
+
+
+509/Unknown  2529s 5s/step - accuracy: 0.9368 - loss: 297.7941
+
+
+510/Unknown  2535s 5s/step - accuracy: 0.9368 - loss: 297.7096
+
+
+511/Unknown  2540s 5s/step - accuracy: 0.9368 - loss: 297.6250
+
+
+512/Unknown  2546s 5s/step - accuracy: 0.9368 - loss: 297.5409
+
+
+513/Unknown  2551s 5s/step - accuracy: 0.9368 - loss: 297.4570
+
+
+514/Unknown  2558s 5s/step - accuracy: 0.9369 - loss: 297.3736
+
+
+515/Unknown  2563s 5s/step - accuracy: 0.9369 - loss: 297.2903
+
+
+516/Unknown  2569s 5s/step - accuracy: 0.9369 - loss: 297.2072
+
+
+517/Unknown  2574s 5s/step - accuracy: 0.9369 - loss: 297.1243
+
+
+518/Unknown  2580s 5s/step - accuracy: 0.9369 - loss: 297.0417
+
+
+519/Unknown  2586s 5s/step - accuracy: 0.9369 - loss: 296.9596
+
+
+520/Unknown  2592s 5s/step - accuracy: 0.9370 - loss: 296.8777
+
+
+521/Unknown  2597s 5s/step - accuracy: 0.9370 - loss: 296.7960
+
+
+522/Unknown  2603s 5s/step - accuracy: 0.9370 - loss: 296.7152
+
+
+523/Unknown  2608s 5s/step - accuracy: 0.9370 - loss: 296.6345
+
+
+524/Unknown  2614s 5s/step - accuracy: 0.9370 - loss: 296.5539
+
+
+525/Unknown  2619s 5s/step - accuracy: 0.9370 - loss: 296.4738
+
+
+526/Unknown  2625s 5s/step - accuracy: 0.9371 - loss: 296.3938
+
+
+527/Unknown  2630s 5s/step - accuracy: 0.9371 - loss: 296.3137
+
+
+528/Unknown  2636s 5s/step - accuracy: 0.9371 - loss: 296.2339
+
+
+529/Unknown  2641s 5s/step - accuracy: 0.9371 - loss: 296.1544
+
+
+530/Unknown  2647s 5s/step - accuracy: 0.9371 - loss: 296.0752
+
+
+531/Unknown  2653s 5s/step - accuracy: 0.9371 - loss: 295.9962
+
+
+532/Unknown  2658s 5s/step - accuracy: 0.9371 - loss: 295.9171
+
+
+533/Unknown  2664s 5s/step - accuracy: 0.9372 - loss: 295.8383
+
+
+534/Unknown  2670s 5s/step - accuracy: 0.9372 - loss: 295.7601
+
+
+535/Unknown  2676s 5s/step - accuracy: 0.9372 - loss: 295.6820
+
+
+536/Unknown  2682s 5s/step - accuracy: 0.9372 - loss: 295.6042
+
+
+537/Unknown  2687s 5s/step - accuracy: 0.9372 - loss: 295.5266
+
+
+538/Unknown  2693s 5s/step - accuracy: 0.9372 - loss: 295.4493
+
+
+539/Unknown  2698s 5s/step - accuracy: 0.9373 - loss: 295.3722
+
+
+540/Unknown  2704s 5s/step - accuracy: 0.9373 - loss: 295.2952
+
+
+541/Unknown  2709s 5s/step - accuracy: 0.9373 - loss: 295.2184
+
+
+542/Unknown  2715s 5s/step - accuracy: 0.9373 - loss: 295.1418
+
+
+543/Unknown  2720s 5s/step - accuracy: 0.9373 - loss: 295.0652
+
+
+544/Unknown  2726s 5s/step - accuracy: 0.9373 - loss: 294.9886
+
+
+545/Unknown  2732s 5s/step - accuracy: 0.9374 - loss: 294.9122
+
+
+546/Unknown  2738s 5s/step - accuracy: 0.9374 - loss: 294.8366
+
+
+547/Unknown  2743s 5s/step - accuracy: 0.9374 - loss: 294.7612
+
+
+548/Unknown  2749s 5s/step - accuracy: 0.9374 - loss: 294.6865
+
+
+549/Unknown  2754s 5s/step - accuracy: 0.9374 - loss: 294.6119
+
+
+550/Unknown  2760s 5s/step - accuracy: 0.9374 - loss: 294.5374
+
+
+551/Unknown  2765s 5s/step - accuracy: 0.9374 - loss: 294.4630
+
+
+552/Unknown  2771s 5s/step - accuracy: 0.9375 - loss: 294.3886
+
+
+553/Unknown  2777s 5s/step - accuracy: 0.9375 - loss: 294.3147
+
+
+554/Unknown  2783s 5s/step - accuracy: 0.9375 - loss: 294.2409
+
+
+555/Unknown  2789s 5s/step - accuracy: 0.9375 - loss: 294.1676
+
+
+556/Unknown  2794s 5s/step - accuracy: 0.9375 - loss: 294.0944
+
+
+557/Unknown  2800s 5s/step - accuracy: 0.9375 - loss: 294.0215
+
+
+558/Unknown  2806s 5s/step - accuracy: 0.9375 - loss: 293.9488
+
+
+559/Unknown  2812s 5s/step - accuracy: 0.9376 - loss: 293.8765
+
+
+560/Unknown  2817s 5s/step - accuracy: 0.9376 - loss: 293.8043
+
+
+561/Unknown  2823s 5s/step - accuracy: 0.9376 - loss: 293.7322
+
+
+562/Unknown  2829s 5s/step - accuracy: 0.9376 - loss: 293.6603
+
+
+563/Unknown  2835s 5s/step - accuracy: 0.9376 - loss: 293.5886
+
+
+564/Unknown  2841s 5s/step - accuracy: 0.9376 - loss: 293.5170
+
+
+565/Unknown  2846s 5s/step - accuracy: 0.9376 - loss: 293.4457
+
+
+566/Unknown  2852s 5s/step - accuracy: 0.9377 - loss: 293.3749
+
+
+567/Unknown  2857s 5s/step - accuracy: 0.9377 - loss: 293.3044
+
+
+568/Unknown  2863s 5s/step - accuracy: 0.9377 - loss: 293.2340
+
+
+569/Unknown  2869s 5s/step - accuracy: 0.9377 - loss: 293.1638
+
+
+570/Unknown  2875s 5s/step - accuracy: 0.9377 - loss: 293.0937
+
+
+571/Unknown  2881s 5s/step - accuracy: 0.9377 - loss: 293.0238
+
+
+572/Unknown  2886s 5s/step - accuracy: 0.9377 - loss: 292.9538
+
+
+573/Unknown  2891s 5s/step - accuracy: 0.9378 - loss: 292.8841
+
+
+574/Unknown  2897s 5s/step - accuracy: 0.9378 - loss: 292.8147
+
+
+575/Unknown  2903s 5s/step - accuracy: 0.9378 - loss: 292.7452
+
+
+576/Unknown  2909s 5s/step - accuracy: 0.9378 - loss: 292.6761
+
+
+577/Unknown  2915s 5s/step - accuracy: 0.9378 - loss: 292.6073
+
+
+578/Unknown  2921s 5s/step - accuracy: 0.9378 - loss: 292.5388
+
+
+579/Unknown  2926s 5s/step - accuracy: 0.9378 - loss: 292.4704
+
+
+580/Unknown  2932s 5s/step - accuracy: 0.9379 - loss: 292.4021
+
+
+581/Unknown  2938s 5s/step - accuracy: 0.9379 - loss: 292.3340
+
+
+582/Unknown  2944s 5s/step - accuracy: 0.9379 - loss: 292.2664
+
+
+583/Unknown  2950s 5s/step - accuracy: 0.9379 - loss: 292.1990
+
+
+584/Unknown  2955s 5s/step - accuracy: 0.9379 - loss: 292.1319
+
+
+585/Unknown  2961s 5s/step - accuracy: 0.9379 - loss: 292.0648
+
+
+586/Unknown  2967s 5s/step - accuracy: 0.9379 - loss: 291.9982
+
+
+587/Unknown  2973s 5s/step - accuracy: 0.9380 - loss: 291.9317
+
+
+588/Unknown  2979s 5s/step - accuracy: 0.9380 - loss: 291.8656
+
+
+589/Unknown  2985s 5s/step - accuracy: 0.9380 - loss: 291.7996
+
+
+590/Unknown  2990s 5s/step - accuracy: 0.9380 - loss: 291.7336
+
+
+591/Unknown  2996s 5s/step - accuracy: 0.9380 - loss: 291.6675
+
+
+592/Unknown  3002s 5s/step - accuracy: 0.9380 - loss: 291.6015
+
+
+593/Unknown  3008s 5s/step - accuracy: 0.9380 - loss: 291.5358
+
+
+594/Unknown  3014s 5s/step - accuracy: 0.9380 - loss: 291.4701
+
+
+595/Unknown  3019s 5s/step - accuracy: 0.9381 - loss: 291.4042
+
+
+596/Unknown  3025s 5s/step - accuracy: 0.9381 - loss: 291.3387
+
+
+597/Unknown  3030s 5s/step - accuracy: 0.9381 - loss: 291.2737
+
+
+598/Unknown  3036s 5s/step - accuracy: 0.9381 - loss: 291.2088
+
+
+599/Unknown  3041s 5s/step - accuracy: 0.9381 - loss: 291.1442
+
+
+600/Unknown  3047s 5s/step - accuracy: 0.9381 - loss: 291.0795
+
+
+601/Unknown  3053s 5s/step - accuracy: 0.9381 - loss: 291.0151
+
+
+602/Unknown  3058s 5s/step - accuracy: 0.9381 - loss: 290.9508
+
+
+603/Unknown  3064s 5s/step - accuracy: 0.9382 - loss: 290.8867
+
+
+604/Unknown  3071s 5s/step - accuracy: 0.9382 - loss: 290.8229
+
+
+605/Unknown  3077s 5s/step - accuracy: 0.9382 - loss: 290.7592
+
+
+606/Unknown  3083s 5s/step - accuracy: 0.9382 - loss: 290.6953
+
+
+607/Unknown  3089s 5s/step - accuracy: 0.9382 - loss: 290.6319
+
+
+608/Unknown  3095s 5s/step - accuracy: 0.9382 - loss: 290.5686
+
+
+609/Unknown  3101s 5s/step - accuracy: 0.9382 - loss: 290.5056
+
+
+610/Unknown  3107s 5s/step - accuracy: 0.9382 - loss: 290.4426
+
+
+611/Unknown  3113s 5s/step - accuracy: 0.9383 - loss: 290.3796
+
+
+612/Unknown  3119s 5s/step - accuracy: 0.9383 - loss: 290.3168
+
+
+613/Unknown  3124s 5s/step - accuracy: 0.9383 - loss: 290.2538
+
+
+614/Unknown  3130s 5s/step - accuracy: 0.9383 - loss: 290.1913
+
+
+615/Unknown  3136s 5s/step - accuracy: 0.9383 - loss: 290.1292
+
+
+616/Unknown  3142s 5s/step - accuracy: 0.9383 - loss: 290.0670
+
+
+617/Unknown  3148s 5s/step - accuracy: 0.9383 - loss: 290.0049
+
+
+618/Unknown  3153s 5s/step - accuracy: 0.9384 - loss: 289.9432
+
+
+619/Unknown  3160s 5s/step - accuracy: 0.9384 - loss: 289.8817
+
+
+620/Unknown  3166s 5s/step - accuracy: 0.9384 - loss: 289.8200
+
+
+621/Unknown  3172s 5s/step - accuracy: 0.9384 - loss: 289.7584
+
+
+622/Unknown  3177s 5s/step - accuracy: 0.9384 - loss: 289.6972
+
+
+623/Unknown  3183s 5s/step - accuracy: 0.9384 - loss: 289.6363
+
+
+624/Unknown  3190s 5s/step - accuracy: 0.9384 - loss: 289.5756
+
+
+625/Unknown  3196s 5s/step - accuracy: 0.9384 - loss: 289.5153
+
+
+626/Unknown  3201s 5s/step - accuracy: 0.9385 - loss: 289.4552
+
+
+627/Unknown  3207s 5s/step - accuracy: 0.9385 - loss: 289.3954
+
+
+628/Unknown  3212s 5s/step - accuracy: 0.9385 - loss: 289.3359
+
+
+629/Unknown  3219s 5s/step - accuracy: 0.9385 - loss: 289.2766
+
+
+630/Unknown  3224s 5s/step - accuracy: 0.9385 - loss: 289.2176
+
+
+631/Unknown  3230s 5s/step - accuracy: 0.9385 - loss: 289.1588
+
+
+632/Unknown  3237s 5s/step - accuracy: 0.9385 - loss: 289.1000
+
+
+633/Unknown  3243s 5s/step - accuracy: 0.9385 - loss: 289.0413
+
+
+634/Unknown  3249s 5s/step - accuracy: 0.9385 - loss: 288.9830
+
+
+635/Unknown  3255s 5s/step - accuracy: 0.9386 - loss: 288.9246
+
+
+636/Unknown  3261s 5s/step - accuracy: 0.9386 - loss: 288.8665
+
+
+637/Unknown  3267s 5s/step - accuracy: 0.9386 - loss: 288.8085
+
+
+638/Unknown  3274s 5s/step - accuracy: 0.9386 - loss: 288.7508
+
+
+639/Unknown  3280s 5s/step - accuracy: 0.9386 - loss: 288.6931
+
+
+640/Unknown  3286s 5s/step - accuracy: 0.9386 - loss: 288.6355
+
+
+641/Unknown  3292s 5s/step - accuracy: 0.9386 - loss: 288.5780
+
+/home/humbulani/tensorflow-env/env/lib/python3.11/site-packages/keras/src/trainers/epoch_iterator.py:151: UserWarning: Your input ran out of data; interrupting training. Make sure that your dataset or generator can generate at least `steps_per_epoch * epochs` batches. You may need to use the `.repeat()` function when building your dataset.
+  self._interrupted_warning()
+
+
+```
+</div>
+ 641/641 ━━━━━━━━━━━━━━━━━━━━ 3383s 5s/step - accuracy: 0.9386 - loss: 288.5208 - val_accuracy: 0.9500 - val_loss: 230.6449
+
+
+<div class="k-default-codeblock">
+```
 Model training finished.
 Evaluating model performance...
-377/377 [==============================] - 4s 11ms/step - loss: 204.5099 - accuracy: 0.9547
-Test accuracy: 95.47%
+
+```
+</div>
+    
+<div class="k-default-codeblock">
+```
+  1/Unknown  1s 969ms/step - accuracy: 0.9585 - loss: 159.8705
+
+
+  2/Unknown  2s 784ms/step - accuracy: 0.9538 - loss: 181.6473
+
+
+  3/Unknown  3s 796ms/step - accuracy: 0.9503 - loss: 201.4849
+
+
+  4/Unknown  3s 797ms/step - accuracy: 0.9479 - loss: 213.0796
+
+
+  5/Unknown  4s 820ms/step - accuracy: 0.9473 - loss: 219.6181
+
+
+  6/Unknown  5s 852ms/step - accuracy: 0.9476 - loss: 223.2487
+
+
+  7/Unknown  6s 852ms/step - accuracy: 0.9482 - loss: 223.5582
+
+
+  8/Unknown  7s 845ms/step - accuracy: 0.9488 - loss: 222.6751
+
+
+  9/Unknown  8s 831ms/step - accuracy: 0.9493 - loss: 221.3878
+
+
+ 10/Unknown  8s 824ms/step - accuracy: 0.9497 - loss: 219.9191
+
+
+ 11/Unknown  9s 823ms/step - accuracy: 0.9501 - loss: 218.7335
+
+
+ 12/Unknown  10s 823ms/step - accuracy: 0.9503 - loss: 217.6873
+
+
+ 13/Unknown  11s 822ms/step - accuracy: 0.9504 - loss: 217.1383
+
+
+ 14/Unknown  12s 820ms/step - accuracy: 0.9505 - loss: 216.5114
+
+
+ 15/Unknown  12s 820ms/step - accuracy: 0.9506 - loss: 216.1290
+
+
+ 16/Unknown  13s 825ms/step - accuracy: 0.9507 - loss: 215.6186
+
+
+ 17/Unknown  14s 837ms/step - accuracy: 0.9509 - loss: 215.1525
+
+
+ 18/Unknown  15s 845ms/step - accuracy: 0.9510 - loss: 215.0510
+
+
+ 19/Unknown  16s 847ms/step - accuracy: 0.9510 - loss: 215.1579
+
+
+ 20/Unknown  17s 845ms/step - accuracy: 0.9511 - loss: 215.3697
+
+
+ 21/Unknown  18s 848ms/step - accuracy: 0.9511 - loss: 215.7154
+
+
+ 22/Unknown  19s 847ms/step - accuracy: 0.9511 - loss: 216.0274
+
+
+ 23/Unknown  20s 843ms/step - accuracy: 0.9510 - loss: 216.3101
+
+
+ 24/Unknown  20s 839ms/step - accuracy: 0.9510 - loss: 216.5270
+
+
+ 25/Unknown  21s 839ms/step - accuracy: 0.9510 - loss: 216.8894
+
+
+ 26/Unknown  22s 839ms/step - accuracy: 0.9510 - loss: 217.1713
+
+
+ 27/Unknown  23s 837ms/step - accuracy: 0.9510 - loss: 217.3974
+
+
+ 28/Unknown  24s 837ms/step - accuracy: 0.9510 - loss: 217.6237
+
+
+ 29/Unknown  24s 836ms/step - accuracy: 0.9510 - loss: 217.8101
+
+
+ 30/Unknown  25s 836ms/step - accuracy: 0.9509 - loss: 217.9722
+
+
+ 31/Unknown  26s 843ms/step - accuracy: 0.9509 - loss: 218.1803
+
+
+ 32/Unknown  27s 846ms/step - accuracy: 0.9509 - loss: 218.3734
+
+
+ 33/Unknown  28s 846ms/step - accuracy: 0.9508 - loss: 218.6991
+
+
+ 34/Unknown  29s 848ms/step - accuracy: 0.9507 - loss: 219.0575
+
+
+ 35/Unknown  30s 851ms/step - accuracy: 0.9506 - loss: 219.3678
+
+
+ 36/Unknown  31s 852ms/step - accuracy: 0.9506 - loss: 219.6365
+
+
+ 37/Unknown  32s 854ms/step - accuracy: 0.9505 - loss: 219.8749
+
+
+ 38/Unknown  33s 855ms/step - accuracy: 0.9505 - loss: 220.0916
+
+
+ 39/Unknown  33s 854ms/step - accuracy: 0.9504 - loss: 220.2763
+
+
+ 40/Unknown  34s 851ms/step - accuracy: 0.9504 - loss: 220.4740
+
+
+ 41/Unknown  35s 849ms/step - accuracy: 0.9504 - loss: 220.6481
+
+
+ 42/Unknown  36s 849ms/step - accuracy: 0.9503 - loss: 220.7809
+
+
+ 43/Unknown  37s 848ms/step - accuracy: 0.9503 - loss: 220.9724
+
+
+ 44/Unknown  37s 847ms/step - accuracy: 0.9503 - loss: 221.1543
+
+
+ 45/Unknown  38s 850ms/step - accuracy: 0.9502 - loss: 221.3142
+
+
+ 46/Unknown  39s 852ms/step - accuracy: 0.9502 - loss: 221.4476
+
+
+ 47/Unknown  40s 853ms/step - accuracy: 0.9502 - loss: 221.5518
+
+
+ 48/Unknown  41s 851ms/step - accuracy: 0.9501 - loss: 221.6600
+
+
+ 49/Unknown  42s 849ms/step - accuracy: 0.9501 - loss: 221.7569
+
+
+ 50/Unknown  43s 848ms/step - accuracy: 0.9501 - loss: 221.8995
+
+
+ 51/Unknown  43s 848ms/step - accuracy: 0.9500 - loss: 222.0217
+
+
+ 52/Unknown  44s 847ms/step - accuracy: 0.9500 - loss: 222.1107
+
+
+ 53/Unknown  45s 848ms/step - accuracy: 0.9500 - loss: 222.1740
+
+
+ 54/Unknown  46s 851ms/step - accuracy: 0.9500 - loss: 222.2534
+
+
+ 55/Unknown  47s 852ms/step - accuracy: 0.9500 - loss: 222.3450
+
+
+ 56/Unknown  48s 851ms/step - accuracy: 0.9499 - loss: 222.4026
+
+
+ 57/Unknown  49s 850ms/step - accuracy: 0.9499 - loss: 222.4373
+
+
+ 58/Unknown  49s 849ms/step - accuracy: 0.9499 - loss: 222.5173
+
+
+ 59/Unknown  50s 848ms/step - accuracy: 0.9499 - loss: 222.5910
+
+
+ 60/Unknown  51s 847ms/step - accuracy: 0.9499 - loss: 222.6672
+
+
+ 61/Unknown  52s 846ms/step - accuracy: 0.9499 - loss: 222.7544
+
+
+ 62/Unknown  53s 849ms/step - accuracy: 0.9499 - loss: 222.8256
+
+
+ 63/Unknown  54s 850ms/step - accuracy: 0.9498 - loss: 222.9229
+
+
+ 64/Unknown  54s 849ms/step - accuracy: 0.9498 - loss: 223.0382
+
+
+ 65/Unknown  55s 848ms/step - accuracy: 0.9498 - loss: 223.1463
+
+
+ 66/Unknown  56s 846ms/step - accuracy: 0.9498 - loss: 223.2352
+
+
+ 67/Unknown  57s 845ms/step - accuracy: 0.9498 - loss: 223.3278
+
+
+ 68/Unknown  58s 845ms/step - accuracy: 0.9497 - loss: 223.4134
+
+
+ 69/Unknown  58s 844ms/step - accuracy: 0.9497 - loss: 223.4989
+
+
+ 70/Unknown  59s 845ms/step - accuracy: 0.9497 - loss: 223.5741
+
+
+ 71/Unknown  60s 847ms/step - accuracy: 0.9497 - loss: 223.6425
+
+
+ 72/Unknown  61s 849ms/step - accuracy: 0.9497 - loss: 223.7317
+
+
+ 73/Unknown  62s 849ms/step - accuracy: 0.9497 - loss: 223.8276
+
+
+ 74/Unknown  63s 849ms/step - accuracy: 0.9497 - loss: 223.9164
+
+
+ 75/Unknown  64s 850ms/step - accuracy: 0.9496 - loss: 223.9929
+
+
+ 76/Unknown  65s 849ms/step - accuracy: 0.9496 - loss: 224.0643
+
+
+ 77/Unknown  65s 848ms/step - accuracy: 0.9496 - loss: 224.1311
+
+
+ 78/Unknown  66s 847ms/step - accuracy: 0.9496 - loss: 224.2050
+
+
+ 79/Unknown  67s 846ms/step - accuracy: 0.9496 - loss: 224.2719
+
+
+ 80/Unknown  68s 846ms/step - accuracy: 0.9496 - loss: 224.3298
+
+
+ 81/Unknown  69s 846ms/step - accuracy: 0.9496 - loss: 224.3810
+
+
+ 82/Unknown  69s 845ms/step - accuracy: 0.9495 - loss: 224.4418
+
+
+ 83/Unknown  70s 845ms/step - accuracy: 0.9495 - loss: 224.5023
+
+
+ 84/Unknown  71s 847ms/step - accuracy: 0.9495 - loss: 224.5610
+
+
+ 85/Unknown  72s 848ms/step - accuracy: 0.9495 - loss: 224.6218
+
+
+ 86/Unknown  73s 848ms/step - accuracy: 0.9495 - loss: 224.6898
+
+
+ 87/Unknown  74s 848ms/step - accuracy: 0.9494 - loss: 224.7545
+
+
+ 88/Unknown  75s 848ms/step - accuracy: 0.9494 - loss: 224.8130
+
+
+ 89/Unknown  76s 847ms/step - accuracy: 0.9494 - loss: 224.8751
+
+
+ 90/Unknown  76s 846ms/step - accuracy: 0.9494 - loss: 224.9411
+
+
+ 91/Unknown  77s 846ms/step - accuracy: 0.9494 - loss: 225.0047
+
+
+ 92/Unknown  78s 845ms/step - accuracy: 0.9493 - loss: 225.0705
+
+
+ 93/Unknown  79s 845ms/step - accuracy: 0.9493 - loss: 225.1329
+
+
+ 94/Unknown  80s 845ms/step - accuracy: 0.9493 - loss: 225.2086
+
+
+ 95/Unknown  81s 847ms/step - accuracy: 0.9493 - loss: 225.2813
+
+
+ 96/Unknown  82s 849ms/step - accuracy: 0.9493 - loss: 225.3567
+
+
+ 97/Unknown  82s 849ms/step - accuracy: 0.9492 - loss: 225.4247
+
+
+ 98/Unknown  83s 848ms/step - accuracy: 0.9492 - loss: 225.4865
+
+
+ 99/Unknown  84s 847ms/step - accuracy: 0.9492 - loss: 225.5487
+
+
+100/Unknown  85s 846ms/step - accuracy: 0.9492 - loss: 225.6207
+
+
+101/Unknown  85s 844ms/step - accuracy: 0.9492 - loss: 225.6911
+
+
+102/Unknown  86s 843ms/step - accuracy: 0.9492 - loss: 225.7601
+
+
+103/Unknown  87s 842ms/step - accuracy: 0.9491 - loss: 225.8305
+
+
+104/Unknown  88s 841ms/step - accuracy: 0.9491 - loss: 225.8976
+
+
+105/Unknown  88s 840ms/step - accuracy: 0.9491 - loss: 225.9651
+
+
+106/Unknown  89s 840ms/step - accuracy: 0.9491 - loss: 226.0321
+
+
+107/Unknown  90s 841ms/step - accuracy: 0.9491 - loss: 226.1055
+
+
+108/Unknown  91s 841ms/step - accuracy: 0.9490 - loss: 226.1780
+
+
+109/Unknown  92s 841ms/step - accuracy: 0.9490 - loss: 226.2571
+
+
+110/Unknown  92s 840ms/step - accuracy: 0.9490 - loss: 226.3349
+
+
+111/Unknown  93s 839ms/step - accuracy: 0.9490 - loss: 226.4156
+
+
+112/Unknown  94s 839ms/step - accuracy: 0.9490 - loss: 226.4971
+
+
+113/Unknown  95s 839ms/step - accuracy: 0.9490 - loss: 226.5796
+
+
+114/Unknown  96s 839ms/step - accuracy: 0.9489 - loss: 226.6544
+
+
+115/Unknown  97s 839ms/step - accuracy: 0.9489 - loss: 226.7242
+
+
+116/Unknown  98s 840ms/step - accuracy: 0.9489 - loss: 226.7973
+
+
+117/Unknown  98s 840ms/step - accuracy: 0.9489 - loss: 226.8732
+
+
+118/Unknown  99s 840ms/step - accuracy: 0.9489 - loss: 226.9461
+
+
+119/Unknown  100s 840ms/step - accuracy: 0.9489 - loss: 227.0159
+
+
+120/Unknown  101s 841ms/step - accuracy: 0.9489 - loss: 227.0847
+
+
+121/Unknown  102s 841ms/step - accuracy: 0.9489 - loss: 227.1547
+
+
+122/Unknown  103s 842ms/step - accuracy: 0.9488 - loss: 227.2229
+
+
+123/Unknown  104s 841ms/step - accuracy: 0.9488 - loss: 227.2818
+
+
+124/Unknown  104s 840ms/step - accuracy: 0.9488 - loss: 227.3406
+
+
+125/Unknown  105s 840ms/step - accuracy: 0.9488 - loss: 227.4021
+
+
+126/Unknown  106s 839ms/step - accuracy: 0.9488 - loss: 227.4603
+
+
+127/Unknown  107s 839ms/step - accuracy: 0.9488 - loss: 227.5192
+
+
+128/Unknown  107s 839ms/step - accuracy: 0.9488 - loss: 227.5745
+
+
+129/Unknown  108s 838ms/step - accuracy: 0.9488 - loss: 227.6251
+
+
+130/Unknown  109s 838ms/step - accuracy: 0.9487 - loss: 227.6736
+
+
+131/Unknown  110s 838ms/step - accuracy: 0.9487 - loss: 227.7185
+
+
+132/Unknown  111s 839ms/step - accuracy: 0.9487 - loss: 227.7645
+
+
+133/Unknown  112s 840ms/step - accuracy: 0.9487 - loss: 227.8065
+
+
+134/Unknown  113s 839ms/step - accuracy: 0.9487 - loss: 227.8499
+
+
+135/Unknown  113s 839ms/step - accuracy: 0.9487 - loss: 227.8890
+
+
+136/Unknown  114s 838ms/step - accuracy: 0.9487 - loss: 227.9345
+
+
+137/Unknown  115s 838ms/step - accuracy: 0.9487 - loss: 227.9822
+
+
+138/Unknown  116s 838ms/step - accuracy: 0.9487 - loss: 228.0268
+
+
+139/Unknown  117s 838ms/step - accuracy: 0.9487 - loss: 228.0708
+
+
+140/Unknown  117s 838ms/step - accuracy: 0.9487 - loss: 228.1134
+
+
+141/Unknown  118s 839ms/step - accuracy: 0.9487 - loss: 228.1554
+
+
+142/Unknown  119s 839ms/step - accuracy: 0.9487 - loss: 228.1968
+
+
+143/Unknown  120s 839ms/step - accuracy: 0.9487 - loss: 228.2378
+
+
+144/Unknown  121s 838ms/step - accuracy: 0.9486 - loss: 228.2773
+
+
+145/Unknown  122s 837ms/step - accuracy: 0.9486 - loss: 228.3152
+
+
+146/Unknown  122s 837ms/step - accuracy: 0.9486 - loss: 228.3522
+
+
+147/Unknown  123s 837ms/step - accuracy: 0.9486 - loss: 228.3878
+
+
+148/Unknown  124s 836ms/step - accuracy: 0.9486 - loss: 228.4215
+
+
+149/Unknown  125s 836ms/step - accuracy: 0.9486 - loss: 228.4591
+
+
+150/Unknown  126s 837ms/step - accuracy: 0.9486 - loss: 228.4945
+
+
+151/Unknown  127s 837ms/step - accuracy: 0.9486 - loss: 228.5322
+
+
+152/Unknown  127s 837ms/step - accuracy: 0.9486 - loss: 228.5719
+
+
+153/Unknown  128s 837ms/step - accuracy: 0.9486 - loss: 228.6125
+
+
+154/Unknown  129s 836ms/step - accuracy: 0.9486 - loss: 228.6527
+
+
+155/Unknown  130s 835ms/step - accuracy: 0.9486 - loss: 228.6951
+
+
+156/Unknown  130s 834ms/step - accuracy: 0.9486 - loss: 228.7370
+
+
+157/Unknown  131s 833ms/step - accuracy: 0.9486 - loss: 228.7771
+
+
+158/Unknown  132s 833ms/step - accuracy: 0.9486 - loss: 228.8156
+
+
+159/Unknown  132s 832ms/step - accuracy: 0.9486 - loss: 228.8530
+
+
+160/Unknown  133s 831ms/step - accuracy: 0.9486 - loss: 228.8878
+
+
+161/Unknown  134s 831ms/step - accuracy: 0.9486 - loss: 228.9214
+
+
+162/Unknown  135s 831ms/step - accuracy: 0.9486 - loss: 228.9536
+
+
+163/Unknown  136s 831ms/step - accuracy: 0.9485 - loss: 228.9850
+
+
+164/Unknown  136s 830ms/step - accuracy: 0.9485 - loss: 229.0151
+
+
+165/Unknown  137s 830ms/step - accuracy: 0.9485 - loss: 229.0431
+
+
+166/Unknown  138s 830ms/step - accuracy: 0.9485 - loss: 229.0700
+
+
+167/Unknown  139s 829ms/step - accuracy: 0.9485 - loss: 229.0960
+
+
+168/Unknown  139s 829ms/step - accuracy: 0.9485 - loss: 229.1205
+
+
+169/Unknown  140s 829ms/step - accuracy: 0.9485 - loss: 229.1428
+
+
+170/Unknown  141s 830ms/step - accuracy: 0.9485 - loss: 229.1650
+
+
+171/Unknown  142s 830ms/step - accuracy: 0.9485 - loss: 229.1879
+
+
+172/Unknown  143s 830ms/step - accuracy: 0.9485 - loss: 229.2117
+
+
+173/Unknown  144s 830ms/step - accuracy: 0.9485 - loss: 229.2364
+
+
+174/Unknown  144s 829ms/step - accuracy: 0.9485 - loss: 229.2587
+
+
+175/Unknown  145s 829ms/step - accuracy: 0.9485 - loss: 229.2807
+
+
+176/Unknown  146s 829ms/step - accuracy: 0.9485 - loss: 229.3035
+
+
+177/Unknown  147s 829ms/step - accuracy: 0.9485 - loss: 229.3256
+
+
+178/Unknown  148s 829ms/step - accuracy: 0.9485 - loss: 229.3470
+
+
+179/Unknown  148s 829ms/step - accuracy: 0.9485 - loss: 229.3654
+
+
+180/Unknown  149s 828ms/step - accuracy: 0.9485 - loss: 229.3816
+
+
+181/Unknown  150s 828ms/step - accuracy: 0.9485 - loss: 229.3967
+
+
+182/Unknown  151s 829ms/step - accuracy: 0.9485 - loss: 229.4137
+
+
+183/Unknown  152s 829ms/step - accuracy: 0.9485 - loss: 229.4307
+
+
+184/Unknown  153s 829ms/step - accuracy: 0.9485 - loss: 229.4493
+
+
+185/Unknown  154s 829ms/step - accuracy: 0.9485 - loss: 229.4674
+
+
+186/Unknown  154s 828ms/step - accuracy: 0.9485 - loss: 229.4838
+
+
+187/Unknown  155s 828ms/step - accuracy: 0.9485 - loss: 229.4995
+
+
+188/Unknown  156s 828ms/step - accuracy: 0.9485 - loss: 229.5143
+
+
+189/Unknown  157s 828ms/step - accuracy: 0.9485 - loss: 229.5294
+
+
+190/Unknown  157s 828ms/step - accuracy: 0.9485 - loss: 229.5453
+
+
+191/Unknown  158s 828ms/step - accuracy: 0.9485 - loss: 229.5600
+
+
+192/Unknown  159s 828ms/step - accuracy: 0.9485 - loss: 229.5728
+
+
+193/Unknown  160s 828ms/step - accuracy: 0.9485 - loss: 229.5844
+
+
+194/Unknown  161s 828ms/step - accuracy: 0.9485 - loss: 229.5949
+
+
+195/Unknown  162s 828ms/step - accuracy: 0.9485 - loss: 229.6060
+
+
+196/Unknown  163s 829ms/step - accuracy: 0.9485 - loss: 229.6188
+
+
+197/Unknown  163s 829ms/step - accuracy: 0.9485 - loss: 229.6285
+
+
+198/Unknown  164s 828ms/step - accuracy: 0.9485 - loss: 229.6418
+
+
+199/Unknown  165s 828ms/step - accuracy: 0.9485 - loss: 229.6544
+
+
+200/Unknown  166s 828ms/step - accuracy: 0.9485 - loss: 229.6676
+
+
+201/Unknown  166s 827ms/step - accuracy: 0.9485 - loss: 229.6789
+
+
+202/Unknown  167s 827ms/step - accuracy: 0.9485 - loss: 229.6895
+
+
+203/Unknown  168s 827ms/step - accuracy: 0.9485 - loss: 229.7000
+
+
+204/Unknown  169s 826ms/step - accuracy: 0.9485 - loss: 229.7093
+
+
+205/Unknown  169s 826ms/step - accuracy: 0.9485 - loss: 229.7209
+
+
+206/Unknown  170s 826ms/step - accuracy: 0.9485 - loss: 229.7325
+
+
+207/Unknown  171s 826ms/step - accuracy: 0.9485 - loss: 229.7428
+
+
+208/Unknown  172s 826ms/step - accuracy: 0.9485 - loss: 229.7533
+
+
+209/Unknown  173s 826ms/step - accuracy: 0.9485 - loss: 229.7653
+
+
+210/Unknown  174s 826ms/step - accuracy: 0.9485 - loss: 229.7759
+
+
+211/Unknown  175s 827ms/step - accuracy: 0.9485 - loss: 229.7850
+
+
+212/Unknown  175s 827ms/step - accuracy: 0.9485 - loss: 229.7936
+
+
+213/Unknown  176s 827ms/step - accuracy: 0.9485 - loss: 229.8021
+
+
+214/Unknown  177s 826ms/step - accuracy: 0.9485 - loss: 229.8111
+
+
+215/Unknown  178s 826ms/step - accuracy: 0.9485 - loss: 229.8193
+
+
+216/Unknown  179s 826ms/step - accuracy: 0.9485 - loss: 229.8291
+
+
+217/Unknown  179s 826ms/step - accuracy: 0.9485 - loss: 229.8381
+
+
+218/Unknown  180s 826ms/step - accuracy: 0.9485 - loss: 229.8456
+
+
+219/Unknown  181s 826ms/step - accuracy: 0.9485 - loss: 229.8517
+
+
+220/Unknown  182s 826ms/step - accuracy: 0.9485 - loss: 229.8562
+
+
+221/Unknown  183s 827ms/step - accuracy: 0.9485 - loss: 229.8600
+
+
+222/Unknown  184s 827ms/step - accuracy: 0.9485 - loss: 229.8624
+
+
+223/Unknown  184s 826ms/step - accuracy: 0.9485 - loss: 229.8643
+
+
+224/Unknown  185s 826ms/step - accuracy: 0.9486 - loss: 229.8661
+
+
+225/Unknown  186s 826ms/step - accuracy: 0.9486 - loss: 229.8689
+
+
+226/Unknown  187s 826ms/step - accuracy: 0.9486 - loss: 229.8717
+
+
+227/Unknown  188s 826ms/step - accuracy: 0.9486 - loss: 229.8735
+
+
+228/Unknown  188s 826ms/step - accuracy: 0.9486 - loss: 229.8744
+
+
+229/Unknown  189s 827ms/step - accuracy: 0.9486 - loss: 229.8756
+
+
+230/Unknown  190s 827ms/step - accuracy: 0.9486 - loss: 229.8762
+
+
+231/Unknown  191s 827ms/step - accuracy: 0.9486 - loss: 229.8766
+
+
+232/Unknown  192s 827ms/step - accuracy: 0.9486 - loss: 229.8752
+
+
+233/Unknown  193s 827ms/step - accuracy: 0.9486 - loss: 229.8736
+
+
+234/Unknown  194s 828ms/step - accuracy: 0.9486 - loss: 229.8711
+
+
+235/Unknown  195s 828ms/step - accuracy: 0.9486 - loss: 229.8693
+
+
+236/Unknown  196s 828ms/step - accuracy: 0.9486 - loss: 229.8688
+
+
+237/Unknown  196s 828ms/step - accuracy: 0.9486 - loss: 229.8675
+
+
+238/Unknown  197s 828ms/step - accuracy: 0.9486 - loss: 229.8669
+
+
+239/Unknown  198s 828ms/step - accuracy: 0.9486 - loss: 229.8669
+
+
+240/Unknown  199s 828ms/step - accuracy: 0.9486 - loss: 229.8657
+
+
+241/Unknown  200s 827ms/step - accuracy: 0.9486 - loss: 229.8640
+
+
+242/Unknown  200s 827ms/step - accuracy: 0.9486 - loss: 229.8625
+
+
+243/Unknown  201s 827ms/step - accuracy: 0.9486 - loss: 229.8612
+
+
+244/Unknown  202s 828ms/step - accuracy: 0.9486 - loss: 229.8591
+
+
+245/Unknown  203s 829ms/step - accuracy: 0.9486 - loss: 229.8574
+
+
+246/Unknown  204s 829ms/step - accuracy: 0.9486 - loss: 229.8549
+
+
+247/Unknown  205s 829ms/step - accuracy: 0.9486 - loss: 229.8528
+
+
+248/Unknown  206s 829ms/step - accuracy: 0.9486 - loss: 229.8504
+
+
+249/Unknown  206s 829ms/step - accuracy: 0.9486 - loss: 229.8476
+
+
+250/Unknown  207s 829ms/step - accuracy: 0.9486 - loss: 229.8455
+
+
+251/Unknown  208s 829ms/step - accuracy: 0.9486 - loss: 229.8447
+
+
+252/Unknown  209s 829ms/step - accuracy: 0.9486 - loss: 229.8435
+
+
+253/Unknown  210s 829ms/step - accuracy: 0.9487 - loss: 229.8426
+
+
+254/Unknown  211s 829ms/step - accuracy: 0.9487 - loss: 229.8415
+
+
+255/Unknown  212s 829ms/step - accuracy: 0.9487 - loss: 229.8404
+
+
+256/Unknown  212s 829ms/step - accuracy: 0.9487 - loss: 229.8398
+
+
+257/Unknown  213s 830ms/step - accuracy: 0.9487 - loss: 229.8387
+
+
+258/Unknown  214s 830ms/step - accuracy: 0.9487 - loss: 229.8384
+
+
+259/Unknown  215s 830ms/step - accuracy: 0.9487 - loss: 229.8384
+
+
+260/Unknown  216s 830ms/step - accuracy: 0.9487 - loss: 229.8374
+
+
+261/Unknown  217s 830ms/step - accuracy: 0.9487 - loss: 229.8360
+
+
+262/Unknown  218s 830ms/step - accuracy: 0.9487 - loss: 229.8331
+
+
+263/Unknown  218s 830ms/step - accuracy: 0.9487 - loss: 229.8302
+
+
+264/Unknown  219s 830ms/step - accuracy: 0.9487 - loss: 229.8270
+
+
+265/Unknown  220s 830ms/step - accuracy: 0.9487 - loss: 229.8239
+
+
+266/Unknown  221s 829ms/step - accuracy: 0.9487 - loss: 229.8224
+
+
+267/Unknown  222s 829ms/step - accuracy: 0.9487 - loss: 229.8216
+
+
+268/Unknown  222s 829ms/step - accuracy: 0.9487 - loss: 229.8201
+
+
+269/Unknown  223s 830ms/step - accuracy: 0.9487 - loss: 229.8193
+
+
+270/Unknown  224s 830ms/step - accuracy: 0.9487 - loss: 229.8182
+
+
+271/Unknown  225s 831ms/step - accuracy: 0.9487 - loss: 229.8172
+
+
+272/Unknown  226s 831ms/step - accuracy: 0.9487 - loss: 229.8150
+
+
+273/Unknown  227s 831ms/step - accuracy: 0.9487 - loss: 229.8130
+
+
+274/Unknown  228s 831ms/step - accuracy: 0.9487 - loss: 229.8102
+
+
+275/Unknown  228s 830ms/step - accuracy: 0.9487 - loss: 229.8071
+
+
+276/Unknown  229s 830ms/step - accuracy: 0.9487 - loss: 229.8048
+
+
+277/Unknown  230s 830ms/step - accuracy: 0.9487 - loss: 229.8029
+
+
+278/Unknown  231s 830ms/step - accuracy: 0.9487 - loss: 229.8008
+
+
+279/Unknown  232s 831ms/step - accuracy: 0.9487 - loss: 229.7984
+
+
+280/Unknown  233s 831ms/step - accuracy: 0.9487 - loss: 229.7951
+
+
+281/Unknown  234s 831ms/step - accuracy: 0.9488 - loss: 229.7920
+
+
+282/Unknown  234s 831ms/step - accuracy: 0.9488 - loss: 229.7879
+
+
+283/Unknown  235s 831ms/step - accuracy: 0.9488 - loss: 229.7829
+
+
+284/Unknown  236s 831ms/step - accuracy: 0.9488 - loss: 229.7788
+
+
+285/Unknown  237s 831ms/step - accuracy: 0.9488 - loss: 229.7740
+
+
+286/Unknown  238s 831ms/step - accuracy: 0.9488 - loss: 229.7697
+
+
+287/Unknown  239s 831ms/step - accuracy: 0.9488 - loss: 229.7654
+
+
+288/Unknown  239s 830ms/step - accuracy: 0.9488 - loss: 229.7608
+
+
+289/Unknown  240s 830ms/step - accuracy: 0.9488 - loss: 229.7555
+
+
+290/Unknown  241s 831ms/step - accuracy: 0.9488 - loss: 229.7503
+
+
+291/Unknown  242s 831ms/step - accuracy: 0.9488 - loss: 229.7450
+
+
+292/Unknown  243s 831ms/step - accuracy: 0.9488 - loss: 229.7401
+
+
+293/Unknown  244s 831ms/step - accuracy: 0.9488 - loss: 229.7349
+
+
+294/Unknown  244s 831ms/step - accuracy: 0.9488 - loss: 229.7300
+
+
+295/Unknown  245s 831ms/step - accuracy: 0.9488 - loss: 229.7247
+
+
+296/Unknown  246s 831ms/step - accuracy: 0.9488 - loss: 229.7213
+
+
+297/Unknown  247s 830ms/step - accuracy: 0.9488 - loss: 229.7185
+
+
+298/Unknown  248s 831ms/step - accuracy: 0.9488 - loss: 229.7160
+
+
+299/Unknown  249s 831ms/step - accuracy: 0.9488 - loss: 229.7128
+
+
+300/Unknown  250s 832ms/step - accuracy: 0.9488 - loss: 229.7092
+
+
+301/Unknown  250s 832ms/step - accuracy: 0.9488 - loss: 229.7068
+
+
+302/Unknown  251s 832ms/step - accuracy: 0.9488 - loss: 229.7043
+
+
+303/Unknown  252s 831ms/step - accuracy: 0.9488 - loss: 229.7027
+
+
+304/Unknown  253s 831ms/step - accuracy: 0.9488 - loss: 229.7015
+
+
+305/Unknown  254s 831ms/step - accuracy: 0.9488 - loss: 229.7003
+
+
+306/Unknown  254s 831ms/step - accuracy: 0.9489 - loss: 229.6985
+
+
+307/Unknown  255s 831ms/step - accuracy: 0.9489 - loss: 229.6976
+
+
+308/Unknown  256s 831ms/step - accuracy: 0.9489 - loss: 229.6960
+
+
+309/Unknown  257s 831ms/step - accuracy: 0.9489 - loss: 229.6949
+
+
+310/Unknown  258s 831ms/step - accuracy: 0.9489 - loss: 229.6949
+
+
+311/Unknown  259s 831ms/step - accuracy: 0.9489 - loss: 229.6954
+
+
+312/Unknown  260s 832ms/step - accuracy: 0.9489 - loss: 229.6953
+
+
+313/Unknown  260s 832ms/step - accuracy: 0.9489 - loss: 229.6953
+
+
+314/Unknown  261s 832ms/step - accuracy: 0.9489 - loss: 229.6953
+
+
+315/Unknown  262s 832ms/step - accuracy: 0.9489 - loss: 229.6954
+
+
+316/Unknown  263s 833ms/step - accuracy: 0.9489 - loss: 229.6950
+
+
+317/Unknown  264s 833ms/step - accuracy: 0.9489 - loss: 229.6952
+
+
+318/Unknown  265s 832ms/step - accuracy: 0.9489 - loss: 229.6959
+
+
+319/Unknown  266s 832ms/step - accuracy: 0.9489 - loss: 229.6970
+
+
+320/Unknown  266s 832ms/step - accuracy: 0.9489 - loss: 229.6978
+
+
+321/Unknown  267s 832ms/step - accuracy: 0.9489 - loss: 229.6986
+
+
+322/Unknown  268s 832ms/step - accuracy: 0.9489 - loss: 229.6996
+
+
+323/Unknown  269s 832ms/step - accuracy: 0.9489 - loss: 229.7004
+
+
+324/Unknown  270s 832ms/step - accuracy: 0.9489 - loss: 229.7011
+
+
+325/Unknown  270s 831ms/step - accuracy: 0.9489 - loss: 229.7024
+
+
+326/Unknown  271s 831ms/step - accuracy: 0.9489 - loss: 229.7045
+
+
+327/Unknown  272s 831ms/step - accuracy: 0.9489 - loss: 229.7063
+
+
+328/Unknown  273s 832ms/step - accuracy: 0.9489 - loss: 229.7081
+
+
+329/Unknown  274s 832ms/step - accuracy: 0.9489 - loss: 229.7094
+
+
+330/Unknown  275s 833ms/step - accuracy: 0.9489 - loss: 229.7113
+
+
+331/Unknown  276s 832ms/step - accuracy: 0.9489 - loss: 229.7128
+
+
+332/Unknown  276s 832ms/step - accuracy: 0.9489 - loss: 229.7154
+
+
+333/Unknown  277s 832ms/step - accuracy: 0.9489 - loss: 229.7180
+
+
+334/Unknown  278s 832ms/step - accuracy: 0.9489 - loss: 229.7203
+
+
+335/Unknown  279s 832ms/step - accuracy: 0.9489 - loss: 229.7221
+
+
+336/Unknown  280s 832ms/step - accuracy: 0.9489 - loss: 229.7232
+
+
+337/Unknown  280s 832ms/step - accuracy: 0.9489 - loss: 229.7246
+
+
+338/Unknown  281s 832ms/step - accuracy: 0.9489 - loss: 229.7261
+
+
+339/Unknown  282s 832ms/step - accuracy: 0.9489 - loss: 229.7272
+
+
+340/Unknown  283s 832ms/step - accuracy: 0.9489 - loss: 229.7288
+
+
+341/Unknown  284s 832ms/step - accuracy: 0.9489 - loss: 229.7313
+
+
+342/Unknown  285s 832ms/step - accuracy: 0.9489 - loss: 229.7336
+
+
+343/Unknown  286s 832ms/step - accuracy: 0.9489 - loss: 229.7360
+
+
+344/Unknown  286s 832ms/step - accuracy: 0.9490 - loss: 229.7383
+
+
+345/Unknown  287s 832ms/step - accuracy: 0.9490 - loss: 229.7407
+
+
+346/Unknown  288s 832ms/step - accuracy: 0.9490 - loss: 229.7439
+
+
+347/Unknown  289s 832ms/step - accuracy: 0.9490 - loss: 229.7469
+
+
+348/Unknown  290s 832ms/step - accuracy: 0.9490 - loss: 229.7512
+
+
+349/Unknown  291s 832ms/step - accuracy: 0.9490 - loss: 229.7557
+
+
+350/Unknown  291s 832ms/step - accuracy: 0.9490 - loss: 229.7600
+
+
+351/Unknown  292s 832ms/step - accuracy: 0.9490 - loss: 229.7649
+
+
+352/Unknown  293s 833ms/step - accuracy: 0.9490 - loss: 229.7693
+
+
+353/Unknown  294s 832ms/step - accuracy: 0.9490 - loss: 229.7743
+
+
+354/Unknown  295s 832ms/step - accuracy: 0.9490 - loss: 229.7806
+
+
+355/Unknown  295s 832ms/step - accuracy: 0.9490 - loss: 229.7871
+
+
+356/Unknown  296s 832ms/step - accuracy: 0.9490 - loss: 229.7933
+
+
+357/Unknown  297s 832ms/step - accuracy: 0.9490 - loss: 229.7989
+
+
+358/Unknown  298s 832ms/step - accuracy: 0.9490 - loss: 229.8050
+
+
+359/Unknown  299s 832ms/step - accuracy: 0.9490 - loss: 229.8113
+
+
+360/Unknown  299s 831ms/step - accuracy: 0.9490 - loss: 229.8174
+
+
+361/Unknown  300s 831ms/step - accuracy: 0.9490 - loss: 229.8240
+
+
+362/Unknown  301s 832ms/step - accuracy: 0.9490 - loss: 229.8305
+
+
+363/Unknown  302s 832ms/step - accuracy: 0.9490 - loss: 229.8366
+
+
+364/Unknown  303s 832ms/step - accuracy: 0.9490 - loss: 229.8427
+
+
+365/Unknown  304s 832ms/step - accuracy: 0.9490 - loss: 229.8484
+
+
+366/Unknown  304s 831ms/step - accuracy: 0.9490 - loss: 229.8530
+
+
+367/Unknown  305s 831ms/step - accuracy: 0.9490 - loss: 229.8573
+
+
+368/Unknown  306s 831ms/step - accuracy: 0.9490 - loss: 229.8619
+
+
+369/Unknown  307s 831ms/step - accuracy: 0.9490 - loss: 229.8664
+
+
+370/Unknown  308s 831ms/step - accuracy: 0.9490 - loss: 229.8705
+
+
+371/Unknown  308s 831ms/step - accuracy: 0.9490 - loss: 229.8742
+
+
+372/Unknown  309s 831ms/step - accuracy: 0.9490 - loss: 229.8776
+
+
+373/Unknown  310s 832ms/step - accuracy: 0.9490 - loss: 229.8809
+
+
+374/Unknown  311s 832ms/step - accuracy: 0.9490 - loss: 229.8844
+
+
+375/Unknown  312s 832ms/step - accuracy: 0.9490 - loss: 229.8880
+
+
+376/Unknown  313s 832ms/step - accuracy: 0.9490 - loss: 229.8915
+
+
+377/Unknown  314s 832ms/step - accuracy: 0.9490 - loss: 229.8950
+
+
+```
+</div>
+ 377/377 ━━━━━━━━━━━━━━━━━━━━ 314s 832ms/step - accuracy: 0.9490 - loss: 229.8986
+
+
+<div class="k-default-codeblock">
+```
+Test accuracy: 94.95%
 
 ```
 </div>


### PR DESCRIPTION
This PR adapts the scripts `fnet_classification_with_keras_hub.py` to `jax` and `torch`, i.e., mak the script ***Backend-Agnostic***.

**Approach**:

- The function [text_dataset_from_directory](https://github.com/keras-team/keras/blob/master/keras/src/utils/text_dataset_utils.py#L14) is actually a wrapper around the [tf.data.Dataset.from_tensor_slices](https://github.com/keras-team/keras/blob/master/keras/src/utils/text_dataset_utils.py#L262)function which is a `tensorflow` function.
- Removed the above function and relied on `pandas` and `python std library` to load the `.txt` files as a `dataframe`.
- Created the `UnifiedPyDataset` which subclasses [keras.utils.PyDataset](https://github.com/keras-team/keras/blob/master/keras/src/trainers/data_adapters/py_dataset_adapter.py#L18) to create data batches during training.
- Generated the `.ipynb` and `.md` files