### PR TITLE
Add GLUE fine-tuning guide for KerasHub

### DIFF
--- a/guides/ipynb/keras_hub/finetuning_on_glue_with_keras_hub.ipynb
+++ b/guides/ipynb/keras_hub/finetuning_on_glue_with_keras_hub.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "# Fine-tuning KerasHub Models on GLUE\n",
+    "\n",
+    "**Author:** [bitanb1999](https://github.com/bitanb1999)<br>\n",
+    "**Date created:** 2026/07/24<br>\n",
+    "**Last modified:** 2026/07/24<br>\n",
+    "**Description:** Fine-tune a pretrained KerasHub text classifier on a GLUE task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "The [General Language Understanding Evaluation (GLUE)](https://gluebenchmark.com/)\n",
+    "benchmark is a collection of nine sentence- and sentence-pair language\n",
+    "understanding tasks, widely used to evaluate how well a pretrained language\n",
+    "model transfers to a variety of downstream problems.\n",
+    "\n",
+    "KerasHub makes it simple to fine-tune any of its pretrained text\n",
+    "classification backbones (BERT, RoBERTa, DeBERTaV3, and more) on a GLUE task\n",
+    "with just a few lines of code. This guide walks through fine-tuning\n",
+    "`keras_hub.models.BertTextClassifier` on **MRPC** (Microsoft Research\n",
+    "Paraphrase Corpus), a GLUE task where the goal is to predict whether two\n",
+    "sentences are semantically equivalent.\n",
+    "\n",
+    "KerasHub also ships a standalone benchmark script at\n",
+    "[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)\n",
+    "that automates the workflow shown in this guide across models and presets\n",
+    "from the command line. This guide covers the same workflow interactively, so\n",
+    "you understand each step before running the full script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "!!pip install -q --upgrade keras-hub\n",
+    "!!pip install -q --upgrade keras  # Upgrade to Keras 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # @param [\"tensorflow\", \"jax\", \"torch\"]\n",
+    "\n",
+    "import keras\n",
+    "import tensorflow as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "\n",
+    "import keras_hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Load the MRPC dataset\n",
+    "\n",
+    "GLUE tasks are available through\n",
+    "[`tensorflow_datasets`](https://www.tensorflow.org/datasets/catalog/glue).\n",
+    "Each MRPC example is a pair of sentences (`sentence1`, `sentence2`) along with\n",
+    "a binary `label` indicating whether the sentences are paraphrases of one\n",
+    "another."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "train_ds, validation_ds, test_ds = tfds.load(\n",
+    "    \"glue/mrpc\",\n",
+    "    split=[\"train\", \"validation\", \"test\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Let's take a look at a single example. KerasHub text classifiers can consume\n",
+    "sentence pairs directly as a tuple of `(sentence1, sentence2)`, so we just\n",
+    "need to reshape the dictionary format that `tfds` gives us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def split_features(x):\n",
+    "    features = (x[\"sentence1\"], x[\"sentence2\"])\n",
+    "    label = x[\"label\"]\n",
+    "    return (features, label)\n",
+    "\n",
+    "\n",
+    "train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "\n",
+    "for features, label in train_ds.take(1):\n",
+    "    print(features)\n",
+    "    print(label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Fine-tune a `BertTextClassifier`\n",
+    "\n",
+    "The highest level module in KerasHub for this task is\n",
+    "`keras_hub.models.BertTextClassifier`, a `keras.Model` that bundles a\n",
+    "pretrained BERT backbone with a classification head and its own text\n",
+    "preprocessing layer. Passing `num_classes=2` builds a two-way classification\n",
+    "head suited to MRPC's binary label.\n",
+    "\n",
+    "We use `bert_tiny_en_uncased` here so this guide runs quickly end-to-end;\n",
+    "swap in a larger preset such as `bert_base_en_uncased` for better accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "BATCH_SIZE = 32\n",
+    "EPOCHS = 3\n",
+    "\n",
+    "classifier = keras_hub.models.BertTextClassifier.from_preset(\n",
+    "    \"bert_tiny_en_uncased\",\n",
+    "    num_classes=2,\n",
+    "    activation=\"softmax\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "Because the classifier carries its own preprocessor, we can pass raw text\n",
+    "straight to `fit()` -- there's no need for a separate tokenization step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
+    "validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
+    "test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "classifier.compile(\n",
+    "    optimizer=keras.optimizers.AdamW(5e-5),\n",
+    "    loss=keras.losses.SparseCategoricalCrossentropy(),\n",
+    "    metrics=[keras.metrics.SparseCategoricalAccuracy()],\n",
+    ")\n",
+    "classifier.fit(\n",
+    "    train_ds,\n",
+    "    validation_data=validation_ds,\n",
+    "    epochs=EPOCHS,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Evaluate and predict\n",
+    "\n",
+    "`evaluate()` reports the fine-tuned model's loss and accuracy on held-out\n",
+    "data, and `predict()` returns class probabilities for new sentence pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "classifier.evaluate(validation_ds)\n",
+    "\n",
+    "sentence_pairs = (\n",
+    "    [\"Sam ate an apple.\", \"Sam ate a fruit.\"],\n",
+    "    [\"Sam ate an apple.\", \"The stock market fell today.\"],\n",
+    ")\n",
+    "probabilities = classifier.predict(sentence_pairs)\n",
+    "print(probabilities)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text"
+   },
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "This guide fine-tuned `BertTextClassifier` on MRPC, but the same workflow\n",
+    "applies to any KerasHub text classifier and any GLUE task available through\n",
+    "`tensorflow_datasets` -- just point `tfds.load()` at a different\n",
+    "`\"glue/<task>\"` config and adjust `num_classes` if the task isn't binary.\n",
+    "\n",
+    "To sweep over models, presets, and hyperparameters from the command line\n",
+    "instead, see the\n",
+    "[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)\n",
+    "script in the KerasHub repository, which implements this same fine-tuning\n",
+    "loop as a configurable benchmark."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "finetuning_on_glue_with_keras_hub",
+   "private_outputs": false,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/guides/ipynb/keras_hub/finetuning_on_glue_with_keras_hub.ipynb
+++ b/guides/ipynb/keras_hub/finetuning_on_glue_with_keras_hub.ipynb
@@ -93,9 +93,9 @@
    },
    "outputs": [],
    "source": [
-    "train_ds, validation_ds, test_ds = tfds.load(\n",
+    "train_ds, validation_ds = tfds.load(\n",
     "    \"glue/mrpc\",\n",
-    "    split=[\"train\", \"validation\", \"test\"],\n",
+    "    split=[\"train\", \"validation\"],\n",
     ")"
    ]
   },
