### PR TITLE
Fix typos in Getting Started With KerasHub

### DIFF
--- a/guides/ipynb/keras_hub/getting_started.ipynb
+++ b/guides/ipynb/keras_hub/getting_started.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "1. Go to the [Gemma 2](https://www.kaggle.com/models/keras/gemma2) model page, and accept\n",
     "   the license at the banner at the top.\n",
-    "2. Generate an Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)\n",
+    "2. Generate a Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)\n",
     "   and clicking \"Create New Token\" button under the \"API\" section.\n",
     "3. Inside your colab notebook, click on the key icon on the left hand toolbar. Add two\n",
     "   secrets: `KAGGLE_USERNAME` with your username, and `KAGGLE_KEY` with the API key you just\n",
@@ -169,7 +169,7 @@
     "    range, or resizing inputs to a specific size. This class encapsulates the image-specific\n",
     "    preprocessing.\n",
     "  * **Inherits from**: `keras.layers.Layer`.\n",
-    "* **AudioConveter**: `keras_hub.layers.AudioConveter`.\n",
+    "* **AudioConverter**: `keras_hub.layers.AudioConverter`.\n",
     "  * **What it does**: Converts raw audio to model ready input.\n",
     "  * **Why it's important**: Audio models often need to preprocess raw audio input before\n",
     "    passing it to a model, e.g. by computing a spectrogram of the audio signal. This class\n",
@@ -181,7 +181,7 @@
     "`keras_hub.tokenizers.Tokenizer.from_preset(\"gemma2_2b_en\")` will create a layer that\n",
     "tokenizes text using a Gemma2 tokenizer vocabulary.\n",
     "\n",
-    "The figure below shows how all these core classes interact. Arrow indicate composition\n",
+    "The figure below shows how all these core classes interact. Arrows indicate composition\n",
     "not inheritance (e.g., a task *has a* backbone).\n",
     "\n",
     "![png](/img/guides/getting_started/class-diagram.png)"
@@ -294,7 +294,7 @@
     "can view the full list of models shipped directly by the Keras team on\n",
     "[Kaggle](https://www.kaggle.com/organizations/keras/models).\n",
     "\n",
-    "A task is just a subclass of `keras.Model` \u2014 you can use `fit()`, `compile()`, and\n",
+    "A task is just a subclass of `keras.Model` — you can use `fit()`, `compile()`, and\n",
     "`save()` on our `classifier` object same as any other model. But tasks come with a few\n",
     "extras provided by the KerasHub library. The first and most important is `from_preset()`,\n",
     "a special constructor you will see on many classes in KerasHub.\n",
@@ -320,7 +320,7 @@
     "specific outputs, depending on what we are trying to do with the model.\n",
     "\n",
     "A **preprocessor** is just a Keras layer that does all the preprocessing for a specific\n",
-    "task. In our case, preprocessing with will resize our input image and rescale it to the\n",
+    "task. In our case, preprocessing will resize our input image and rescale it to the\n",
     "range `[0, 1]` using some ImageNet specific mean and variance data. Let's call our\n",
     "task's preprocessor and backbone in succession to see what happens to our input shape."
    ]
@@ -347,7 +347,7 @@
    },
    "source": [
     "Our raw image is rescaled to `(224, 224)` during preprocessing and finally\n",
-    "downscaled to a `(7, 7)` image of 2048 feature vectors \u2014 the latent space of the\n",
+    "downscaled to a `(7, 7)` image of 2048 feature vectors — the latent space of the\n",
     "ResNet model. Note that ResNet can actually handle images of arbitrary sizes,\n",
     "though performance will eventually fall off if your image is very different\n",
     "sized than the pretrained data. If you'd like to disable the resizing in the\n",
@@ -562,7 +562,7 @@
     "The net effect is that we will explore our model's distribution much more broadly each\n",
     "time we generate output. Generation will now be a random process, each time we re-run\n",
     "generate we will get a different result. We can note that the results feel \"looser\" than\n",
-    "greedy search \u2014 more minor mistakes and a less consistent tone.\n",
+    "greedy search — more minor mistakes and a less consistent tone.\n",
     "\n",
     "You can look at all the samplers Keras supports at [keras_hub.samplers](https://keras.io/api/keras_hub/samplers/).\n",
     "\n",
@@ -841,8 +841,8 @@
     "Huggingface models hub and share them with others. `keras_hub.upload_preset` allows you\n",
     "to upload a saved preset.\n",
     "\n",
-    "In this case, we will upload to Kaggle. We have already authenticated with Kaggle to,\n",
-    "download the Gemma model earlier. Running the following cell well upload a new model\n",
+    "In this case, we will upload to Kaggle. We have already authenticated with Kaggle to\n",
+    "download the Gemma model earlier. Running the following cell will upload a new model\n",
     "to Kaggle."
    ]
   },
