### PR TITLE
Move Keras 2 apis to a constant url

### DIFF
--- a/scripts/keras2_api_master.py
+++ b/scripts/keras2_api_master.py
@@ -6,18 +6,11 @@ except Exception as e:
 
 if tf_keras:
     parts = tf_keras.__version__.split(".")
-    tf_keras_version = parts[0] + "." + parts[1]
+    tf_keras_version = parts[0]
 else:
     tf_keras_version = "None"
 
 
-# In order to refresh the pages for an old version (e.g. 2.14)
-# You will need to re-run `python autogen.py make` after updating
-# the tf_keras version in autogen.py and making sure to install
-# the targeted keras_version locally. When you do this
-# `/2.14/api/` (for instance) will be regenerated. You can then
-# just reupload, which won't affect the directories for any other
-# version number.
 KERAS2_API_MASTER = {
     "path": tf_keras_version + "/api/",
     "title": "Keras 2 API documentation",

--- a/theme/base.html
+++ b/theme/base.html
@@ -65,8 +65,8 @@
   <div class="k-page">
     <div class="hidden">
       {% set related_nav_urls_map = {
-        "/api/": ["/2.18/api/"],
-        "/2.18/api/": ["/api/"],
+        "/api/": ["/2/api/"],
+        "/2/api/": ["/api/"],
       } %}
       {% set vars = {'related_urls': [], 'active_url': ''} %}
       {% for item in nav %}


### PR DESCRIPTION
We had the idea of a rolling Keras 2 api url, that would append to the set of files we publish on keras.io. It's broken for a couple reasons:

1. The site might change between tf version, and we don't want to serve old versions of pages from the site hoping that they match up.
2. We should have a stable url for the latest keras 2 api for things like SEO. We don't have that!

We should only serve what we can build from the current version of the site. If we want rolling selectable API versions, we should do so by extending our site build to be able to build all Keras 2 versions we care about when we render.