### PR TITLE
Use `keras-rs-nightly` for now.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ keras-nlp
 keras-tuner
 tf-keras
 keras-hub
-keras-rs
+keras-rs-nightly


### PR DESCRIPTION
`DistributedEmbedding` as an issue in the docstring, which was fixed here: https://github.com/keras-team/keras-rs/pull/118 However, it is not picked up by keras.io because the pip wheel was not released after the fix.

The issue only affects keras.io, so instead of creating a release just for this, we're using `keras-rs-nightly` for now.