@@ -980,7 +980,7 @@
     "colab_type": "text"
    },
    "source": [
-    "The IMDb dataset contrains a large amount of unlabeled movie reviews. We don't need those\n",
+    "The IMDb dataset contains a large amount of unlabeled movie reviews. We don't need those\n",
     "here, we can simply delete them."
    ]
   },
@@ -1119,8 +1119,7 @@
     "        \"token_ids\": x,\n",
     "        \"padding_mask\": x != tokenizer.pad_token_id,\n",
     "    }\n",
-    "    return keras.utils.pack_x_y_sample_weight(x, y)\n",
-    ""
+    "    return keras.utils.pack_x_y_sample_weight(x, y)\n"
    ]
   },
   {
@@ -1185,7 +1184,7 @@
     "\n",
     "Since the Gemma model is a generative model, information only passed from left to right\n",
     "in the sequence. The only token representation that can \"see\" the entire movie review\n",
-    "input is the final token in each review. We can write a simple pooling layer to do this \u2014\n",
+    "input is the final token in each review. We can write a simple pooling layer to do this —\n",
     "we will simply grab the last non-padding position of each input sequence. There's no special\n",
     "process to writing a layer like this, we can use Keras and `keras.ops` normally."
    ]
@@ -1206,8 +1205,7 @@
     "        end_positions = ops.sum(padding_mask, axis=1, keepdims=True) - 1\n",
     "        end_positions = ops.cast(end_positions, \"int\")[:, :, None]\n",
     "        outputs = ops.take_along_axis(inputs, end_positions, axis=1)\n",
-    "        return ops.squeeze(outputs, axis=1)\n",
-    ""
+    "        return ops.squeeze(outputs, axis=1)\n"
    ]
   },
   {
@@ -1291,7 +1289,7 @@
     "colab_type": "text"
    },
    "source": [
-    "After enabling LoRA, our model goes from 10GB of traininable parameters to just 20MB.\n",
+    "After enabling LoRA, our model goes from 10GB of trainable parameters to just 20MB.\n",
     "That means the space used by optimizer variables will no longer be a concern.\n",
     "\n",
     "With all that set up, we can compile and train our model as normal."

--- a/guides/keras_hub/getting_started.py
+++ b/guides/keras_hub/getting_started.py
@@ -65,7 +65,7 @@ guide, so we can follow the following steps:
 
 1. Go to the [Gemma 2](https://www.kaggle.com/models/keras/gemma2) model page, and accept
    the license at the banner at the top.
-2. Generate an Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)
+2. Generate a Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)
    and clicking "Create New Token" button under the "API" section.
 3. Inside your colab notebook, click on the key icon on the left hand toolbar. Add two
    secrets: `KAGGLE_USERNAME` with your username, and `KAGGLE_KEY` with the API key you just
@@ -116,7 +116,7 @@ Before we begin, let's take a look at the key classes we will use in the KerasHu
     range, or resizing inputs to a specific size. This class encapsulates the image-specific
     preprocessing.
   * **Inherits from**: `keras.layers.Layer`.
-* **AudioConveter**: `keras_hub.layers.AudioConveter`.
+* **AudioConverter**: `keras_hub.layers.AudioConverter`.
   * **What it does**: Converts raw audio to model ready input.
   * **Why it's important**: Audio models often need to preprocess raw audio input before
     passing it to a model, e.g. by computing a spectrogram of the audio signal. This class
@@ -128,7 +128,7 @@ the component with weights and state for the given pre-trained model identifier.
 `keras_hub.tokenizers.Tokenizer.from_preset("gemma2_2b_en")` will create a layer that
 tokenizes text using a Gemma2 tokenizer vocabulary.
 
-The figure below shows how all these core classes interact. Arrow indicate composition
+The figure below shows how all these core classes interact. Arrows indicate composition
 not inheritance (e.g., a task *has a* backbone).
 
 ![png](/img/guides/getting_started/class-diagram.png)
@@ -215,7 +215,7 @@ pretrained model's latent space. We can then map this latent space to any number
 specific outputs, depending on what we are trying to do with the model.
 
 A **preprocessor** is just a Keras layer that does all the preprocessing for a specific
-task. In our case, preprocessing with will resize our input image and rescale it to the
+task. In our case, preprocessing will resize our input image and rescale it to the
 range `[0, 1]` using some ImageNet specific mean and variance data. Let's call our
 task's preprocessor and backbone in succession to see what happens to our input shape.
 """
@@ -488,8 +488,8 @@ One of the most powerful features of KerasHub is the ability upload models to Ka
 Huggingface models hub and share them with others. `keras_hub.upload_preset` allows you
 to upload a saved preset.
 
-In this case, we will upload to Kaggle. We have already authenticated with Kaggle to,
-download the Gemma model earlier. Running the following cell well upload a new model
+In this case, we will upload to Kaggle. We have already authenticated with Kaggle to
+download the Gemma model earlier. Running the following cell will upload a new model
 to Kaggle.
 """
 
