### PR TITLE
Compatibility fixes with newer tf versions in Keras 2 Backward compat…

### DIFF
--- a/examples/vision/nl_image_search.py
+++ b/examples/vision/nl_image_search.py
@@ -42,7 +42,6 @@ from tensorflow import keras
 from tensorflow.keras import layers
 import tensorflow_hub as hub
 import tensorflow_text as text
-import tensorflow_addons as tfa
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 from tqdm import tqdm
@@ -286,12 +285,7 @@ def create_text_encoder(
         name="text_preprocessing",
     )
     # Load the pre-trained BERT model to be used as the base encoder.
-    bert = hub.KerasLayer(
-        "https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1",
-        "bert",
-    )
-    # Set the trainability of the base encoder.
-    bert.trainable = trainable
+    bert = hub.KerasLayer("https://tfhub.dev/tensorflow/small_bert/bert_en_uncased_L-4_H-512_A-8/1",trainable=False,name="bert")
     # Receive the text as inputs.
     inputs = layers.Input(shape=(), dtype=tf.string, name="text_input")
     # Preprocess the text.
@@ -407,7 +401,7 @@ text_encoder = create_text_encoder(
 )
 dual_encoder = DualEncoder(text_encoder, vision_encoder, temperature=0.05)
 dual_encoder.compile(
-    optimizer=tfa.optimizers.AdamW(learning_rate=0.001, weight_decay=0.001)
+    optimizer=tf.keras.optimizers.AdamW(learning_rate=0.001, weight_decay=0.001)
 )
 
 """


### PR DESCRIPTION
… mode.

Multiple Bug fixes for the code to be usable with newer tf versions (tested with 2.19.0) under keras 2 compat mode : 
Change log:

* Removed TF-Addons as it doesn't work with newer version and was only being used for the AdamW optimizer which is part of keras natively now
* `Changed tf.nn.gelu` -> `tf.keras.activations.gelu` so that modern keras 2 backward compat can use it within the model api
* Updated the `hub.KerasLayer` calls to use the correct arguments 