### PR TITLE
Fix bounding box formatting in YOLOv8 example to prevent RaggedTensor...

### DIFF
--- a/examples/vision/yolov8.py
+++ b/examples/vision/yolov8.py
@@ -413,7 +413,13 @@ fed into the model.
 
 
 def dict_to_tuple(inputs):
-    return inputs["images"], inputs["bounding_boxes"]
+    return (
+        inputs["images"],
+        {
+            "boxes": inputs["bounding_boxes"]["boxes"],
+            "classes": inputs["bounding_boxes"]["classes"],
+        },
+    )
 
 
 train_ds = train_ds.map(dict_to_tuple, num_parallel_calls=tf.data.AUTOTUNE)


### PR DESCRIPTION
The YOLOv8 example currently passes the entire `bounding_boxes` dictionary directly in `dict_to_tuple`, which can lead to RaggedTensor-related issues during training.

This PR updates `dict_to_tuple` to explicitly pass the "boxes" and "classes" fields, ensuring compatibility with the expected input format of KerasCV models.

This aligns the example with the required structure and prevents potential runtime errors during training.