### PR TITLE
Add RLHF guide and dummy demo with Keras/JAX

### DIFF
--- a/examples/rl/rlhf_demo.py
+++ b/examples/rl/rlhf_demo.py
@@ -9,41 +9,27 @@ Accelerator: GPU
 
 """
 # Reinforcement Learning from AI Feedback(RLAIF) - Demo Guide
-
 This guide explains the concept of  Reinforcement Learning from AI Feedback (RLAIF) and walks through the components of the accompanying script `rlhf_demo.py`.
-
 ## 1. What is Reinforcement Learning from Human Feedback (RLHF)?
-
 Reinforcement Learning (RL) is a machine learning paradigm where an agent learns to make decisions by interacting with an environment to achieve a goal. The agent receives rewards or penalties based on its actions, and it tries to maximize its cumulative reward over time.
-
 In many real-world scenarios, defining a precise reward function that perfectly captures desired behavior can be extremely challenging. For example, how do you define a reward for "writing a helpful and harmless AI assistant response"? This is where RLHF comes in.
-
 **RLHF** is a technique that incorporates human feedback into the RL process to guide the agent's learning, especially for tasks with complex or hard-to-specify objectives. Instead of relying solely on a pre-defined reward function, RLHF uses human preferences to train a separate "reward model" that learns to predict what kind of behaviors humans prefer. This learned reward model is then used to provide reward signals to the RL agent.
-
 ## 2. How RLHF Works (High-Level)
-
 The RLHF process generally involves these key stages:
-
 1.  **Pre-training a Language Model (or Policy Model):**
     Start with a base model that can generate responses or take actions. For language tasks, this is often a pre-trained language model (LM). This model acts as the initial policy.
-
 2.  **Collecting Human Feedback & Training a Reward Model:**
     *   Generate multiple outputs (e.g., text responses) from the current policy model for various prompts.
     *   Present these outputs to human evaluators, who rank them or choose the best one(s) based on desired criteria (e.g., helpfulness, safety, coherence).
     *   This collected preference data (e.g., "Response A is better than Response B for prompt X") is used to train a separate **reward model**. The reward model takes a prompt and a response (or state-action pair) as input and outputs a scalar score indicating how good that response is according to human preferences.
-
 3.  **Fine-tuning the Policy Model via RL:**
     *   The pre-trained policy model is then fine-tuned using an RL algorithm (like Proximal Policy Optimization - PPO).
     *   Instead of using a fixed reward function from the environment, the RL agent receives rewards from the **trained reward model**.
     *   The agent explores the environment (or generates responses), and the reward model scores these actions/responses. The policy model is updated to produce outputs that the reward model scores highly.
     *   Often, a constraint (e.g., a KL divergence penalty) is added to prevent the policy from diverging too much from the original pre-trained model, helping to maintain coherence and avoid reward hacking.
-
 This cycle (collecting more data, refining the reward model, and further fine-tuning the policy) can be iterated.
-
 ## 3. Walking Through `rlhf_demo.py`
-
 The `rlhf_demo.py` script provides a very simplified implementation of these concepts to illustrate the basic mechanics.
-
 **Important Note on Keras Backend:**
 This demo is configured to run with the JAX backend for Keras. This is set at the beginning of the script:
 """
@@ -68,7 +54,6 @@ def calculate_discounted_returns(rewards, gamma=0.99):
 
 """
 ### 3.1. The Environment (`SimpleEnvironment`)
-
 The script defines a very basic grid-world like environment where the agent's state is its position on a line.
 """
 # Define a simple environment (e.g., a GridWorld)
@@ -96,13 +81,11 @@ class SimpleEnvironment:
         return (1,) # State is a single integer
 
     def get_action_space_n(self):
-        return 2 # Two possible actions: left or right      
+        return 2 # Two possible actions: left or right
 """
 - The agent can move left or right.
 - It receives a "true" reward of 1 if it reaches the rightmost state (`size - 1`), otherwise 0. This "true" reward is used in the demo to simulate human feedback for training the reward model.
-
 ### 3.2. The Policy Model (`create_policy_model`)
-
 This is a simple Keras neural network that takes the current state (observation) as input and outputs probabilities for each action (left/right).
 """
 # Define a simple policy model
