### PR TITLE
Add sklearn wrappers to API docs

### DIFF
--- a/scripts/api_master.py
+++ b/scripts/api_master.py
@@ -1866,7 +1866,7 @@ API_MASTER = {
         },
         {
             "path": "utils/",
-            "title": "Utilities",
+            "title": "Utilities and Wrappers",
             "toc": True,
             "children": [
                 {
@@ -1914,6 +1914,15 @@ API_MASTER = {
                         "keras.utils.PyDataset",
                         "keras.utils.to_categorical",
                         "keras.utils.normalize",
+                    ],
+                },
+                {
+                    "path": "sklearn_wrappers",
+                    "title": "scikit-learn wrappers",
+                    "generate": [
+                        "keras.wrappers.SKLearnClassifier",
+                        "keras.wrappers.SKLearnRegressor",
+                        "keras.wrappers.SKLearnTransformer",
                     ],
                 },
                 {


### PR DESCRIPTION
https://github.com/keras-team/keras/pull/20599 added these classes and it's now released, but they're missing from the API docs.

This PR adds them to the API tree.

Let me know if it's added in the right place.