### PR TITLE
add survey to nav bar

### DIFF
--- a/theme/base.html
+++ b/theme/base.html
@@ -129,6 +129,7 @@
           '/keras_tuner/': 'Keras Tuner',
           '/keras_rs/': 'Keras RS',
           '/keras_hub/': 'Keras Hub',
+          'https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC': '2025 Survey',
           } %}
           <ul class="nav__item--container">
             {% for key, value in main_nav_items.items() %}

--- a/theme/keras_3.html
+++ b/theme/keras_3.html
@@ -99,6 +99,7 @@
           <a class="nav-link" href="/2.18/api/" role="tab" aria-selected="">Keras 2 API documentation</a>
           <a class="nav-link" href="/keras_tuner/" role="tab" aria-selected="">KerasTuner: Hyperparam Tuning</a>
           <a class="nav-link" href="/keras_hub/" role="tab" aria-selected="">KerasHub: Pretrained Models</a>
+          <a class="nav-link" href="https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC" role="tab" aria-selected="" style="color:blue;">2025 Survey</a>
         </div>
       </div>
       <a href="/">
@@ -121,6 +122,7 @@
           <li class="nav__item"><a class="nav__link" href="/keras_tuner/">KERAS TUNER</a></li>
           <li class="nav__item"><a class="nav__link" href="/keras_rs/">KERAS RS</a></li>
           <li class="nav__item"><a class="nav__link" href="/keras_hub/">KERAS HUB</a></li>
+          <li class="nav__item"><a class="nav__link" href="https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC" style="color:blue;">2025 SURVEY</a></li>
         </ul>
 
         <form class="nav__search">

--- a/theme/landing.html
+++ b/theme/landing.html
@@ -127,6 +127,7 @@
             <a class="nav-link" href="/2.18/api/" role="tab" aria-selected="">Keras 2 API documentation</a>
             <a class="nav-link" href="/keras_tuner/" role="tab" aria-selected="">KerasTuner: Hyperparam Tuning</a>
             <a class="nav-link" href="/keras_hub/" role="tab" aria-selected="">KerasHub: Pretrained Models</a>
+            <a class="nav-link" href="https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC" role="tab" aria-selected="">Take Our Survey!</a>
           </div>
         </div>
         <a href="/">
@@ -149,6 +150,7 @@
             <li class="nav__item"><a class="nav__link" href="/keras_tuner/">KERAS TUNER</a></li>
             <li class="nav__item"><a class="nav__link" href="/keras_rs/">KERAS RS</a></li>
             <li class="nav__item"><a class="nav__link" href="/keras_hub/">KERAS HUB</a></li>
+            <li class="nav__item"><a class="nav__link" href="https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC" style="color:blue;">2025 SURVEY</a></li>
           </ul>
 
           <form class="nav__search">
@@ -170,7 +172,7 @@
       <div class="hero">
         <div class="hero__content--wrapper">
           <div class="hero__content">
-            <a class="button__round" href="/keras_3/">KERAS 3.0 RELEASED</a>
+            <a class="button__round" href="https://google.qualtrics.com/jfe/form/SV_5psTvNYQKv2mAwC">TAKE OUR SURVEY!</a>
 
             <h1 class="hero__title text--white">A superpower for ML developers</h1>
 


### PR DESCRIPTION
This change adds a link to the survey in two places: (1) nav bar  (2) announcement chip, see image attached.

<img width="2856" height="1152" alt="dq3Pjb2FgwwNuab" src="https://github.com/user-attachments/assets/77f43b01-f5ad-4525-9f9a-9ec73e8705c9" />




