### PR TITLE
Add support for API aliases when discovering examples.

### DIFF
--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -116,9 +116,22 @@ class KerasDocumentationGenerator:
             if table is not None:
                 subblocks.append(table)
 
-        examples = self.api_to_example.get(element, None)
-        if examples:
-            subblocks.append(get_examples_block(element, examples))
+        # Extract and render links to examples using the API
+        if hasattr(object_, "_api_export_path"):
+            apis = object_._api_export_path
+        else:
+            apis = [element]
+
+        all_examples = []
+        for api in apis:
+            api_examples = self.api_to_example.get(api, None)
+            if api_examples:
+                for api_example in api_examples:
+                    if api_example not in all_examples:
+                        all_examples.append(api_example)
+
+        if all_examples:
+            subblocks.append(get_examples_block(element, all_examples))
 
         return "\n\n".join(subblocks) + "\n\n----\n\n"
 
@@ -158,8 +171,7 @@ def make_source_link(cls, project_url):
     module_version = copy.copy(importlib.import_module(base_module).__version__)
     if ".dev" in module_version:
         module_version = project_url_version[: module_version.find(".dev")]
-    # TODO: Remove keras-rs condition, this is just a temporary thing.
-    if "keras-rs" not in project_url and module_version != project_url_version:
+    if module_version != project_url_version:
         raise RuntimeError(
             f"For project {base_module}, URL {project_url} "
             f"has version number {project_url_version} which does not match the "

--- a/scripts/docstrings.py
+++ b/scripts/docstrings.py
@@ -117,18 +117,13 @@ class KerasDocumentationGenerator:
                 subblocks.append(table)
 
         # Extract and render links to examples using the API
-        if hasattr(object_, "_api_export_path"):
-            apis = object_._api_export_path
-        else:
-            apis = [element]
+        apis = getattr(object_, "_api_export_path", [element])
 
         all_examples = []
         for api in apis:
-            api_examples = self.api_to_example.get(api, None)
-            if api_examples:
-                for api_example in api_examples:
-                    if api_example not in all_examples:
-                        all_examples.append(api_example)
+            for api_example in self.api_to_example.get(api, []):
+                if api_example not in all_examples:
+                    all_examples.append(api_example)
 
         if all_examples:
             subblocks.append(get_examples_block(element, all_examples))


### PR DESCRIPTION
As a follow-up to https://github.com/keras-team/keras-io/pull/2263 this adds support for API aliases.

Verified manually that we indeed get more example links.