### PR TITLE
Fix WGAN GP Example Notebook

### DIFF
--- a/examples/generative/ipynb/wgan_gp.ipynb
+++ b/examples/generative/ipynb/wgan_gp.ipynb
@@ -564,7 +564,7 @@
     "display(Image(\"generated_img_1_19.png\"))\n",
     "display(Image(\"generated_img_2_19.png\"))"
    ]
-  },
+  }
  ],
  "metadata": {
   "accelerator": "GPU",


### PR DESCRIPTION
There was an extra comma in [wgan_gp.ipynb](https://colab.sandbox.google.com/github/keras-team/keras-io/blob/master/examples/generative/ipynb/wgan_gp.ipynb) that was breaking the notebook. 

<img width="1676" height="1016" alt="image" src="https://github.com/user-attachments/assets/ab4bff0d-66b6-4499-9450-62a9559fd5e4" />
