### PR TITLE
Updated broken links in jupyter notebooks

### DIFF
--- a/examples/generative/ipynb/gpt2_text_generation_with_keras_hub.ipynb
+++ b/examples/generative/ipynb/gpt2_text_generation_with_keras_hub.ipynb
@@ -150,7 +150,7 @@
     "KerasHub provides a number of pre-trained models, such as [Google\n",
     "Bert](https://ai.googleblog.com/2018/11/open-sourcing-bert-state-of-art-pre.html)\n",
     "and [GPT-2](https://openai.com/research/better-language-models). You can see\n",
-    "the list of models available in the [KerasHub repository](https://github.com/keras-team/keras-hub/tree/master/keras_hub/models).\n",
+    "the list of models available in the [KerasHub repository](https://github.com/keras-team/keras-hub/tree/master/keras_hub/src/models).\n",
     "\n",
     "It's very easy to load the GPT-2 model as you can see below:"
    ]
@@ -257,7 +257,7 @@
     "with for GPT2.\n",
     "\n",
     "The code of GPT2 can be found\n",
-    "[here](https://github.com/keras-team/keras-hub/blob/master/keras_hub/models/gpt2/).\n",
+    "[here](https://github.com/keras-team/keras-hub/tree/master/keras_hub/src/models/gpt2).\n",
     "Conceptually the `GPT2CausalLM` can be hierarchically broken down into several\n",
     "modules in KerasHub, all of which have a *from_preset()* function that loads a\n",
     "pretrained model:\n",
@@ -478,7 +478,7 @@
    },
    "source": [
     "For more details on KerasHub `Sampler` class, you can check the code\n",
-    "[here](https://github.com/keras-team/keras-hub/tree/master/keras_hub/samplers)."
+    "[here](https://github.com/keras-team/keras-hub/tree/master/keras_hub/src/samplers)."
    ]
   },
   {

--- a/guides/ipynb/keras_cv/coco_metrics.ipynb
+++ b/guides/ipynb/keras_cv/coco_metrics.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "Utility functions to manipulate bounding boxes, transform between formats, and\n",
     "pad bounding box Tensors with `-1s` are available from the\n",
-    "[`keras_cv.bounding_box`](https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box)\n",
+    "[`keras_cv.bounding_box`](https://github.com/keras-team/keras-cv/tree/master/keras_cv/src/bounding_box)\n",
     "package."
    ]
   },

--- a/guides/ipynb/keras_tuner/custom_tuner.ipynb
+++ b/guides/ipynb/keras_tuner/custom_tuner.ipynb
@@ -50,7 +50,7 @@
     "In this guide, we will subclass the `HyperModel` class and write a custom\n",
     "training loop by overriding `HyperModel.fit()`. For how to write a custom\n",
     "training loop with Keras, you can refer to the guide\n",
-    "[Writing a training loop from scratch](https://keras.io/guides/writing_a_training_loop_from_scratch/).\n",
+    "[Writing a training loop from scratch](https://keras.io/guides/writing_a_custom_training_loop_in_tensorflow/).\n",
     "\n",
     "First, we import the libraries we need, and we create datasets for training and\n",
     "validation. Here, we just use some random data for demonstration purposes."
@@ -215,8 +215,7 @@
     "            best_epoch_loss = min(best_epoch_loss, epoch_loss)\n",
     "\n",
     "        # Return the evaluation metric value.\n",
-    "        return best_epoch_loss\n",
-    ""
+    "        return best_epoch_loss\n"
    ]
   },
   {
@@ -247,8 +246,7 @@
     "    directory=\"results\",\n",
     "    project_name=\"custom_training\",\n",
     "    overwrite=True,\n",
-    ")\n",
-    ""
+    ")\n"
    ]
   },
   {


### PR DESCRIPTION
Updated broken links in:
- examples/generative/ipynb/gpt2_text_generation_with_keras_hub.ipynb
- guides/ipynb/keras_cv/coco_metrics.ipynb
- guides/ipynb/keras_tuner/custom_tuner.ipynb