### PR TITLE
Fix incorrect reference to model in Transformer class

### DIFF
--- a/examples/audio/transformer_asr.py
+++ b/examples/audio/transformer_asr.py
@@ -247,7 +247,7 @@ class Transformer(keras.Model):
             preds = self([source, dec_input])
             one_hot = tf.one_hot(dec_target, depth=self.num_classes)
             mask = tf.math.logical_not(tf.math.equal(dec_target, 0))
-            loss = model.compute_loss(None, one_hot, preds, sample_weight=mask)
+            loss = self.compute_loss(None, one_hot, preds, sample_weight=mask)
         trainable_vars = self.trainable_variables
         gradients = tape.gradient(loss, trainable_vars)
         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
@@ -262,7 +262,7 @@ class Transformer(keras.Model):
         preds = self([source, dec_input])
         one_hot = tf.one_hot(dec_target, depth=self.num_classes)
         mask = tf.math.logical_not(tf.math.equal(dec_target, 0))
-        loss = model.compute_loss(None, one_hot, preds, sample_weight=mask)
+        loss = self.compute_loss(None, one_hot, preds, sample_weight=mask)
         self.loss_metric.update_state(loss)
         return {"loss": self.loss_metric.result()}
 


### PR DESCRIPTION
**Description:**
In the train_step and test_step methods of the Transformer class, there's a reference to model.compute_loss() which should be self.compute_loss() instead. Since we're inside the class methods, we should use self to refer to the current instance of the model.

**Files Changed:**

[transformer_asr.py](https://github.com/keras-team/keras-io/blob/master/examples/audio/transformer_asr.py#L182)

**Changes Made:**

Replaced model.compute_loss() with self.compute_loss() in both train_step and test_step methods

**Impact:**
This correction ensures proper access to the parent class's compute_loss method through the correct instance reference. The original code would raise a NameError since model is not defined in this context, while self properly refers to the current Transformer instance.