### PR TITLE
[keras.io] EfficientNet fine-tuning: unfreeze by block instead of last 20 layers

### DIFF
--- a/examples/vision/image_classification_efficientnet_fine_tuning.py
+++ b/examples/vision/image_classification_efficientnet_fine_tuning.py
@@ -368,8 +368,14 @@ plot_hist(hist)
 
 """
 The second step is to unfreeze a number of layers and fit the model using smaller
-learning rate. In this example we show unfreezing all layers, but depending on
-specific dataset it may be desireble to only unfreeze a fraction of all layers.
+learning rate. In this example we show unfreezing only the last block while leaving
+all other layers frozen, but depending on the specific dataset it may be desirable to
+unfreeze more or fewer layers.
+
+Because EfficientNet shortcuts connect whole blocks, it is important to unfreeze a
+block as a unit rather than individual layers. The code below demonstrates
+block-by-block fine-tuning by unfreezing the last EfficientNet block (`block7`) and
+all subsequent layers, while keeping BatchNormalization layers frozen.
 
 When the feature extraction with
 pretrained model works good enough, this step would give a very limited gain on
@@ -392,12 +398,23 @@ to `True`.
 
 
 def unfreeze_model(model):
-    # We unfreeze the top 20 layers while leaving BatchNorm layers frozen
-    for layer in model.layers[-20:]:
+    # We unfreeze the top block (block7) and all subsequent layers while leaving
+    # BatchNorm layers frozen, because EfficientNet shortcuts connect whole blocks.
+    # EfficientNet may be loaded either as a nested sub-model or with its layers
+    # directly in `model.layers`, so we look for the nested model first.
+    base_model = model
+    for layer in model.layers:
+        if layer.name.startswith("efficientnet"):
+            base_model = layer
+            break
+    for block_start_index, layer in enumerate(base_model.layers):
+        if layer.name.startswith("block7"):
+            break
+    for layer in base_model.layers[block_start_index:]:
         if not isinstance(layer, layers.BatchNormalization):
             layer.trainable = True
 
-    optimizer = keras.optimizers.Adam(learning_rate=1e-5)
+    optimizer = keras.optimizers.Adam(learning_rate=1e-4)
     model.compile(
         optimizer=optimizer, loss="categorical_crossentropy", metrics=["accuracy"]
     )
@@ -423,7 +440,9 @@ unfreezing all. This will make fine tuning much faster when going to larger mode
 B7.
 - Each block needs to be all turned on or off. This is because the architecture includes
 a shortcut from the first layer to the last layer for each block. Not respecting blocks
-also significantly harms the final performance.
+also significantly harms the final performance. The `unfreeze_model` implementation
+above demonstrates this by unfreezing `block7a` onward (the last EfficientNet block and
+all subsequent layers).
 
 Some other tips for utilizing EfficientNet:
 


### PR DESCRIPTION
Fixes keras-team/keras-io#995

This PR updates the EfficientNet fine-tuning example to unfreeze layers by block boundaries instead of by a fixed count of the last 20 layers, matching the tutorial's stated guidance that EfficientNet blocks should be turned on/off as whole units.

Changes made:
- Replaced the implementation of `unfreeze_model` so it locates the first layer whose name starts with `block7` and unfreezes that layer and all subsequent layers, while keeping BatchNormalization layers frozen.
- Updated the recompile optimizer to `keras.optimizers.Adam(learning_rate=1e-4)` (as validated by the issue reporter).
- Updated the preceding markdown text to explain that the example demonstrates block-by-block fine-tuning by unfreezing the last EfficientNet block.
- Updated the "Tips for fine tuning EfficientNet" bullet about blocks to reference the code above and note that `block7a` onward is unfrozen.

Verification:
- `python -m py_compile examples/vision/image_classification_efficientnet_fine_tuning.py` passed.
- `python scripts/autogen.py add_example vision/image_classification_efficientnet_fine_tuning` failed during notebook execution due to an unrelated environment issue: `AttributeError: module 'tensorflow_datasets' has no attribute 'load'`. This error occurs before the modified code path is reached and is caused by a Protobuf/tensorflow-datasets compatibility problem in the local environment, not by the changes in this PR.