@@ -115,9 +98,7 @@ def create_policy_model(observation_space_shape, action_space_n):
 """
 - It's a small Multi-Layer Perceptron (MLP).
 - The `softmax` activation ensures the output represents a probability distribution over actions.
-
 ### 3.3. The Reward Model (`create_reward_model`)
-
 This Keras model is designed to predict how "good" a state-action pair is. In a real RLHF setup, this model would be trained on human preference data. In this dummy demo, it's trained using the environment's "true" reward signal as a proxy for human feedback.
 """
 # Define a simple reward model
@@ -130,9 +111,7 @@ def create_reward_model(observation_space_shape, action_space_n):
 """
 - It takes the current state and the chosen action (one-hot encoded) as input.
 - It outputs a single scalar value, representing the predicted reward.
-
 ### 3.4. The RLHF Training Loop (`rlhf_training_loop`)
-
 This function contains the core logic for the RLHF process.
 """
 # RLHF Training Loop
@@ -288,7 +267,6 @@ def rlhf_training_loop(env, policy_model, reward_model, num_episodes=10, learnin
     print("Training finished.")
 """
 **Key Parts of the Training Loop (Updated):**
-
 1.  **Initialization:** Optimizers and JAX gradient functions (`policy_value_and_grad_fn`, `reward_value_and_grad_fn`) are set up. The `policy_loss_fn` is now designed to accept a `discounted_return_for_step` argument.
 2.  **Trajectory Collection:** During each episode, the agent's experiences (states, actions taken, and the `true_reward` received from the environment) are stored.
 3.  **Reward Model Training:** The reward model continues to be trained. Its gradients are calculated based on the immediate `true_reward` (simulating feedback) and accumulated over the episode. These accumulated gradients are applied once at the end of the episode.
@@ -301,18 +279,13 @@ def rlhf_training_loop(env, policy_model, reward_model, num_episodes=10, learnin
         *   Gradients for the policy model are computed for each step and accumulated across the entire episode.
     *   **Gradient Application:** The accumulated policy gradients are averaged over the number of steps and applied to the policy model using its optimizer. This update rule aims to increase the probability of actions that lead to good long-term outcomes.
 5.  **Logging:** Average policy and reward losses for the episode are printed periodically.
-
 The core idea of RLHF is still present: we have a reward model that *could* be trained from human preferences. However, the policy update mechanism has shifted. Instead of using the reward model's output directly as the advantage signal for each step (as in the previous version of the script), the policy now learns from the actual discounted returns experienced in the episode, which is a more standard RL approach when actual rewards (or good proxies like `true_reward` here) are available for the full trajectory. In a full RLHF system, `episode_true_rewards` might themselves be replaced or augmented by the reward model's predictions if no dense "true" reward exists.
 8.  **Logging:** Periodically, average losses are printed.
-
 ## 4. How to Run the Demo
-
 To run the demo, execute the Python script from your terminal:
-
 ```bash
 python examples/rl/rlhf_demo.py
 ```
-
 This will:
 1.  Initialize the environment, policy model, and reward model.
 2.  Print summaries of the policy and reward models.


### PR DESCRIPTION
This commit introduces a new example for Reinforcement Learning from Human Feedback (RLHF).

It includes:
- \`examples/rl/rlhf_dummy_demo.py\`: A Python script demonstrating a simple RLHF loop with a dummy environment, a policy model, and a reward model, using Keras with the JAX backend.
- \`examples/rl/md/rlhf_dummy_demo.md\`: A Markdown guide explaining the RLHF concept and the implementation details of the demo script.
- \`examples/rl/README.md\`: A new README for the RL examples section, now including the RLHF demo.

Note: The Python demo script (\`rlhf_dummy_demo.py\`) currently experiences timeout issues during the training loop in the development environment, even with significantly reduced computational load. This is documented in the guide and README. The code serves as a structural example of implementing the RLHF components.