### PR TITLE
Generate Documentation for STFTSpectrogram layer

### DIFF
--- a/scripts/api_master.py
+++ b/scripts/api_master.py
@@ -747,11 +747,11 @@ API_MASTER = {
                                     "title": "MelSpectrogram layer",
                                     "generate": ["keras.layers.MelSpectrogram"],
                                 },
-                                # {
-                                #     "path": "stft_spectrogram",
-                                #     "title": "STFTSpectrogram layer",
-                                #     "generate": ["keras.layers.STFTSpectrogram"],
-                                # },
+                                {
+                                    "path": "stft_spectrogram",
+                                    "title": "STFTSpectrogram layer",
+                                    "generate": ["keras.layers.STFTSpectrogram"],
+                                },
                             ],
                         },
                     ],


### PR DESCRIPTION
`STFTSpectogram` Layer was added in this [PR](https://github.com/keras-team/keras/pull/20313), there is no documentation for it in keras.io

I have uncommented the `STFTSpectogram` layer part in the API Master file to generate the documentation. This part was previously commented out in this [PR](https://github.com/keras-team/keras-io/pull/1971) 