### PR TITLE
Fixes `bert_vocab_uncased.txt` dataset links

### DIFF
--- a/guides/ipynb/keras_hub/transformer_pretraining.ipynb
+++ b/guides/ipynb/keras_hub/transformer_pretraining.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "# Download vocabulary data.\n",
     "vocab_file = keras.utils.get_file(\n",
-    "    origin=\"https://storage.googleapis.com/tensorflow/keras-hub/examples/bert/bert_vocab_uncased.txt\",\n",
+    "    origin=\"https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert/bert_vocab_uncased.txt\",\n",
     ")"
    ]
   },

--- a/guides/keras_hub/transformer_pretraining.py
+++ b/guides/keras_hub/transformer_pretraining.py
@@ -72,7 +72,7 @@ sst_dir = os.path.expanduser("~/.keras/datasets/SST-2/")
 
 # Download vocabulary data.
 vocab_file = keras.utils.get_file(
-    origin="https://storage.googleapis.com/tensorflow/keras-hub/examples/bert/bert_vocab_uncased.txt",
+    origin="https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert/bert_vocab_uncased.txt",
 )
 
 """

--- a/guides/md/keras_hub/transformer_pretraining.md
+++ b/guides/md/keras_hub/transformer_pretraining.md
@@ -78,7 +78,7 @@ sst_dir = os.path.expanduser("~/.keras/datasets/SST-2/")
 
 # Download vocabulary data.
 vocab_file = keras.utils.get_file(
-    origin="https://storage.googleapis.com/tensorflow/keras-hub/examples/bert/bert_vocab_uncased.txt",
+    origin="https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert/bert_vocab_uncased.txt",
 )
 ```
 


### PR DESCRIPTION
Presently the links for the `bert_vocab_uncased.txt` point to https://storage.googleapis.com/tensorflow/keras-hub/examples/bert/bert_vocab_uncased.txt which doesn't lead anywhere. This PR replaces the link with https://storage.googleapis.com/tensorflow/keras-nlp/examples/bert/bert_vocab_uncased.txt

This seems to have broken during a previous renaming exercise renaming `keras-nlp` -> `keras-hub`.