### PR TITLE
Fix CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ tensorflow==2.18.1
 keras-cv
 keras-nlp
 keras-tuner
-tf_keras==2.18.0
+tf-keras==2.18.0
 keras-hub

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ keras-nlp
 keras-tuner
 tf-keras==2.18.0
 keras-hub
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ pandas
 jupyter
 pydot
 boto3
-tensorflow
+tensorflow==2.18.1
 keras-cv
 keras-nlp
 keras-tuner
-tf_keras
-keras-hub-nightly  # TODO: update to keras-hub.
+tf_keras==2.18.0
+keras-hub

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -32,9 +32,9 @@ EXAMPLES_GH_LOCATION = Path("keras-team") / "keras-io" / "blob" / "master" / "ex
 GUIDES_GH_LOCATION = Path("keras-team") / "keras-io" / "blob" / "master" / "guides"
 KERAS_TEAM_GH = "https://github.com/keras-team"
 PROJECT_URL = {
-    "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.9.0/",
+    "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.9.1/",
     "keras_tuner": f"{KERAS_TEAM_GH}/keras-tuner/tree/v1.4.7/",
-    "keras_hub": f"{KERAS_TEAM_GH}/keras-hub/tree/v0.19.1/",
+    "keras_hub": f"{KERAS_TEAM_GH}/keras-hub/tree/v0.19.3/",
     "tf_keras": f"{KERAS_TEAM_GH}/tf-keras/tree/v2.18.0/",
 }
 USE_MULTIPROCESSING = False


### PR DESCRIPTION
`tf-keras==2.19` requires `tensorflow==2.19` but the latest version of `tf-text` is `2.18` and requires `tensorflow==2.18` which creates a requirements conflict. To workaround this issue, we pin `tf-keras==2.18` to remove the strict dependency on `tensorflow==2.19`.

This PR also updates the `keras` and `keras-hub` to their latest version.