### PR TITLE
Update tf-keras version to 2.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ pandas
 jupyter
 pydot
 boto3
-tensorflow==2.18.1
+tensorflow
 keras-cv
 keras-nlp
 keras-tuner
-tf-keras==2.18.0
+tf-keras
 keras-hub
 

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -35,7 +35,7 @@ PROJECT_URL = {
     "keras": f"{KERAS_TEAM_GH}/keras/tree/v3.9.2/",
     "keras_tuner": f"{KERAS_TEAM_GH}/keras-tuner/tree/v1.4.7/",
     "keras_hub": f"{KERAS_TEAM_GH}/keras-hub/tree/v0.20.0/",
-    "tf_keras": f"{KERAS_TEAM_GH}/tf-keras/tree/v2.18.0/",
+    "tf_keras": f"{KERAS_TEAM_GH}/tf-keras/tree/v2.19.0/",
 }
 USE_MULTIPROCESSING = False
 


### PR DESCRIPTION
`tf-text` version `2.19` is released: https://pypi.org/project/tensorflow-text/2.19.0/#files

This resolves the conflict `tf` version conflict between `tf-keras` and `tf-text` so we don't have to pin `tf` and `tf-keras` versions to an older version anymore.