### PR TITLE
Fix logic error in Siamese Network: Remove inconsistent sigmoid activation for Contrastive Loss

### DIFF
--- a/examples/vision/ipynb/siamese_contrastive.ipynb
+++ b/examples/vision/ipynb/siamese_contrastive.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Author:** Mehdi<br>\n",
     "**Date created:** 2021/05/06<br>\n",
-    "**Last modified:** 2022/09/10<br>\n",
+    "**Last modified:** 2026/01/28<br>\n",
     "**Description:** Similarity learning using a siamese network trained with a contrastive loss."
    ]
   },

--- a/examples/vision/siamese_contrastive.py
+++ b/examples/vision/siamese_contrastive.py
@@ -2,7 +2,7 @@
 Title: Image similarity estimation using a Siamese Network with a contrastive loss
 Author: Mehdi
 Date created: 2021/05/06
-Last modified: 2022/09/10
+Last modified: 2026/01/28
 Description: Similarity learning using a siamese network trained with a contrastive loss.
 Accelerator: GPU
 """


### PR DESCRIPTION
This PR fixes a mathematical conflict between the model architecture and the loss function in the Siamese Network tutorial.

The model previously used a sigmoid activation on the final output. Because sigmoid squashes values between 0 and 1, the model could never output a distance greater than 1.0. Since the Contrastive Loss uses a margin of 1.0, the model was not able to push dissimilar images far enough apart to satisfy the loss function.

Removed the final 'Dense(1, activation="sigmoid")' layer so the model can output raw Euclidean distance.

Ref : https://github.com/keras-team/keras-io/issues/2230
