### PR TITLE
Fix unsafe FordA paper link

### DIFF
--- a/examples/timeseries/ipynb/timeseries_classification_from_scratch.ipynb
+++ b/examples/timeseries/ipynb/timeseries_classification_from_scratch.ipynb
@@ -65,7 +65,7 @@
     "Each timeseries corresponds to a measurement of engine noise captured by a motor sensor.\n",
     "For this task, the goal is to automatically detect the presence of a specific issue with\n",
     "the engine. The problem is a balanced binary classification task. The full description of\n",
-    "this dataset can be found [here](http://www.j-wichard.de/publications/FordPaper.pdf).\n",
+    "this dataset can be found [here](https://www.researchgate.net/publication/228506182_Classification_of_Ford_Motor_Data).\n",
     "\n",
     "### Read the TSV data\n",
     "\n",

--- a/examples/timeseries/md/timeseries_classification_from_scratch.md
+++ b/examples/timeseries/md/timeseries_classification_from_scratch.md
@@ -38,7 +38,7 @@ The dataset contains 3601 training instances and another 1320 testing instances.
 Each timeseries corresponds to a measurement of engine noise captured by a motor sensor.
 For this task, the goal is to automatically detect the presence of a specific issue with
 the engine. The problem is a balanced binary classification task. The full description of
-this dataset can be found [here](http://www.j-wichard.de/publications/FordPaper.pdf).
+this dataset can be found [here](https://www.researchgate.net/publication/228506182_Classification_of_Ford_Motor_Data).
 
 ### Read the TSV data
 

--- a/examples/timeseries/timeseries_classification_from_scratch.py
+++ b/examples/timeseries/timeseries_classification_from_scratch.py
@@ -35,7 +35,7 @@ The dataset contains 3601 training instances and another 1320 testing instances.
 Each timeseries corresponds to a measurement of engine noise captured by a motor sensor.
 For this task, the goal is to automatically detect the presence of a specific issue with
 the engine. The problem is a balanced binary classification task. The full description of
-this dataset can be found [here](http://www.j-wichard.de/publications/FordPaper.pdf).
+this dataset can be found [here](https://www.researchgate.net/publication/228506182_Classification_of_Ford_Motor_Data).
 
 ### Read the TSV data
 


### PR DESCRIPTION
The existing _FordA_ dataset reference now redirects to an unrelated casino website.

This replaces it with the corresponding _ResearchGate_ publication page for Joerg Wichard’s "Classification of Ford Motor Data".

The Python source, Markdown rendering, and notebook have all been updated.