### PR TITLE
 Add API doc for BasNet,Efficientnet,ViT,SegFormer,RetinaNet,MobileNet

### DIFF
--- a/scripts/hub_master.py
+++ b/scripts/hub_master.py
@@ -509,52 +509,6 @@ MODELS_MASTER = {
                 },
             ],
         },
-        """
-        # Code is not available in keras-hub v0.19.1(stable),
-        # Will be enabled once it is available to generate the API doc.
-        {
-            "path": "cspnet/",
-            "title": "CSPNet",
-            "toc": True,
-            "children": [
-                {
-                    "path": "cspnet_image_converter",
-                    "title": "CSPNetImageConverter",
-                    "generate": [
-                        "keras_hub.layers.CSPNetImageConverter",
-                        "keras_hub.layers.CSPNetImageConverter.from_preset",
-                    ],
-                },
-                {
-                    "path": "cspnet_backbone",
-                    "title": "CSPNetBackbone model",
-                    "generate": [
-                        "keras_hub.models.CSPNetBackbone",
-                        "keras_hub.models.CSPNetBackbone.from_preset",
-                    ],
-                },
-                {
-                    "path": "cspnet_image_classifier",
-                    "title": "CSPNetImageClassifier model",
-                    "generate": [
-                        "keras_hub.models.CSPNetImageClassifier",
-                        "keras_hub.models.CSPNetImageClassifier.from_preset",
-                        "keras_hub.models.CSPNetImageClassifier.backbone",
-                        "keras_hub.models.CSPNetImageClassifier.preprocessor",
-                    ],
-                },
-                {
-                    "path": "cspnet_image_classifier_preprocessor",
-                    "title": "CSPNetImageClassifierPreprocessor layer",
-                    "generate": [
-                        "keras_hub.models.CSPNetImageClassifierPreprocessor",
-                        "keras_hub.models.CSPNetImageClassifierPreprocessor.from_preset",
-                        "keras_hub.models.CSPNetImageClassifierPreprocessor.image_converter",
-                    ],
-                },
-            ],
-        },
-        """
         {
             "path": "deberta_v3/",
             "title": "DebertaV3",


### PR DESCRIPTION
Adding Missing API doc for Keras Hub Models BasNet,Efficientnet,ViT,SegFormer,RetinaNet,MobileNet.