### PR TITLE
Fix installation of `pasta` in `requirements.txt`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 mdx_truly_sane_lists
 PyYAML
 pandas
-pasta
+google-pasta
 jupyter
 pydot
 boto3


### PR DESCRIPTION
The API to examples link feature from https://github.com/keras-team/keras-io/pull/2263 is not working because we were installing the wrong `pasta` package.

Logs before (none of the files parse):

```
2026-01-23 20:23:58.329111: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/functional_api.py'
  warnings.warn(f"Could not parse '{py_path}'")
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/sequential_model.py'
  warnings.warn(f"Could not parse '{py_path}'")
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/making_new_layers_and_models_via_subclassing.py'
  warnings.warn(f"Could not parse '{py_path}'")
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/training_with_built_in_methods.py'
  warnings.warn(f"Could not parse '{py_path}'")
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/custom_train_step_in_jax.py'
  warnings.warn(f"Could not parse '{py_path}'")
/home/runner/work/keras-io/keras-io/scripts/autogen.py:154: UserWarning: Could not parse '/home/runner/work/keras-io/keras-io/guides/custom_train_step_in_tensorflow.py'
  warnings.warn(f"Could not parse '{py_path}'")
...
```

Logs after (3 files don't parse, this is a known issue):

```
#12 0.635 2026-01-27 23:51:48.029445: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
#12 0.635 To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
#12 6.715 /scripts/autogen.py:154: UserWarning: Could not parse '/examples/vision/visualizing_what_convnets_learn.py'
#12 6.715   warnings.warn(f"Could not parse '{py_path}'")
#12 10.60 /scripts/autogen.py:154: UserWarning: Could not parse '/examples/generative/midi_generation_with_transformer.py'
#12 10.60   warnings.warn(f"Could not parse '{py_path}'")
#12 10.76 /scripts/autogen.py:154: UserWarning: Could not parse '/examples/audio/vocal_track_separation.py'
#12 10.76   warnings.warn(f"Could not parse '{py_path}'")
#12 12.67 Generating md sources
#12 12.67 ...Processing .
```