### PR TITLE
Fix object_detection_keras_cv redirect target

### DIFF
--- a/redirects/guides/keras_cv/object_detection_keras_cv/index.html
+++ b/redirects/guides/keras_cv/object_detection_keras_cv/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='https://keras.io/keras_hub/guides/segment_anything_in_keras_hub/'" />
+<meta http-equiv="refresh" content="0; URL='https://keras.io/keras_hub/guides/object_detection_retinanet/'" />


### PR DESCRIPTION
## Description

Fixes #2012.

The old KerasCV object detection guide URL (`/guides/keras_cv/object_detection_keras_cv/`) was redirecting to the segment-anything guide instead of the new KerasHub object detection (RetinaNet) guide. This points the redirect at the correct successor at `/keras_hub/guides/object_detection_retinanet/`.

The RetinaNet guide has been live since #2069 merged on 2026-04-01, so the target exists.