### PR TITLE
Add logaddexp2 for description

### DIFF
--- a/scripts/api_master.py
+++ b/scripts/api_master.py
@@ -1270,6 +1270,7 @@ API_MASTER = {
                         "keras.ops.log1p",
                         "keras.ops.log2",
                         "keras.ops.logaddexp",
+                        "keras.ops.logaddexp2",
                         "keras.ops.logical_and",
                         "keras.ops.logical_not",
                         "keras.ops.logical_or",


### PR DESCRIPTION
I added the missing logaddexp2 entry to the Keras API documentation on keras.io.