### PR TITLE
Fix section rendering issue

### DIFF
--- a/theme/css/docs.css
+++ b/theme/css/docs.css
@@ -2,6 +2,10 @@
 @import url("icons.css");
 @import url("colors.css");
 
+html {
+  scroll-padding-top: 100px;
+}
+
 body {
   font-family: 'Montserrat', 'Open Sans', sans-serif;
   font-size: 0.95rem


### PR DESCRIPTION
Currently, when we click on any API links or sublinks, the display section starts showing the content from the middle of the document instead of the header. This is confusing and annoying for users trying to locate the correct API.

Added padding on top to make the target links directly visible and avoid hiding behind the top navigation bar which is fixed length.

Changes to 
<img width="1408" height="487" alt="Screenshot 2026-02-24 at 3 00 47 PM" src="https://github.com/user-attachments/assets/213ebee5-8e5b-4c07-8817-5e521784abad" />

From:
<img width="1408" height="487" alt="image" src="https://github.com/user-attachments/assets/7820a66b-1d98-446e-908f-88e8fcbb31eb" />
