### PR TITLE
Updated demo to work with newer version of JAX

### DIFF
--- a/guides/writing_a_custom_training_loop_in_jax.py
+++ b/guides/writing_a_custom_training_loop_in_jax.py
@@ -277,9 +277,9 @@ you'd need to call it on a batch of data to build it.
 # Build optimizer variables.
 optimizer.build(model.trainable_variables)
 
-trainable_variables = model.trainable_variables
-non_trainable_variables = model.non_trainable_variables
-optimizer_variables = optimizer.variables
+trainable_variables = [v.value for v in model.trainable_variables]
+non_trainable_variables = [v.value for v in model.non_trainable_variables]
+optimizer_variables = [v.value for v in optimizer.variables]
 state = trainable_variables, non_trainable_variables, optimizer_variables
 
 # Training loop


### PR DESCRIPTION
Since new versions of JAX don't support the abstraction using `__jax_array__` anymore, the old method of passing `keras.Variables` to `jax.jit` compiled functions doesn't work.

This change fixes that by manually extracting the underlying jax arrays