@@ -127,7 +127,6 @@
     "\n",
     "train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
     "validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
-    "test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)\n",
     "\n",
     "for features, label in train_ds.take(1):\n",
     "    print(features)\n",
@@ -190,7 +189,6 @@
    "source": [
     "train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
     "validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
-    "test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)\n",
     "\n",
     "classifier.compile(\n",
     "    optimizer=keras.optimizers.AdamW(5e-5),\n",

--- a/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
+++ b/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
@@ -72,7 +72,6 @@ def split_features(x):
 
 train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
 validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
-test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
 
 for features, label in train_ds.take(1):
     print(features)

--- a/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
+++ b/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
@@ -106,7 +106,6 @@ straight to `fit()` -- there's no need for a separate tokenization step.
 
 train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
 validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
-test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
 
 classifier.compile(
     optimizer=keras.optimizers.AdamW(5e-5),

--- a/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
+++ b/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
@@ -52,9 +52,9 @@ a binary `label` indicating whether the sentences are paraphrases of one
 another.
 """
 
-train_ds, validation_ds, test_ds = tfds.load(
+train_ds, validation_ds = tfds.load(
     "glue/mrpc",
-    split=["train", "validation", "test"],
+    split=["train", "validation"],
 )
 
 """

--- a/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
+++ b/guides/keras_hub/finetuning_on_glue_with_keras_hub.py
@@ -1,0 +1,152 @@
+"""
+Title: Fine-tuning KerasHub Models on GLUE
+Author: [bitanb1999](https://github.com/bitanb1999)
+Date created: 2026/07/24
+Last modified: 2026/07/24
+Description: Fine-tune a pretrained KerasHub text classifier on a GLUE task.
+Accelerator: GPU
+"""
+
+"""
+The [General Language Understanding Evaluation (GLUE)](https://gluebenchmark.com/)
+benchmark is a collection of nine sentence- and sentence-pair language
+understanding tasks, widely used to evaluate how well a pretrained language
+model transfers to a variety of downstream problems.
+
+KerasHub makes it simple to fine-tune any of its pretrained text
+classification backbones (BERT, RoBERTa, DeBERTaV3, and more) on a GLUE task
+with just a few lines of code. This guide walks through fine-tuning
+`keras_hub.models.BertTextClassifier` on **MRPC** (Microsoft Research
+Paraphrase Corpus), a GLUE task where the goal is to predict whether two
+sentences are semantically equivalent.
+
+KerasHub also ships a standalone benchmark script at
+[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)
+that automates the workflow shown in this guide across models and presets
+from the command line. This guide covers the same workflow interactively, so
+you understand each step before running the full script.
+"""
+
+"""shell
+!pip install -q --upgrade keras-hub
+!pip install -q --upgrade keras  # Upgrade to Keras 3.
+"""
+
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"  # @param ["tensorflow", "jax", "torch"]
+
+import keras
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+import keras_hub
+
+"""
+## Load the MRPC dataset
+
+GLUE tasks are available through
+[`tensorflow_datasets`](https://www.tensorflow.org/datasets/catalog/glue).
+Each MRPC example is a pair of sentences (`sentence1`, `sentence2`) along with
+a binary `label` indicating whether the sentences are paraphrases of one
+another.
+"""
+
+train_ds, validation_ds, test_ds = tfds.load(
+    "glue/mrpc",
+    split=["train", "validation", "test"],
+)
+
+"""
+Let's take a look at a single example. KerasHub text classifiers can consume
+sentence pairs directly as a tuple of `(sentence1, sentence2)`, so we just
+need to reshape the dictionary format that `tfds` gives us.
+"""
+
+
+def split_features(x):
+    features = (x["sentence1"], x["sentence2"])
+    label = x["label"]
+    return (features, label)
+
+
+train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+
+for features, label in train_ds.take(1):
+    print(features)
+    print(label)
+
+"""
+## Fine-tune a `BertTextClassifier`
+
+The highest level module in KerasHub for this task is
+`keras_hub.models.BertTextClassifier`, a `keras.Model` that bundles a
+pretrained BERT backbone with a classification head and its own text
+preprocessing layer. Passing `num_classes=2` builds a two-way classification
+head suited to MRPC's binary label.
+
+We use `bert_tiny_en_uncased` here so this guide runs quickly end-to-end;
+swap in a larger preset such as `bert_base_en_uncased` for better accuracy.
+"""
+
+BATCH_SIZE = 32
+EPOCHS = 3
+
+classifier = keras_hub.models.BertTextClassifier.from_preset(
+    "bert_tiny_en_uncased",
+    num_classes=2,
+    activation="softmax",
+)
+
+"""
+Because the classifier carries its own preprocessor, we can pass raw text
+straight to `fit()` -- there's no need for a separate tokenization step.
+"""
+
+train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+
+classifier.compile(
+    optimizer=keras.optimizers.AdamW(5e-5),
+    loss=keras.losses.SparseCategoricalCrossentropy(),
+    metrics=[keras.metrics.SparseCategoricalAccuracy()],
+)
+classifier.fit(
+    train_ds,
+    validation_data=validation_ds,
+    epochs=EPOCHS,
+)
+
+"""
+## Evaluate and predict
+
+`evaluate()` reports the fine-tuned model's loss and accuracy on held-out
+data, and `predict()` returns class probabilities for new sentence pairs.
+"""
+
+classifier.evaluate(validation_ds)
+
+sentence_pairs = (
+    ["Sam ate an apple.", "Sam ate a fruit."],
+    ["Sam ate an apple.", "The stock market fell today."],
+)
+probabilities = classifier.predict(sentence_pairs)
+print(probabilities)
+
+"""
+## Next steps
+
+This guide fine-tuned `BertTextClassifier` on MRPC, but the same workflow
+applies to any KerasHub text classifier and any GLUE task available through
+`tensorflow_datasets` -- just point `tfds.load()` at a different
+`"glue/<task>"` config and adjust `num_classes` if the task isn't binary.
+
+To sweep over models, presets, and hyperparameters from the command line
+instead, see the
+[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)
+script in the KerasHub repository, which implements this same fine-tuning
+loop as a configurable benchmark.
+"""

--- a/guides/md/keras_hub/finetuning_on_glue_with_keras_hub.md
+++ b/guides/md/keras_hub/finetuning_on_glue_with_keras_hub.md
@@ -68,9 +68,9 @@ another.
 
 
 ```python
-train_ds, validation_ds, test_ds = tfds.load(
+train_ds, validation_ds = tfds.load(
     "glue/mrpc",
-    split=["train", "validation", "test"],
+    split=["train", "validation"],
 )
 ```
 
@@ -89,7 +89,6 @@ def split_features(x):
 
 train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
 validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
-test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
 
 for features, label in train_ds.take(1):
     print(features)
@@ -134,7 +133,6 @@ straight to `fit()` -- there's no need for a separate tokenization step.
 ```python
 train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
 validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
-test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
 
 classifier.compile(
     optimizer=keras.optimizers.AdamW(5e-5),
@@ -152,17 +150,17 @@ classifier.fit(
 ```
 Epoch 1/3
 
-115/115 ━━━━━━━━━━━━━━━━━━━━ 87s 743ms/step - loss: 0.6129 - sparse_categorical_accuracy: 0.6868 - val_loss: 0.5975 - val_sparse_categorical_accuracy: 0.6985
+115/115 ━━━━━━━━━━━━━━━━━━━━ 114s 977ms/step - loss: 0.6176 - sparse_categorical_accuracy: 0.6737 - val_loss: 0.5952 - val_sparse_categorical_accuracy: 0.7010
 
 Epoch 2/3
 
-115/115 ━━━━━━━━━━━━━━━━━━━━ 85s 737ms/step - loss: 0.5697 - sparse_categorical_accuracy: 0.7165 - val_loss: 0.5894 - val_sparse_categorical_accuracy: 0.7083
+115/115 ━━━━━━━━━━━━━━━━━━━━ 149s 1s/step - loss: 0.5648 - sparse_categorical_accuracy: 0.7170 - val_loss: 0.5809 - val_sparse_categorical_accuracy: 0.7132
 
 Epoch 3/3
 
-115/115 ━━━━━━━━━━━━━━━━━━━━ 84s 724ms/step - loss: 0.5214 - sparse_categorical_accuracy: 0.7541 - val_loss: 0.5686 - val_sparse_categorical_accuracy: 0.7279
+115/115 ━━━━━━━━━━━━━━━━━━━━ 132s 1s/step - loss: 0.5250 - sparse_categorical_accuracy: 0.7508 - val_loss: 0.5864 - val_sparse_categorical_accuracy: 0.7255
 
-<keras.src.callbacks.history.History at 0xfffeb03080d0>
+<keras.src.callbacks.history.History at 0xfffee80e74c0>
 ```
 </div>
 
@@ -187,10 +185,10 @@ print(probabilities)
     
 <div class="k-default-codeblock">
 ```
-1/1 ━━━━━━━━━━━━━━━━━━━━ 1s 584ms/step
+1/1 ━━━━━━━━━━━━━━━━━━━━ 1s 754ms/step
 
-[[0.14576346 0.85423654]
- [0.7407407  0.25925928]]
+[[0.18662773 0.8133723 ]
+ [0.7085468  0.29145318]]
 ```
 </div>
 

--- a/guides/md/keras_hub/finetuning_on_glue_with_keras_hub.md
+++ b/guides/md/keras_hub/finetuning_on_glue_with_keras_hub.md
@@ -1,0 +1,209 @@
+# Fine-tuning KerasHub Models on GLUE
+
+**Author:** [bitanb1999](https://github.com/bitanb1999)<br>
+**Date created:** 2026/07/24<br>
+**Last modified:** 2026/07/24<br>
+**Description:** Fine-tune a pretrained KerasHub text classifier on a GLUE task.
+
+
+<img class="k-inline-icon" src="https://colab.research.google.com/img/colab_favicon.ico"/> [**View in Colab**](https://colab.research.google.com/github/keras-team/keras-io/blob/master/guides/ipynb/keras_hub/finetuning_on_glue_with_keras_hub.ipynb)  <span class="k-dot">•</span><img class="k-inline-icon" src="https://github.com/favicon.ico"/> [**GitHub source**](https://github.com/keras-team/keras-io/blob/master/guides/keras_hub/finetuning_on_glue_with_keras_hub.py)
+
+
+
+The [General Language Understanding Evaluation (GLUE)](https://gluebenchmark.com/)
+benchmark is a collection of nine sentence- and sentence-pair language
+understanding tasks, widely used to evaluate how well a pretrained language
+model transfers to a variety of downstream problems.
+
+KerasHub makes it simple to fine-tune any of its pretrained text
+classification backbones (BERT, RoBERTa, DeBERTaV3, and more) on a GLUE task
+with just a few lines of code. This guide walks through fine-tuning
+`keras_hub.models.BertTextClassifier` on **MRPC** (Microsoft Research
+Paraphrase Corpus), a GLUE task where the goal is to predict whether two
+sentences are semantically equivalent.
+
+KerasHub also ships a standalone benchmark script at
+[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)
+that automates the workflow shown in this guide across models and presets
+from the command line. This guide covers the same workflow interactively, so
+you understand each step before running the full script.
+
+
+```python
+!!pip install -q --upgrade keras-hub
+!!pip install -q --upgrade keras  # Upgrade to Keras 3.
+```
+
+
+
+
+```python
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"  # @param ["tensorflow", "jax", "torch"]
+
+import keras
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+import keras_hub
+```
+<div class="k-default-codeblock">
+```
+[]
+
+/home/vscode/glue-guide-venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
+  from .autonotebook import tqdm as notebook_tqdm
+```
+</div>
+
+---
+## Load the MRPC dataset
+
+GLUE tasks are available through
+[`tensorflow_datasets`](https://www.tensorflow.org/datasets/catalog/glue).
+Each MRPC example is a pair of sentences (`sentence1`, `sentence2`) along with
+a binary `label` indicating whether the sentences are paraphrases of one
+another.
+
+
+```python
+train_ds, validation_ds, test_ds = tfds.load(
+    "glue/mrpc",
+    split=["train", "validation", "test"],
+)
+```
+
+Let's take a look at a single example. KerasHub text classifiers can consume
+sentence pairs directly as a tuple of `(sentence1, sentence2)`, so we just
+need to reshape the dictionary format that `tfds` gives us.
+
+
+```python
+
+def split_features(x):
+    features = (x["sentence1"], x["sentence2"])
+    label = x["label"]
+    return (features, label)
+
+
+train_ds = train_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+validation_ds = validation_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+test_ds = test_ds.map(split_features, num_parallel_calls=tf.data.AUTOTUNE)
+
+for features, label in train_ds.take(1):
+    print(features)
+    print(label)
+```
+
+<div class="k-default-codeblock">
+```
+(<tf.Tensor: shape=(), dtype=string, numpy=b'The identical rovers will act as robotic geologists , searching for evidence of past water .'>, <tf.Tensor: shape=(), dtype=string, numpy=b'The rovers act as robotic geologists , moving on six wheels .'>)
+tf.Tensor(0, shape=(), dtype=int64)
+```
+</div>
+
+---
+## Fine-tune a `BertTextClassifier`
+
+The highest level module in KerasHub for this task is
+`keras_hub.models.BertTextClassifier`, a `keras.Model` that bundles a
+pretrained BERT backbone with a classification head and its own text
+preprocessing layer. Passing `num_classes=2` builds a two-way classification
+head suited to MRPC's binary label.
+
+We use `bert_tiny_en_uncased` here so this guide runs quickly end-to-end;
+swap in a larger preset such as `bert_base_en_uncased` for better accuracy.
+
+
+```python
+BATCH_SIZE = 32
+EPOCHS = 3
+
+classifier = keras_hub.models.BertTextClassifier.from_preset(
+    "bert_tiny_en_uncased",
+    num_classes=2,
+    activation="softmax",
+)
+```
+
+Because the classifier carries its own preprocessor, we can pass raw text
+straight to `fit()` -- there's no need for a separate tokenization step.
+
+
+```python
+train_ds = train_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+validation_ds = validation_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+test_ds = test_ds.batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+
+classifier.compile(
+    optimizer=keras.optimizers.AdamW(5e-5),
+    loss=keras.losses.SparseCategoricalCrossentropy(),
+    metrics=[keras.metrics.SparseCategoricalAccuracy()],
+)
+classifier.fit(
+    train_ds,
+    validation_data=validation_ds,
+    epochs=EPOCHS,
+)
+```
+
+<div class="k-default-codeblock">
+```
+Epoch 1/3
+
+115/115 ━━━━━━━━━━━━━━━━━━━━ 87s 743ms/step - loss: 0.6129 - sparse_categorical_accuracy: 0.6868 - val_loss: 0.5975 - val_sparse_categorical_accuracy: 0.6985
+
+Epoch 2/3
+
+115/115 ━━━━━━━━━━━━━━━━━━━━ 85s 737ms/step - loss: 0.5697 - sparse_categorical_accuracy: 0.7165 - val_loss: 0.5894 - val_sparse_categorical_accuracy: 0.7083
+
+Epoch 3/3
+
+115/115 ━━━━━━━━━━━━━━━━━━━━ 84s 724ms/step - loss: 0.5214 - sparse_categorical_accuracy: 0.7541 - val_loss: 0.5686 - val_sparse_categorical_accuracy: 0.7279
+
+<keras.src.callbacks.history.History at 0xfffeb03080d0>
+```
+</div>
+
+---
+## Evaluate and predict
+
+`evaluate()` reports the fine-tuned model's loss and accuracy on held-out
+data, and `predict()` returns class probabilities for new sentence pairs.
+
+
+```python
+classifier.evaluate(validation_ds)
+
+sentence_pairs = (
+    ["Sam ate an apple.", "Sam ate a fruit."],
+    ["Sam ate an apple.", "The stock market fell today."],
+)
+probabilities = classifier.predict(sentence_pairs)
+print(probabilities)
+```
+
+    
+<div class="k-default-codeblock">
+```
+1/1 ━━━━━━━━━━━━━━━━━━━━ 1s 584ms/step
+
+[[0.14576346 0.85423654]
+ [0.7407407  0.25925928]]
+```
+</div>
+
+---
+## Next steps
+
+This guide fine-tuned `BertTextClassifier` on MRPC, but the same workflow
+applies to any KerasHub text classifier and any GLUE task available through
+`tensorflow_datasets` -- just point `tfds.load()` at a different
+`"glue/<task>"` config and adjust `num_classes` if the task isn't binary.
+
+To sweep over models, presets, and hyperparameters from the command line
+instead, see the
+[`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py)
+script in the KerasHub repository, which implements this same fine-tuning
+loop as a configurable benchmark.

--- a/scripts/hub_master.py
+++ b/scripts/hub_master.py
@@ -3865,6 +3865,10 @@ HUB_GUIDES_MASTER = {
             "path": "gemma4_multimodal_and_agentic_workflows",
             "title": "Multimodal and Agentic Workflows with Gemma 4 in KerasHub",
         },
+        {
+            "path": "finetuning_on_glue_with_keras_hub",
+            "title": "Fine-tuning KerasHub Models on GLUE",
+        },
     ],
 }
 


