### PR TITLE
Fix typo in `KerasHub Model Architectures` documentation under `Bart model`

### DIFF
--- a/scripts/hub_master.py
+++ b/scripts/hub_master.py
@@ -281,19 +281,19 @@ MODELS_MASTER = {
             "children": [
                 {
                     "path": "bart_tokenizer",
-                    "title": "BertTokenizer",
+                    "title": "BartTokenizer",
                     "generate": [
-                        "keras_hub.tokenizers.BertTokenizer",
-                        "keras_hub.tokenizers.BertTokenizer.from_preset",
+                        "keras_hub.tokenizers.BartTokenizer",
+                        "keras_hub.tokenizers.BartTokenizer.from_preset",
                     ],
                 },
                 {
                     "path": "bart_backbone",
-                    "title": "BertBackbone model",
+                    "title": "BartBackbone model",
                     "generate": [
-                        "keras_hub.models.BertBackbone",
-                        "keras_hub.models.BertBackbone.from_preset",
-                        "keras_hub.models.BertBackbone.token_embedding",
+                        "keras_hub.models.BartBackbone",
+                        "keras_hub.models.BartBackbone.from_preset",
+                        "keras_hub.models.BartBackbone.token_embedding",
                     ],
                 },
                 {


### PR DESCRIPTION
The [KerasHub Model Architectures documentation](https://keras.io/keras_hub/api/models/) for the `Bart Model` incorrectly lists `BertTokenizer` and `BertBackbone model`.

![image](https://github.com/user-attachments/assets/72c29951-4d92-42c0-ba7c-99bce91a43c7)
