### PR TITLE
Fixes to `neural_machine_translation_with_keras_hub` example.

### DIFF
--- a/examples/nlp/ipynb/neural_machine_translation_with_keras_hub.ipynb
+++ b/examples/nlp/ipynb/neural_machine_translation_with_keras_hub.ipynb
@@ -69,8 +69,7 @@
    "outputs": [],
    "source": [
     "!pip install -q --upgrade rouge-score\n",
-    "!pip install -q --upgrade keras-hub\n",
-    "!pip install -q --upgrade keras  # Upgrade to Keras 3."
+    "!pip install -q --upgrade keras-hub"
    ]
   },
   {
@@ -88,10 +87,7 @@
     "import keras\n",
     "from keras import ops\n",
     "\n",
-    "import tensorflow.data as tf_data\n",
-    "from tensorflow_text.tools.wordpiece_vocab import (\n",
-    "    bert_vocab_from_dataset as bert_vocab,\n",
-    ")"
+    "import tensorflow.data as tf_data"
    ]
   },
   {
@@ -147,7 +143,7 @@
     "    origin=\"http://storage.googleapis.com/download.tensorflow.org/data/spa-eng.zip\",\n",
     "    extract=True,\n",
     ")\n",
-    "text_file = pathlib.Path(text_file).parent / \"spa-eng\" / \"spa.txt\""
+    "text_file = pathlib.Path(text_file) / \"spa-eng\" / \"spa.txt\""
    ]
   },
   {
@@ -435,8 +431,6 @@
    "source": [
     "\n",
     "def preprocess_batch(eng, spa):\n",
-    "    batch_size = ops.shape(spa)[0]\n",
-    "\n",
     "    eng = eng_tokenizer(eng)\n",
     "    spa = spa_tokenizer(spa)\n",
     "\n",
@@ -659,12 +653,15 @@
     "    batch_size = 1\n",
     "\n",
     "    # Tokenize the encoder input.\n",
-    "    encoder_input_tokens = ops.convert_to_tensor(eng_tokenizer(input_sentences))\n",
-    "    if len(encoder_input_tokens[0]) < MAX_SEQUENCE_LENGTH:\n",
-    "        pads = ops.full((1, MAX_SEQUENCE_LENGTH - len(encoder_input_tokens[0])), 0)\n",
-    "        encoder_input_tokens = ops.concatenate(\n",
-    "            [encoder_input_tokens.to_tensor(), pads], 1\n",
+    "    encoder_input_tokens = ops.convert_to_tensor(\n",
+    "        eng_tokenizer(input_sentences), sparse=False, ragged=False\n",
+    "    )\n",
+    "    if ops.shape(encoder_input_tokens)[1] < MAX_SEQUENCE_LENGTH:\n",
+    "        pads = ops.zeros(\n",
+    "            (1, MAX_SEQUENCE_LENGTH - ops.shape(encoder_input_tokens)[1]),\n",
+    "            dtype=encoder_input_tokens.dtype,\n",
     "        )\n",
+    "        encoder_input_tokens = ops.concatenate([encoder_input_tokens, pads], 1)\n",
     "\n",
     "    # Define a function that outputs the next token's probability given the\n",
     "    # input sequence.\n",
@@ -693,8 +690,7 @@
     "test_eng_texts = [pair[0] for pair in test_pairs]\n",
     "for i in range(2):\n",
     "    input_sentence = random.choice(test_eng_texts)\n",
-    "    translated = decode_sequences([input_sentence])\n",
-    "    translated = translated.numpy()[0].decode(\"utf-8\")\n",
+    "    translated = decode_sequences([input_sentence])[0]\n",
     "    translated = (\n",
     "        translated.replace(\"[PAD]\", \"\")\n",
     "        .replace(\"[START]\", \"\")\n",
@@ -740,8 +736,7 @@
     "    input_sentence = test_pair[0]\n",
     "    reference_sentence = test_pair[1]\n",
     "\n",
-    "    translated_sentence = decode_sequences([input_sentence])\n",
-    "    translated_sentence = translated_sentence.numpy()[0].decode(\"utf-8\")\n",
+    "    translated_sentence = decode_sequences([input_sentence])[0]\n",
     "    translated_sentence = (\n",
     "        translated_sentence.replace(\"[PAD]\", \"\")\n",
     "        .replace(\"[START]\", \"\")\n",

--- a/examples/nlp/neural_machine_translation_with_keras_hub.py
+++ b/examples/nlp/neural_machine_translation_with_keras_hub.py
@@ -46,7 +46,6 @@ Before we start implementing the pipeline, let's import all the libraries we nee
 """shell
 pip install -q --upgrade rouge-score
 pip install -q --upgrade keras-hub
-pip install -q --upgrade keras  # Upgrade to Keras 3.
 """
 
 import keras_hub
@@ -57,9 +56,6 @@ import keras
 from keras import ops
 
 import tensorflow.data as tf_data
-from tensorflow_text.tools.wordpiece_vocab import (
-    bert_vocab_from_dataset as bert_vocab,
-)
 
 """
 Let's also define our parameters/hyperparameters.
@@ -87,7 +83,7 @@ text_file = keras.utils.get_file(
     origin="http://storage.googleapis.com/download.tensorflow.org/data/spa-eng.zip",
     extract=True,
 )
-text_file = pathlib.Path(text_file).parent / "spa-eng" / "spa.txt"
+text_file = pathlib.Path(text_file) / "spa-eng" / "spa.txt"
 
 """
 ## Parsing the data
@@ -249,8 +245,6 @@ This can be easily done using `keras_hub.layers.StartEndPacker`.
 
 
 def preprocess_batch(eng, spa):
-    batch_size = ops.shape(spa)[0]
-
     eng = eng_tokenizer(eng)
     spa = spa_tokenizer(spa)
 
@@ -417,12 +411,15 @@ def decode_sequences(input_sentences):
     batch_size = 1
 
     # Tokenize the encoder input.
-    encoder_input_tokens = ops.convert_to_tensor(eng_tokenizer(input_sentences))
-    if len(encoder_input_tokens[0]) < MAX_SEQUENCE_LENGTH:
-        pads = ops.full((1, MAX_SEQUENCE_LENGTH - len(encoder_input_tokens[0])), 0)
-        encoder_input_tokens = ops.concatenate(
-            [encoder_input_tokens.to_tensor(), pads], 1
+    encoder_input_tokens = ops.convert_to_tensor(
+        eng_tokenizer(input_sentences), sparse=False, ragged=False
+    )
+    if ops.shape(encoder_input_tokens)[1] < MAX_SEQUENCE_LENGTH:
+        pads = ops.zeros(
+            (1, MAX_SEQUENCE_LENGTH - ops.shape(encoder_input_tokens)[1]),
+            dtype=encoder_input_tokens.dtype,
         )
+        encoder_input_tokens = ops.concatenate([encoder_input_tokens, pads], 1)
 
     # Define a function that outputs the next token's probability given the
     # input sequence.
@@ -451,8 +448,7 @@ def decode_sequences(input_sentences):
 test_eng_texts = [pair[0] for pair in test_pairs]
 for i in range(2):
     input_sentence = random.choice(test_eng_texts)
-    translated = decode_sequences([input_sentence])
-    translated = translated.numpy()[0].decode("utf-8")
+    translated = decode_sequences([input_sentence])[0]
     translated = (
         translated.replace("[PAD]", "")
         .replace("[START]", "")
@@ -484,8 +480,7 @@ for test_pair in test_pairs[:30]:
     input_sentence = test_pair[0]
     reference_sentence = test_pair[1]
 
-    translated_sentence = decode_sequences([input_sentence])
-    translated_sentence = translated_sentence.numpy()[0].decode("utf-8")
+    translated_sentence = decode_sequences([input_sentence])[0]
     translated_sentence = (
         translated_sentence.replace("[PAD]", "")
         .replace("[START]", "")


### PR DESCRIPTION
This example was no longer running beause of:
- breaking change in `get_file`.
- use of `to_tensor` on a non-ragged tensor, which was replaced with the cross-backend `convert_to_tensor(ragged=False)`.
- decoding of string that was no longer needed.

Fixes https://github.com/keras-team/keras-io/issues/2176