### PR TITLE
Update transformer_asr.py

### DIFF
--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -372,7 +372,7 @@ def path_to_audio(path):
     # normalisation
     means = tf.math.reduce_mean(x, 1, keepdims=True)
     stddevs = tf.math.reduce_std(x, 1, keepdims=True)
-    x = (x - means) / stddevs
+    x = (x - means) / (stddevs + 1e-10)
     audio_len = tf.shape(x)[0]
     # padding to 10 seconds
     pad_len = 2754


### PR DESCRIPTION
Add small epsilon (1e-10) to stddevs to prevent division by zero

Modified the normalization step by adding a small constant to stddevs  to avoid potential division by zero errors when standard deviation is zero.