### PR TITLE
Fix Sam Image Converter docs incorrectly listed under Stable Diffusion 3

### DIFF
--- a/redirects/api/keras_hub/models/stable_diffusion_3/sam_image_converter/index.html
+++ b/redirects/api/keras_hub/models/stable_diffusion_3/sam_image_converter/index.html
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="0; URL='https://keras.io/keras_hub/api/models/stable_diffusion_3/sam_image_converter/'" />

--- a/scripts/hub_master.py
+++ b/scripts/hub_master.py
@@ -2469,14 +2469,6 @@ MODELS_MASTER = {
             "toc": True,
             "children": [
                 {
-                    "path": "sam_image_converter",
-                    "title": "SAMImageConverter",
-                    "generate": [
-                        "keras_hub.layers.SAMImageConverter",
-                        "keras_hub.layers.SAMImageConverter.from_preset",
-                    ],
-                },
-                {
                     "path": "stable_diffusion_3_backbone",
                     "title": "StableDiffusion3Backbone model",
                     "generate": [


### PR DESCRIPTION
Removed Sam Image Converter  which was incorrectly listed under [Stable Diffsuion 3 documentation](https://keras.io/keras_hub/api/models/stable_diffusion_3/)
Fixes #2377 

<img width="536" height="251" alt="image" src="https://github.com/user-attachments/assets/9497a747-a3da-4a68-a7d5-542701d406cc" />
