### PR TITLE
Update meta description tag to contain the specific title of the page.

### DIFF
--- a/theme/base.html
+++ b/theme/base.html
@@ -5,7 +5,7 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Keras documentation">
+  <meta name="description" content="Keras documentation: {{title}}">
   <meta name="author" content="Keras Team">
   <link rel="shortcut icon" href="https://keras.io/img/favicon.ico">
   {% if relative_url %}


### PR DESCRIPTION
Every page had a fixed `<meta name="description" content="Keras documentation">` tag. It now contains the title of the page, which is more specific because it has the API name for instance.

Google search in particular looks at this tag, and this tag only, for indexing [Documentation](https://developers.google.com/search/docs/crawling-indexing/special-tags#meta-tags). The hope is that it will improve search results.

This also makes it consistent with other meta tags like `<meta property="og:title" content="...">`.