### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Owners for /guides directory
-/guides/ @fchollet @MarkDaoust @pcoet
+/guides/ @hertschuh


### PR DESCRIPTION
Currently any changes under /guides are assigning the reviewers based on the code owners list mentioned in this file.
It might spam them with many PRs for review.
Updating the file to assign /guides changes to @hertschuh or if you want something different, I can update that as well.