### PR TITLE
Fix VMEM OOM and benchmark issue in Pallas guide

### DIFF
--- a/guides/ipynb/define_custom_kernel.ipynb
+++ b/guides/ipynb/define_custom_kernel.ipynb
@@ -102,10 +102,12 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "def add_vectors_kernel(x_ref, y_ref, o_ref):\n",
     "    \"\"\"Pallas kernel for adding two vectors together.\"\"\"\n",
     "    x, y = x_ref[...], y_ref[...]\n",
-    "    o_ref[...] = x + y"
+    "    o_ref[...] = x + y\n",
+    ""
    ]
   },
   {
@@ -125,6 +127,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "@jax.jit\n",
     "def add_vectors(x: jax.Array, y: jax.Array) -> jax.Array:\n",
     "    return pl.pallas_call(\n",
@@ -153,6 +156,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "class PallasAddLayer(keras.Layer):\n",
     "    def call(self, x, y):\n",
     "        # Reuse the JIT-compiled Pallas function\n",
@@ -221,6 +225,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "class StandardDenseReLU(keras.layers.Layer):\n",
     "    \"\"\"Standard Matmul and ReLU implementation using keras.ops.\"\"\"\n",
     "\n",
@@ -241,7 +246,8 @@
     "        # 1. Matmul: inputs (HBM) -> compute -> intermediate (HBM)\n",
     "        y = keras.ops.matmul(inputs, self.w)\n",
     "        # 2. ReLU: intermediate (HBM) -> compute -> output (HBM)\n",
-    "        return keras.ops.relu(y)"
+    "        return keras.ops.relu(y)\n",
+    ""
    ]
   },
   {
@@ -278,7 +284,8 @@
     "    result = jnp.maximum(acc, 0)\n",
     "\n",
     "    # Write the final result to the output reference\n",
-    "    c_ref[...] = result"
+    "    c_ref[...] = result\n",
+    ""
    ]
   },
   {
@@ -305,15 +312,16 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "@jax.jit\n",
     "def fused_matmul(a, b):\n",
     "    m, k = a.shape\n",
     "    _, n = b.shape\n",
     "\n",
     "    # Define tile sizes\n",
-    "    tile_m, tile_n = 128, 128\n",
+    "    tile_m, tile_k, tile_n = 128, 128, 128\n",
     "    assert (\n",
-    "        m % tile_m == 0 and n % tile_n == 0\n",
+    "        m % tile_m == 0 and k % tile_k == 0 and n % tile_n == 0\n",
     "    ), \"Inputs must be multiples of 128 for this demo\"\n",
     "\n",
     "    return pl.pallas_call(\n",
@@ -321,18 +329,14 @@
     "        # Map output indices to input blocks\n",
     "        out_shape=jax.ShapeDtypeStruct((m, n), a.dtype),\n",
     "        in_specs=[\n",
-    "            # For each output tile, we take a slice of A of shape (tile_m, k)\n",
-    "            pl.BlockSpec(\n",
-    "                index_map=lambda i, j: (i, 0), block_shape=(tile_m, k)\n",
-    "            ),  # Matrix A\n",
-    "            # For each output tile, we take a slice of B of shape (k, tile_n)\n",
-    "            pl.BlockSpec(\n",
-    "                index_map=lambda i, j: (0, j), block_shape=(k, tile_n)\n",
-    "            ),  # Matrix B\n",
+    "            # For each output tile, we take a (tile_m, tile_k) slice of A\n",
+    "            pl.BlockSpec(index_map=lambda i, j: (i, 0), block_shape=(tile_m, tile_k)),\n",
+    "            # For each output tile, we take a (tile_k, tile_n) slice of B\n",
+    "            pl.BlockSpec(index_map=lambda i, j: (0, j), block_shape=(tile_k, tile_n)),\n",
     "        ],\n",
     "        out_specs=pl.BlockSpec(\n",
     "            index_map=lambda i, j: (i, j), block_shape=(tile_m, tile_n)\n",
-    "        ),  # Matrix C\n",
+    "        ),\n",
     "        grid=(m // tile_m, n // tile_n),\n",
     "    )(a, b)\n",
     "\n",
@@ -360,6 +364,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "class FusedDense(keras.layers.Layer):\n",
     "    \"\"\"Custom Keras layer that applies the fused Dense and ReLU op.\"\"\"\n",
     "\n",
@@ -427,7 +432,8 @@
     "# 2. Run Comparison\n",
     "print(f\"Benchmarking Matrix Size: {N}x{N}\\n\" + \"-\" * 30)\n",
     "benchmark(standard_layer, input_data, \"Standard Keras (Matmul + ReLU)\")\n",
-    "benchmark(pallas_layer, input_data, \"Pallas Fused (Matmul + ReLU)\")"
+    "benchmark(pallas_layer, input_data, \"Pallas Fused (Matmul + ReLU)\")\n",
+    ""
    ]
   },
   {
@@ -484,6 +490,7 @@
    },
    "outputs": [],
    "source": [
+    "\n",
     "# 1. Define the wrapper with `custom_vjp` using our original `fused_matmul`.\n",
     "@jax.custom_vjp\n",
     "def fused_matmul_trainable(x, w):\n",


### PR DESCRIPTION
Running the [custom kernel guide](https://keras.io/guides/define_custom_kernel/) as-is on TPU v5e will encounter a VMEM compiler OOM in newer versions of JAX:

<img width="810" height="624" alt="image" src="https://github.com/user-attachments/assets/01b196e7-6033-47a1-97f7-3f4cd32e4122" />

This is caused by newer versions of Pallas in JAX >0.8.0 enabling [double VMEM buffering](https://docs.jax.dev/en/latest/pallas/pipelining.html#pallas-pipelining-api) by default. The guide was rendered with an older version of JAX so it didn't hit this issue.

Additionally, in the guide's benchmark, the non-Pallas vanilla JAX version is unintentionally faster:

```
Benchmarking Matrix Size: 8192x8192
------------------------------
Standard Keras (Matmul + ReLU) Average Latency: 7.811 ms
Pallas Fused (Matmul + ReLU) Average Latency: 35.039 ms
```

(Thanks to [Aditya Kane](https://www.linkedin.com/in/aditya-kane/) for pointing this out)

This PR updates the guide to tile the contracting dimension in the matmul, avoiding the VMEM OOM. After re-rendering on TPU, the benchmark correctly shows the fused Pallas kernel as being faster:

```
Benchmarking Matrix Size: 8192x8192
------------------------------
Standard Keras (Matmul + ReLU) Average Latency: 7.807 ms
Pallas Fused (Matmul + ReLU) Average Latency: 2.240 ms
```