### PR TITLE
Added copy button to the code cells in the Keras.io website 

### DIFF
--- a/scripts/autogen_utils.py
+++ b/scripts/autogen_utils.py
@@ -77,34 +77,30 @@ def add_copy_buttons_to_code(html_content):
     def add_button(match):
         full_match = match.group(0)
         
-        # EXCLUSION 1: Explicit output blocks
         if 'class="k-default-codeblock"' in full_match:
             return full_match
             
-        # EXCLUSION 2: Model summary blocks (check for specific style or font)
         if 'style="white-space:pre;overflow-x:auto' in full_match or "DejaVu Sans Mono" in full_match:
             return full_match
 
-        # EXCLUSION 3: Content-based check for table borders or summary keywords
         if "┏━━━━━━" in full_match or "Total params:" in full_match:
             return full_match
 
         copy_button_html = (
             '<div class="code__container">'
-            '<button class="code__copy--button" onclick="copyCode(this)">'
+            '<button class="code__copy--button">'
             '<i class="icon--copy"></i>'
             '<span class="code__copy--tooltip">Copy</span>'
             '</button>'
         )
         return f'{copy_button_html}{full_match}</div>'
 
-    # Broaden pattern to capture all <pre> tags, including those with style attributes
     combined_pattern = r'(<div class="k-default-codeblock">.*?</div>)|(<pre[^>]*>.*?</pre>)'
     
     def handle_match(m):
-        if m.group(1): # It is a k-default-codeblock output
+        if m.group(1):
             return m.group(1)
-        else: # It is a <pre> tag, evaluate for button
+        else:
             return add_button(m)
 
     return re.sub(combined_pattern, handle_match, html_content, flags=re.DOTALL)

--- a/scripts/autogen_utils.py
+++ b/scripts/autogen_utils.py
@@ -76,11 +76,8 @@ def make_outline(md_source):
 def add_copy_buttons_to_code(html_content):
     def add_button(match):
         full_match = match.group(0)
-        
-        if 'class="k-default-codeblock"' in full_match:
-            return full_match
-            
-        if 'style="white-space:pre;overflow-x:auto' in full_match or "DejaVu Sans Mono" in full_match:
+
+        if 'style="white-space:pre;overflow-x:auto' in full_match:
             return full_match
 
         if "┏━━━━━━" in full_match or "Total params:" in full_match:

--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -66,26 +66,22 @@ pre {
   font-size: 100%;
 }
 
-/* 1. The container acts as the anchor for the floating button */
 .code__container {
   position: relative;
-  display: block; /* Standard block behavior restores natural spacing */
-  /* margin: 20px 0; */
-  /* border-radius: 8px; */
-  overflow: hidden; /* Ensures code doesn't spill out of corners */
+  display: block; 
+  overflow: hidden; 
 }
 
