### PR TITLE
Add links to guides/examples from API documentation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 mdx_truly_sane_lists
 PyYAML
 pandas
+pasta
 jupyter
 pydot
 boto3

--- a/scripts/autogen.py
+++ b/scripts/autogen.py
@@ -19,8 +19,9 @@ import signal
 import docstrings
 import jinja2
 import multiprocessing
-import autogen_utils
+import warnings
 
+import autogen_utils
 from master import MASTER
 from examples_master import EXAMPLES_MASTER
 import tutobooks
@@ -107,8 +108,53 @@ class KerasIO:
         )
         self.sync_tutobook_templates()
 
+        # Find all symbols for all guides and examples in MASTER
+        self.find_apis_in_tutobook(MASTER, [])
+
         # Recursively generate all md sources based on the MASTER tree
         self.make_md_source_for_entry(self.master, path_stack=[], title_stack=[])
+
+    def find_apis_in_tutobook(self, entry, path_stack):
+        path = entry["path"]
+        if "children" in entry:
+            # This is a TOC, recurse in tree
+            sub_path_stack = path_stack + [path] if path != "/" else path_stack
+            for child in entry["children"]:
+                self.find_apis_in_tutobook(child, sub_path_stack)
+            return
+        elif "generate" in entry:
+            # This is an API, ignore
+            return
+
+        # This is a guide / example, reverse engineer the path to the Python.
+        url = "/" + str(Path(*path_stack) / path) + "/"
+        is_guide = False
+        if path_stack[0] == "examples/":
+            py_path_stack = [self.examples_dir] + path_stack[1:]
+        elif path_stack[0] == "guides/":
+            py_path_stack = [self.guides_dir] + path_stack[1:]
+            is_guide = True
+        elif len(path_stack) < 2:
+            return
+        elif path_stack[1] == "examples/":
+            py_path_stack = [self.examples_dir, path_stack[0]] + path_stack[2:]
+        elif path_stack[1] == "guides/":
+            py_path_stack = [self.guides_dir, path_stack[0]] + path_stack[2:]
+            is_guide = True
+        else:
+            return
+
+        py_path = os.path.join(*py_path_stack, path + ".py")
+
+        # Parse the Python file and extract all the symbols from Keras packages.
+        apis = autogen_utils.find_all_symbols(
+            py_path, ["keras", "keras_hub", "keras_rs"]
+        )
+        if apis is None:
+            warnings.warn(f"Could not parse '{py_path}'")
+        else:
+            # Provide the results to the docstring_printer.
+            self.docstring_printer.add_example_apis(url, entry["title"], is_guide, apis)
 
     def preprocess_tutobook_md_source(
         self, md_content, fname, github_repo_dir, img_dir, site_img_dir

--- a/scripts/autogen_utils.py
+++ b/scripts/autogen_utils.py
@@ -5,6 +5,9 @@ import copy
 import pathlib
 import os
 
+import pasta
+from pasta.base import scope
+
 
 def save_file(path, content):
     parent = pathlib.Path(path).parent
@@ -114,3 +117,39 @@ def set_active_flag_in_nav_entry(entry, relative_url):
     ]
     entry["children"] = children
     return entry
+
+
+def find_all_symbols(path, packages):
+    """Parse a Python file and find all symbols from specific packages.
+
+    Args:
+        path: the path to the Python file
+        packages: collection of Python package, for instance ["keras"]
+
+    Returns:
+        a collection of symbols found in the Python code, for instance
+        ["keras", "keras.layers", "keras.layers.Dense"]
+    """
+    with open(path, "r") as src_file:
+        src = src_file.read()
+
+    try:
+        tree = pasta.parse(src)
+    except Exception:
+        return None
+    s = scope.analyze(tree)
+    symbols = set()
+
+    def explore(path, attrs):
+        symbols.add(path)
+        for name, attr in attrs.items():
+            new_path = path + "." + name
+            explore(new_path, attr.attrs)
+
+    for package in packages:
+        refs = s.external_references.get(package, [])
+        for ref in refs:
+            if ref.name_ref is not None:
+                explore(package, ref.name_ref.attrs)
+
+    return symbols


### PR DESCRIPTION
Add a block with a list of links to guides and examples using the specific API being documented.

This feature uses `pasta` (a higher level library on top of AST) to detect all Keras APIs used in each guide and example.

----
### Sample in Keras

<img width="744" height="478" alt="Screenshot 2026-01-23 at 11 33 02 AM" src="https://github.com/user-attachments/assets/96720b71-d4c2-498f-ac97-4786b2b85379" />

----
### Sample in Keras Hub

<img width="749" height="439" alt="Screenshot 2026-01-23 at 11 34 41 AM" src="https://github.com/user-attachments/assets/769b3c34-3832-41cf-bc86-01499bfc99d1" />
