### PR TITLE
Fix: Transformer encoder - apply LayerNorm after residual

### DIFF
--- a/examples/timeseries/timeseries_classification_transformer.py
+++ b/examples/timeseries/timeseries_classification_transformer.py
@@ -75,15 +75,16 @@ def transformer_encoder(inputs, head_size, num_heads, ff_dim, dropout=0):
         key_dim=head_size, num_heads=num_heads, dropout=dropout
     )(inputs, inputs)
     x = layers.Dropout(dropout)(x)
-    x = layers.LayerNormalization(epsilon=1e-6)(x)
     res = x + inputs
+    x = layers.LayerNormalization(epsilon=1e-6)(res) 
 
     # Feed Forward Part
-    x = layers.Conv1D(filters=ff_dim, kernel_size=1, activation="relu")(res)
+    x = layers.Conv1D(filters=ff_dim, kernel_size=1, activation="relu")(x)
     x = layers.Dropout(dropout)(x)
     x = layers.Conv1D(filters=inputs.shape[-1], kernel_size=1)(x)
-    x = layers.LayerNormalization(epsilon=1e-6)(x)
-    return x + res
+    res = x + res
+    x = layers.LayerNormalization(epsilon=1e-6)(res)
+    return x
 
 
 """


### PR DESCRIPTION
This PR fixes the Transformer encoder to properly apply Layer Normalization after the residual connections, in accordance with the specification from the [Attention is All You Need" (Vaswani et al., 2017)](https://arxiv.org/abs/1706.03762) paper. 

Previously, Layer Normalization was incorrectly applied before the residual connection, which violated the design outlined in Section 3.1 of "Attention is All You Need," where it states: "the output of each sub-layer is`LayerNorm(x + Sublayer(x))`". 

This update ensures that Layer Normalization is applied after the residual addition in both the attention and feed-forward sub-layers. 

Fixes : [#1256 ](https://github.com/keras-team/keras-io/issues/1256)