@@ -552,7 +552,7 @@ extract_dir = keras.utils.get_file(
 data_dir = pathlib.Path(extract_dir) / "aclImdb"
 
 """
-The IMDb dataset contrains a large amount of unlabeled movie reviews. We don't need those
+The IMDb dataset contains a large amount of unlabeled movie reviews. We don't need those
 here, we can simply delete them.
 """
 
@@ -737,7 +737,7 @@ backbone.enable_lora(4)
 text_classifier.summary()
 
 """
-After enabling LoRA, our model goes from 10GB of traininable parameters to just 20MB.
+After enabling LoRA, our model goes from 10GB of trainable parameters to just 20MB.
 That means the space used by optimizer variables will no longer be a concern.
 
 With all that set up, we can compile and train our model as normal.

--- a/guides/md/keras_hub/getting_started.md
+++ b/guides/md/keras_hub/getting_started.md
@@ -64,7 +64,7 @@ guide, so we can follow the following steps:
 
 1. Go to the [Gemma 2](https://www.kaggle.com/models/keras/gemma2) model page, and accept
    the license at the banner at the top.
-2. Generate an Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)
+2. Generate a Kaggle API key by going to [Kaggle settings](https://www.kaggle.com/settings)
    and clicking "Create New Token" button under the "API" section.
 3. Inside your colab notebook, click on the key icon on the left hand toolbar. Add two
    secrets: `KAGGLE_USERNAME` with your username, and `KAGGLE_KEY` with the API key you just
@@ -114,7 +114,7 @@ Before we begin, let's take a look at the key classes we will use in the KerasHu
     range, or resizing inputs to a specific size. This class encapsulates the image-specific
     preprocessing.
   * **Inherits from**: `keras.layers.Layer`.
-* **AudioConveter**: `keras_hub.layers.AudioConveter`.
+* **AudioConverter**: `keras_hub.layers.AudioConverter`.
   * **What it does**: Converts raw audio to model ready input.
   * **Why it's important**: Audio models often need to preprocess raw audio input before
     passing it to a model, e.g. by computing a spectrogram of the audio signal. This class
@@ -126,7 +126,7 @@ the component with weights and state for the given pre-trained model identifier.
 `keras_hub.tokenizers.Tokenizer.from_preset("gemma2_2b_en")` will create a layer that
 tokenizes text using a Gemma2 tokenizer vocabulary.
 
-The figure below shows how all these core classes interact. Arrow indicate composition
+The figure below shows how all these core classes interact. Arrows indicate composition
 not inheritance (e.g., a task *has a* backbone).
 
 ![png](/img/guides/getting_started/class-diagram.png)
@@ -236,7 +236,7 @@ pretrained model's latent space. We can then map this latent space to any number
 specific outputs, depending on what we are trying to do with the model.
 
 A **preprocessor** is just a Keras layer that does all the preprocessing for a specific
-task. In our case, preprocessing with will resize our input image and rescale it to the
+task. In our case, preprocessing will resize our input image and rescale it to the
 range `[0, 1]` using some ImageNet specific mean and variance data. Let's call our
 task's preprocessor and backbone in succession to see what happens to our input shape.
 
@@ -805,8 +805,8 @@ One of the most powerful features of KerasHub is the ability upload models to Ka
 Huggingface models hub and share them with others. `keras_hub.upload_preset` allows you
 to upload a saved preset.
 
-In this case, we will upload to Kaggle. We have already authenticated with Kaggle to,
-download the Gemma model earlier. Running the following cell well upload a new model
+In this case, we will upload to Kaggle. We have already authenticated with Kaggle to
+download the Gemma model earlier. Running the following cell will upload a new model
 to Kaggle.
 
 
@@ -901,7 +901,7 @@ extract_dir = keras.utils.get_file(
 data_dir = pathlib.Path(extract_dir) / "aclImdb"
 ```
 
-The IMDb dataset contrains a large amount of unlabeled movie reviews. We don't need those
+The IMDb dataset contains a large amount of unlabeled movie reviews. We don't need those
 here, we can simply delete them.
 
 
@@ -1223,7 +1223,7 @@ text_classifier.summary()
 
 
 
-After enabling LoRA, our model goes from 10GB of traininable parameters to just 20MB.
+After enabling LoRA, our model goes from 10GB of trainable parameters to just 20MB.
 That means the space used by optimizer variables will no longer be a concern.
 
 With all that set up, we can compile and train our model as normal.


### PR DESCRIPTION
Noticed a few minor typos while reading the [KerasHub Getting Started Guide](https://keras.io/keras_hub/getting_started/). Per the keras-io [ReadMe (Fixing Typos)](https://github.com/keras-team/keras-io?tab=readme-ov-file#fixing-typos), I made the same edits in the corresponding `.py`, `.ipynb`, and `.md` files. 