-/* 2. Position the button ABSOLUTELY so it sits INSIDE the code area */
 .code__copy--button {
   position: absolute;
-  right: 8px; /* Shifted towards the right edge */
-  top: 5px;
-  background-color: rgba(255, 255, 255, 0.1); /* Subtle dark-mode look */
+  right: 10px; 
+  top: 0;
+  background-color: rgba(255, 255, 255, 0.1); 
   border: none;
   border-radius: 4px;
   cursor: pointer;
   width: 32px;
-  height: 32px; /* Set height so it is clickable */
+  height: 32px; 
   z-index: 10;
   display: flex;
   align-items: center;
@@ -93,20 +89,14 @@ pre {
   transition: background-color 0.2s;
 }
 
-/* 3. The code block recovers its original spacing and "gap" */
 .code__container pre {
   margin: 0;
-  /* Extra right padding (45px) ensures code doesn't go under the button */
-  padding: 20px 45px 24px 24px; 
-  /* background-color: #000000 !important; Pure black like the Keras images */
-  /* color: #eeffff; */
+  padding: 28px 45px 24px 24px; 
   overflow-x: auto;
   border-radius: 8px;
-  line-height: 1.5; /* Restores vertical breathing room */
-  /* font-family: 'Fira Code', 'Courier New', monospace; Modern coding font */
+  line-height: 1.5; 
 }
 
-/* 4. Icon styling */
 .code__copy--button .icon--copy {
   filter: invert(1); 
   width: 18px;
@@ -122,19 +112,19 @@ pre {
   opacity: 1;
 }
 
-/* 5. Tooltip stays aligned with the button */
 .code__copy--tooltip {
-  /* background-color: #000000; */
-  /* color: #fff; */
   font-size: 11px;
-  padding: 4px 8px;
+  padding: 4px 4px;
   position: absolute;
-  right: 45px; /* Sits to the left of the button */
-  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 40px;
   display: none;
   border-radius: 4px;
   z-index: 101;
   white-space: nowrap;
+  background-color: #ffffff;
+  color: #AB0000
 }
 
 hr {

--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -124,7 +124,7 @@ pre {
   z-index: 101;
   white-space: nowrap;
   background-color: #ffffff;
-  color: #AB0000
+  color: var(--text-red);
 }
 
 hr {

--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -69,7 +69,7 @@ pre {
 .code__container {
   position: relative;
   display: block; 
-  overflow: hidden; 
+  overflow: visible; 
 }
 
 .code__copy--button {
@@ -114,7 +114,7 @@ pre {
 
 .code__copy--tooltip {
   font-size: 11px;
-  padding: 4px 4px;
+  padding: 4px 8px;
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
@@ -125,6 +125,10 @@ pre {
   white-space: nowrap;
   background-color: #ffffff;
   color: var(--text-red);
+}
+
+.code__copy--button.active .code__copy--tooltip {
+  display: block;
 }
 
 hr {

--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -74,9 +74,9 @@ pre {
 
 .code__copy--button {
   position: absolute;
-  right: 10px; 
+  right: 0;
   top: 0;
-  background-color: rgba(255, 255, 255, 0.1); 
+  background-color: rgba(255, 255, 255, 0.1);
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -66,6 +66,77 @@ pre {
   font-size: 100%;
 }
 
+/* 1. The container acts as the anchor for the floating button */
+.code__container {
+  position: relative;
+  display: block; /* Standard block behavior restores natural spacing */
+  /* margin: 20px 0; */
+  /* border-radius: 8px; */
+  overflow: hidden; /* Ensures code doesn't spill out of corners */
+}
+
+/* 2. Position the button ABSOLUTELY so it sits INSIDE the code area */
+.code__copy--button {
+  position: absolute;
+  right: 8px; /* Shifted towards the right edge */
+  top: 5px;
+  background-color: rgba(255, 255, 255, 0.1); /* Subtle dark-mode look */
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 32px;
+  height: 32px; /* Set height so it is clickable */
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+}
+
+/* 3. The code block recovers its original spacing and "gap" */
+.code__container pre {
+  margin: 0;
+  /* Extra right padding (45px) ensures code doesn't go under the button */
+  padding: 20px 45px 24px 24px; 
+  /* background-color: #000000 !important; Pure black like the Keras images */
+  /* color: #eeffff; */
+  overflow-x: auto;
+  border-radius: 8px;
+  line-height: 1.5; /* Restores vertical breathing room */
+  /* font-family: 'Fira Code', 'Courier New', monospace; Modern coding font */
+}
+
+/* 4. Icon styling */
+.code__copy--button .icon--copy {
+  filter: invert(1); 
+  width: 18px;
+  height: 18px;
+  opacity: 0.6;
+}
+
+.code__copy--button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.code__copy--button:hover .icon--copy {
+  opacity: 1;
+}
+
+/* 5. Tooltip stays aligned with the button */
+.code__copy--tooltip {
+  /* background-color: #000000; */
+  /* color: #fff; */
+  font-size: 11px;
+  padding: 4px 8px;
+  position: absolute;
+  right: 45px; /* Sits to the left of the button */
+  top: 14px;
+  display: none;
+  border-radius: 4px;
+  z-index: 101;
+  white-space: nowrap;
+}
+
 hr {
   margin-top: 2rem;
   margin-bottom: 2rem;

--- a/theme/js/index.js
+++ b/theme/js/index.js
@@ -23,7 +23,7 @@ const copyButtons = document.querySelectorAll('.code__copy--button');
 copyButtons.forEach((button) => {
   button.addEventListener('click', () => {
     const parent = button.parentNode;
-    const text = parent.querySelector('.language-python').innerText;
+    const text = parent.querySelector('code').innerText;
     const inputElement = document.createElement('textarea');
     console.log('text', text);
     inputElement.value = text;
@@ -34,9 +34,12 @@ copyButtons.forEach((button) => {
     document.execCommand('copy');
     inputElement.remove();
 
-    button.querySelector('.code__copy--tooltip').style.display = 'block';
+    const tooltip = button.querySelector('.code__copy--tooltip');
+    tooltip.textContent = 'Copied!';
+    tooltip.style.display = 'block';
     setTimeout(() => {
-      button.querySelector('.code__copy--tooltip').style.display = 'none';
+      tooltip.textContent = 'Copy';
+      tooltip.style.display = 'none';
     }, 2000);
   });
 });
@@ -103,3 +106,4 @@ if (exploreModule && window.innerWidth > 1199) {
 function verticallyCenterExploreContent() {
   exploreContent.style.marginTop = `${Math.round(exploreContent.getBoundingClientRect().height / 2)}px`;
 }
+

--- a/theme/js/index.js
+++ b/theme/js/index.js
@@ -23,7 +23,15 @@ const copyButtons = document.querySelectorAll('.code__copy--button');
 copyButtons.forEach((button) => {
   button.addEventListener('click', () => {
     const parent = button.parentNode;
-    const text = parent.querySelector('code').innerText;
+    let text = parent.querySelector('code').innerText;
+
+    if (text.includes('>>>')) {
+      text = text.split('\n')
+        .filter(line => /^(>>>|\.\.\.)/.test(line.trim()))
+        .map(line => line.replace(/^(>>>|\.\.\.) ?/, ""))
+        .join('\n');
+    }
+
     const inputElement = document.createElement('textarea');
     console.log('text', text);
     inputElement.value = text;

--- a/theme/js/index.js
+++ b/theme/js/index.js
@@ -106,4 +106,3 @@ if (exploreModule && window.innerWidth > 1199) {
 function verticallyCenterExploreContent() {
   exploreContent.style.marginTop = `${Math.round(exploreContent.getBoundingClientRect().height / 2)}px`;
 }
-


### PR DESCRIPTION
This pull request adds a copy button to the code cells on the keras.io website. It shows a tooltip saying "Copied" when the user clicks on the button and copies the code. 

This is how the code cell appears now:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/42e67c22-f1f7-4ba5-8075-fe911dcd8050" />

After the copy button is clicked:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/c840619e-9e70-4111-8c1b-e895d7a59037" />


For code cells like below the code output is as shown:

<img width="1052" height="257" alt="image" src="https://github.com/user-attachments/assets/4f751d1d-2629-47bf-be57-1600be6c8bae" />

Copied content:
layer = Dense(3)
layer.build(input_shape=(None, 3)) # Create the weights of the layer
layer.trainable
layer.trainable_weights
layer.trainable = False
layer.trainable_weights

<img width="1050" height="310" alt="image" src="https://github.com/user-attachments/assets/fa5ee042-d8d7-4c2a-bb55-bf66b14c7e69" />

Copied content:
model = Sequential([
    ResNet50Base(input_shape=(32, 32, 3), weights='pretrained'),
    Dense(10),
])
model.layers[0].trainable = False  # Freeze ResNet50Base.

assert model.layers[0].trainable_weights == []  # ResNet50Base has no trainable weights.
assert len(model.trainable_weights) == 2  # Just the bias & kernel of the Dense layer.

model.compile(...)
model.fit(...)  # Train Dense while excluding ResNet50Base.