### PR DESCRIPTION
## Summary
- Adds a keras.io guide (`guides/keras_hub/finetuning_on_glue_with_keras_hub.py`) that fine-tunes `keras_hub.models.BertTextClassifier` on GLUE/MRPC end-to-end: loading the dataset via `tensorflow_datasets`, fine-tuning `bert_tiny_en_uncased`, evaluating, and predicting on new sentence pairs.
- Links out to the existing [`benchmarks/glue.py`](https://github.com/keras-team/keras-hub/blob/master/benchmarks/glue.py) script in keras-hub for a configurable CLI sweep over models/presets.
- Registers the guide in `HUB_GUIDES_MASTER` (`scripts/hub_master.py`).
- `.md`/`.ipynb` generated via `python autogen.py add_guide keras_hub/finetuning_on_glue_with_keras_hub` (actually executed, real outputs included).

Fixes keras-team/keras-hub#2401 (follow-up to keras-team/keras-io#2403).

## Test plan
- [x] Ran `black` on the guide source per tutobook conventions
- [x] Ran `python autogen.py add_guide keras_hub/finetuning_on_glue_with_keras_hub` end-to-end (downloads BERT-tiny + GLUE/MRPC, fine-tunes 3 epochs, evaluates, predicts) with no errors
- [x] Verified `predict()` output are genuine class probabilities (softmax) that sum to 1 and make sense for the example sentence pairs